### PR TITLE
Fix Compilation Errors for VS Code Fluent Branch

### DIFF
--- a/JitHub.WebView/JitHub.WebView.csproj
+++ b/JitHub.WebView/JitHub.WebView.csproj
@@ -27,6 +27,7 @@
     <DefineConstants>DEBUG;TRACE;NETFX_CORE;WINDOWS_UWP</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -36,6 +37,7 @@
     <DefineConstants>TRACE;NETFX_CORE;WINDOWS_UWP</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">
     <PlatformTarget>x86</PlatformTarget>
@@ -46,6 +48,7 @@
     <DebugType>full</DebugType>
     <UseVSHostingProcess>false</UseVSHostingProcess>
     <ErrorReport>prompt</ErrorReport>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x86'">
     <PlatformTarget>x86</PlatformTarget>
@@ -56,6 +59,7 @@
     <DebugType>pdbonly</DebugType>
     <UseVSHostingProcess>false</UseVSHostingProcess>
     <ErrorReport>prompt</ErrorReport>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|ARM'">
     <PlatformTarget>ARM</PlatformTarget>
@@ -66,6 +70,7 @@
     <DebugType>full</DebugType>
     <UseVSHostingProcess>false</UseVSHostingProcess>
     <ErrorReport>prompt</ErrorReport>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|ARM'">
     <PlatformTarget>ARM</PlatformTarget>
@@ -76,6 +81,7 @@
     <DebugType>pdbonly</DebugType>
     <UseVSHostingProcess>false</UseVSHostingProcess>
     <ErrorReport>prompt</ErrorReport>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|ARM64'">
     <PlatformTarget>ARM64</PlatformTarget>
@@ -86,6 +92,7 @@
     <DebugType>full</DebugType>
     <UseVSHostingProcess>false</UseVSHostingProcess>
     <ErrorReport>prompt</ErrorReport>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|ARM64'">
     <PlatformTarget>ARM64</PlatformTarget>
@@ -96,6 +103,7 @@
     <DebugType>pdbonly</DebugType>
     <UseVSHostingProcess>false</UseVSHostingProcess>
     <ErrorReport>prompt</ErrorReport>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">
     <PlatformTarget>x64</PlatformTarget>
@@ -106,6 +114,7 @@
     <DebugType>full</DebugType>
     <UseVSHostingProcess>false</UseVSHostingProcess>
     <ErrorReport>prompt</ErrorReport>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'">
     <PlatformTarget>x64</PlatformTarget>
@@ -116,6 +125,7 @@
     <DebugType>pdbonly</DebugType>
     <UseVSHostingProcess>false</UseVSHostingProcess>
     <ErrorReport>prompt</ErrorReport>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup>
     <RestoreProjectStyle>PackageReference</RestoreProjectStyle>
@@ -151,6 +161,7 @@
     <Compile Include="UI\WebView2Ex.SmoothScroll.cs" />
     <Compile Include="UI\WebView2Ex.Visibility.cs" />
     <Compile Include="UI\WebView2Ex.Windowing.cs" />
+    <Compile Include="UI\WebView2ExBasicMapping.cs" />
     <Compile Include="Utility.cs" />
     <Compile Include="WebView2Runtime.cs" />
     <EmbeddedResource Include="Properties\JitHub.WebView.rd.xml" />

