### PR TITLE
Build editor assets in Store pipeline

### DIFF
--- a/.github/workflows/jithub-store-release.yml
+++ b/.github/workflows/jithub-store-release.yml
@@ -65,6 +65,11 @@ jobs:
           cache: yarn
           cache-dependency-path: editor-assets/yarn.lock
 
+      - name: Install editor asset dependencies
+        working-directory: editor-assets
+        shell: pwsh
+        run: yarn --frozen-lockfile
+
       - name: Set up MSBuild
         uses: microsoft/setup-msbuild@v2
 
@@ -77,6 +82,7 @@ jobs:
           .\eng\Sync-JitHubVsCodeAssets.ps1
           -VsCodeRepoPath "${{ github.workspace }}\editor-assets"
           -DestinationPath "${{ github.workspace }}\JitHub\Assets\dist"
+          -SkipInstall
 
       - name: Patch Store manifest values
         shell: pwsh

--- a/.github/workflows/jithub-store-release.yml
+++ b/.github/workflows/jithub-store-release.yml
@@ -7,8 +7,13 @@ on:
         description: Four-part Store package version (for example 1.6.5.0)
         required: true
         type: string
+      editor_assets_ref:
+        description: jithub-vs-code ref to build for Assets\dist (use master after nerocui/jithub-vs-code PR #1 merges)
+        required: false
+        default: feature/windows-build-support
+        type: string
       use_signing_certificate:
-        description: Sign the package with the configured PFX before Store upload
+        description: Sign the package with the configured PFX before Store upload; leave false unless STORE_PACKAGE_CERTIFICATE_BASE64 and STORE_PACKAGE_CERTIFICATE_PASSWORD are set
         required: false
         default: false
         type: boolean
@@ -46,11 +51,32 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Checkout jithub-vs-code
+        uses: actions/checkout@v4
+        with:
+          repository: nerocui/jithub-vs-code
+          ref: ${{ inputs.editor_assets_ref }}
+          path: editor-assets
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 18
+          cache: yarn
+          cache-dependency-path: editor-assets/yarn.lock
+
       - name: Set up MSBuild
         uses: microsoft/setup-msbuild@v2
 
       - name: Set up Microsoft Store CLI
         uses: microsoft/microsoft-store-apppublisher@v1.2
+
+      - name: Build editor assets
+        shell: pwsh
+        run: >
+          .\eng\Sync-JitHubVsCodeAssets.ps1
+          -VsCodeRepoPath "${{ github.workspace }}\editor-assets"
+          -DestinationPath "${{ github.workspace }}\JitHub\Assets\dist"
 
       - name: Patch Store manifest values
         shell: pwsh

--- a/.github/workflows/jithub-store-release.yml
+++ b/.github/workflows/jithub-store-release.yml
@@ -61,7 +61,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 22
           cache: yarn
           cache-dependency-path: editor-assets/yarn.lock
 

--- a/NuGet.config
+++ b/NuGet.config
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <clear />
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
+    <add key="CommunityToolkit-Labs" value="https://pkgs.dev.azure.com/dotnet/CommunityToolkit/_packaging/CommunityToolkit-Labs/nuget/v3/index.json" />
+  </packageSources>
+</configuration>

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Then, you need to create a file named `appsettings.json` in the `JitHub` project
 
 Finally, set environment variable `JithubAppSecret` to your GitHub seret and `JitHubClientId` to your GitHub client ID.
 
-Now you need to download the built vs code files. Run `.\download-vscode.ps1` in PowerShell. This script will download the latest release of vs code from [jithub-vs-code](https://github.com/nerocui/jithub-vs-code) and unzip it to the `JitHub/Assets/dist` folder. No additional action needs to be performed.
+Now you need to build the editor assets from [jithub-vs-code](https://github.com/nerocui/jithub-vs-code). Run `.\sync-vscode-assets.ps1` in PowerShell. The script looks for a local `jithub-vs-code` clone (including `E:\jithub-vs-code`), runs `yarn --frozen-lockfile` and `yarn build`, and then copies the generated `dist` output into `JitHub\Assets\dist`.
 
 After that, you can open the `JitHub.sln` file in Visual Studio and run the app.
 
@@ -99,7 +99,9 @@ Optional environment variables:
 - `STORE_PUBLISHER_DISPLAY_NAME`
 - `JITHUB_STORE_BUNDLE_PLATFORMS` (defaults to `x86|x64|arm64`)
 
-Run the **Publish JitHub to Microsoft Store** workflow manually and provide a four-part `release_version` such as `1.6.5.0`. The workflow patches `JitHub\Package.appxmanifest` at runtime from the configured environment values, builds a Store upload package, uploads the build artifacts, and then publishes the generated `.appxupload` or `.msixupload` to the Microsoft Store.
+Run the **Publish JitHub to Microsoft Store** workflow manually and provide a four-part `release_version` such as `1.6.5.0`. The workflow first checks out `nerocui/jithub-vs-code`, builds the editor assets into `JitHub\Assets\dist`, patches `JitHub\Package.appxmanifest` at runtime from the configured environment values, builds a Store upload package, uploads the build artifacts, and then publishes the generated `.appxupload` or `.msixupload` to the Microsoft Store.
+
+The workflow currently accepts an `editor_assets_ref` input so you can point it at a specific `jithub-vs-code` branch while the Windows-build support change is under review. After that PR merges, use `master`.
 
 If the publish step fails with Partner Center authorization errors, the remaining fix is not in GitHub Actions itself: the linked Microsoft Entra application still needs the correct Partner Center access for the individual developer account.
 

--- a/eng/Sync-JitHubVsCodeAssets.ps1
+++ b/eng/Sync-JitHubVsCodeAssets.ps1
@@ -1,0 +1,122 @@
+[CmdletBinding()]
+param(
+    [string]$VsCodeRepoPath,
+    [string]$DestinationPath = (Join-Path (Split-Path -Parent $PSScriptRoot) 'JitHub\Assets\dist'),
+    [switch]$SkipInstall
+)
+
+$ErrorActionPreference = 'Stop'
+
+function Resolve-RepoRoot {
+    return Split-Path -Parent $PSScriptRoot
+}
+
+function Resolve-VsCodeRepoPath {
+    param(
+        [string]$ExplicitPath
+    )
+
+    $repoRoot = Resolve-RepoRoot
+    $candidates = @(
+        $ExplicitPath,
+        $env:JITHUB_VSCODE_PATH,
+        (Join-Path $repoRoot '..\jithub-vs-code'),
+        'E:\jithub-vs-code'
+    ) | Where-Object { -not [string]::IsNullOrWhiteSpace($_) }
+
+    foreach ($candidate in $candidates) {
+        $fullPath = [System.IO.Path]::GetFullPath($candidate)
+        if (
+            (Test-Path -LiteralPath $fullPath) -and
+            (Test-Path -LiteralPath (Join-Path $fullPath 'package.json')) -and
+            (Test-Path -LiteralPath (Join-Path $fullPath 'webpack.config.js'))
+        ) {
+            return $fullPath
+        }
+    }
+
+    throw 'Unable to locate the jithub-vs-code repository. Pass -VsCodeRepoPath or set JITHUB_VSCODE_PATH.'
+}
+
+function Invoke-CheckedCommand {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$FilePath,
+
+        [string[]]$ArgumentList = @(),
+
+        [Parameter(Mandatory = $true)]
+        [string]$WorkingDirectory
+    )
+
+    Write-Host "> $FilePath $($ArgumentList -join ' ')"
+    Push-Location $WorkingDirectory
+    try {
+        & $FilePath @ArgumentList
+        if ($LASTEXITCODE -ne 0) {
+            throw "Command failed with exit code ${LASTEXITCODE}: $FilePath $($ArgumentList -join ' ')"
+        }
+    }
+    finally {
+        Pop-Location
+    }
+}
+
+function Clear-DestinationDirectory {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Path
+    )
+
+    $attempt = 0
+    while ($attempt -lt 3) {
+        $attempt++
+        try {
+            Get-ChildItem -LiteralPath $Path -Force -ErrorAction SilentlyContinue |
+                Remove-Item -Recurse -Force -ErrorAction Stop
+            return
+        }
+        catch {
+            if ($attempt -ge 3) {
+                throw "Unable to clear $Path. Close JitHub or any process using files under Assets\\dist, then try again. $($_.Exception.Message)"
+            }
+
+            Start-Sleep -Seconds 1
+        }
+    }
+}
+
+$repoPath = Resolve-VsCodeRepoPath -ExplicitPath $VsCodeRepoPath
+$destinationFullPath = [System.IO.Path]::GetFullPath($DestinationPath)
+
+if (-not (Get-Command node -ErrorAction SilentlyContinue)) {
+    throw 'Node.js is required to build jithub-vs-code assets.'
+}
+
+if (-not (Get-Command yarn -ErrorAction SilentlyContinue)) {
+    throw 'Yarn is required to build jithub-vs-code assets.'
+}
+
+Write-Host "Using jithub-vs-code repository at: $repoPath"
+
+if (-not $SkipInstall) {
+    Invoke-CheckedCommand -FilePath 'yarn' -ArgumentList @('--frozen-lockfile') -WorkingDirectory $repoPath
+}
+
+Invoke-CheckedCommand -FilePath 'yarn' -ArgumentList @('build') -WorkingDirectory $repoPath
+
+$sourceDistPath = Join-Path $repoPath 'dist'
+if (
+    -not (Test-Path -LiteralPath $sourceDistPath) -or
+    -not (Test-Path -LiteralPath (Join-Path $sourceDistPath 'index.html'))
+) {
+    throw "The jithub-vs-code build did not produce the expected dist output at $sourceDistPath"
+}
+
+New-Item -ItemType Directory -Path $destinationFullPath -Force | Out-Null
+
+Clear-DestinationDirectory -Path $destinationFullPath
+
+Copy-Item -Path (Join-Path $sourceDistPath '*') -Destination $destinationFullPath -Recurse -Force
+
+Write-Host "Synced editor assets to: $destinationFullPath"

--- a/sync-vscode-assets.ps1
+++ b/sync-vscode-assets.ps1
@@ -1,0 +1,11 @@
+[CmdletBinding()]
+param(
+    [string]$VsCodeRepoPath,
+    [switch]$SkipInstall
+)
+
+$ErrorActionPreference = 'Stop'
+
+& (Join-Path $PSScriptRoot 'eng\Sync-JitHubVsCodeAssets.ps1') `
+    -VsCodeRepoPath $VsCodeRepoPath `
+    -SkipInstall:$SkipInstall


### PR DESCRIPTION
## Summary
- add the CommunityToolkit Labs NuGet feed for restore
- build jithub-vs-code editor assets as part of the Store pipeline
- add a local sync-vscode-assets.ps1 helper for development

## Notes
- this branch currently points the workflow at nerocui/jithub-vs-code ref feature/windows-build-support for editor asset builds
- switch editor_assets_ref back to master after that PR merges

## Validation
- .\\sync-vscode-assets.ps1
- dotnet restore of a temp project resolving CommunityToolkit.Labs.Uwp.Shimmer via NuGet.config