--- a/JitHub.WebView/UI/WebView2ExBasicMapping.cs
+++ b/JitHub.WebView/UI/WebView2ExBasicMapping.cs
@@ -1,0 +1,42 @@
+﻿using Microsoft.Web.WebView2.Core;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Windows.Foundation;
+using Windows.UI.Core;
+
+namespace WebView2Ex.UI;
+
+public partial class WebView2ExBasicMapping : WebView2Ex
+{
+    public CoreWebView2 CoreWebView2 => WebView2Runtime.CoreWebView2;
+    public WebView2ExBasicMapping()
+    {
+        // Assuming we are on core window only
+        SetWindow(CoreWindow.GetForCurrentThread());
+
+        InitializeAsync();
+    }
+
+    // normal TaskCompletionSource does not exist in UWP
+    readonly TaskCompletionSource<bool> WebView2RuntimeTCS = new();
+    async void InitializeAsync()
+    {
+        // Assuming we create our own runtime
+        WebView2Runtime = await WebView2Runtime.CreateAsync();
+        WebView2Runtime.CoreWebView2.NavigationCompleted += CoreWebView2_NavigationCompleted;
+        WebView2RuntimeTCS.SetResult(true);
+        CoreWebView2Initialized?.Invoke(this, new());
+    }
+
+    private void CoreWebView2_NavigationCompleted(CoreWebView2 sender, CoreWebView2NavigationCompletedEventArgs args)
+    {
+        NavigationCompleted?.Invoke(sender, args);
+    }
+
+    public TypedEventHandler<WebView2ExBasicMapping, EventArgs> CoreWebView2Initialized;
+    public IAsyncAction EnsureCoreWebView2Async() => WebView2RuntimeTCS.Task.AsAsyncAction();
+    public event TypedEventHandler<CoreWebView2, CoreWebView2NavigationCompletedEventArgs> NavigationCompleted;
+}

--- a/JitHub/JitHub.csproj
+++ b/JitHub/JitHub.csproj
@@ -28,7 +28,6 @@
     <AppxBundle>Always</AppxBundle>
     <AppxBundlePlatforms>x86|x64|arm|arm64</AppxBundlePlatforms>
     <HoursBetweenUpdateChecks>24</HoursBetweenUpdateChecks>
-    <PackageCertificateThumbprint>8D152E0318409B1EAEC7DD6EBEF62D255E17EB84</PackageCertificateThumbprint>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">
     <DebugSymbols>true</DebugSymbols>
@@ -1359,6 +1358,10 @@
     <ProjectReference Include="..\JitHub.Utilities.SVG\JitHub.Utilities.SVG.csproj">
       <Project>{ace52ff0-0a75-4b14-8d0f-464c9b09b85f}</Project>
       <Name>JitHub.Utilities.SVG</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\JitHub.WebView\JitHub.WebView.csproj">
+      <Project>{3bed258e-df3f-4bd8-982a-5ad2c941c897}</Project>
+      <Name>JitHub.WebView</Name>
     </ProjectReference>
     <ProjectReference Include="..\Markdig.UWP\Markdig.UWP.csproj">
       <Project>{76bb207b-5175-4e9c-af8c-add0ea67ad18}</Project>

--- a/JitHub/JitHub.csproj
+++ b/JitHub/JitHub.csproj
@@ -28,6 +28,7 @@
     <AppxBundle>Always</AppxBundle>
     <AppxBundlePlatforms>x86|x64|arm|arm64</AppxBundlePlatforms>
     <HoursBetweenUpdateChecks>24</HoursBetweenUpdateChecks>
+    <PackageCertificateThumbprint>8D152E0318409B1EAEC7DD6EBEF62D255E17EB84</PackageCertificateThumbprint>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">
     <DebugSymbols>true</DebugSymbols>

--- a/JitHub/Views/Pages/RepoCodePage.xaml
+++ b/JitHub/Views/Pages/RepoCodePage.xaml
@@ -38,7 +38,7 @@
                     Duration="0:0:0.5"
                     From="0.95" To="1"/>
             </animations:Implicit.ShowAnimations>
-            <wv2ex:WebView2Ex x:Name="ShellWebView" />
+            <wv2ex:WebView2ExBasicMapping x:Name="ShellWebView" />
         </Grid>
     </Grid>
 </Page>


### PR DESCRIPTION
- Add WebView2ExBasicMapping.cs
- Allow Unsafe Blocks in JitHub.WebView
- Change WebView2Ex to WebView2ExBasicMapping

This PR only contains compilation error fixes, and it does not include setting the background of the webview2 itself to transparent. If you would like to do that, you can add
```csharp
ShellWebView.WebView2Runtime.CompositionController.DefaultBackgroundColor = Colors.Transparent;
```
to `RepoCodePage.xaml.cs` inside the `CoreWebView2Initializzed` event