### PR TITLE
Fix Store workflow SDK selection

### DIFF
--- a/.github/workflows/jithub-store-release.yml
+++ b/.github/workflows/jithub-store-release.yml
@@ -8,9 +8,9 @@ on:
         required: true
         type: string
       editor_assets_ref:
-        description: jithub-vs-code ref to build for Assets\dist (use master after nerocui/jithub-vs-code PR #1 merges)
+        description: jithub-vs-code ref to build for Assets\dist
         required: false
-        default: feature/windows-build-support
+        default: master
         type: string
       use_signing_certificate:
         description: Sign the package with the configured PFX before Store upload; leave false unless STORE_PACKAGE_CERTIFICATE_BASE64 and STORE_PACKAGE_CERTIFICATE_PASSWORD are set
@@ -35,6 +35,7 @@ jobs:
       APP_DISPLAY_NAME: ${{ vars.STORE_APP_DISPLAY_NAME }}
       BUNDLE_PLATFORMS: ${{ vars.JITHUB_STORE_BUNDLE_PLATFORMS }}
       PUBLISHER_DISPLAY_NAME: ${{ vars.STORE_PUBLISHER_DISPLAY_NAME }}
+      TARGET_PLATFORM_VERSION: 10.0.26100.0
       STORE_CLIENT_ID: ${{ secrets.STORE_CLIENT_ID }}
       STORE_CLIENT_SECRET: ${{ secrets.STORE_CLIENT_SECRET }}
       STORE_PACKAGE_CERTIFICATE_BASE64: ${{ secrets.STORE_PACKAGE_CERTIFICATE_BASE64 }}
@@ -97,6 +98,18 @@ jobs:
           -PhoneProductId "$env:STORE_PHONE_PRODUCT_ID"
           -PhonePublisherId "$env:STORE_PHONE_PUBLISHER_ID"
 
+      - name: Verify Windows SDK availability
+        shell: pwsh
+        run: |
+          $sdkPath = Join-Path "${env:ProgramFiles(x86)}\Windows Kits\10\Include" $env:TARGET_PLATFORM_VERSION
+          if (-not (Test-Path -LiteralPath $sdkPath)) {
+            $availableSdks = Get-ChildItem -Path "${env:ProgramFiles(x86)}\Windows Kits\10\Include" -Directory |
+              Sort-Object Name |
+              Select-Object -ExpandProperty Name
+
+            throw "Required Windows SDK $env:TARGET_PLATFORM_VERSION was not found. Available SDKs: $($availableSdks -join ', ')"
+          }
+
       - name: Build Store upload package
         id: build-package
         shell: pwsh
@@ -120,6 +133,7 @@ jobs:
             '/m'
             '/p:Configuration=Release'
             '/p:Platform=x86'
+            "/p:TargetPlatformVersion=$env:TARGET_PLATFORM_VERSION"
             '/p:UapAppxPackageBuildMode=StoreUpload'
             '/p:AppxBundle=Always'
             "/p:AppxBundlePlatforms=$bundlePlatforms"

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Optional environment variables:
 
 Run the **Publish JitHub to Microsoft Store** workflow manually and provide a four-part `release_version` such as `1.6.5.0`. The workflow first checks out `nerocui/jithub-vs-code`, builds the editor assets into `JitHub\Assets\dist`, patches `JitHub\Package.appxmanifest` at runtime from the configured environment values, builds a Store upload package, uploads the build artifacts, and then publishes the generated `.appxupload` or `.msixupload` to the Microsoft Store.
 
-The workflow currently accepts an `editor_assets_ref` input so you can point it at a specific `jithub-vs-code` branch while the Windows-build support change is under review. After that PR merges, use `master`.
+The workflow accepts an `editor_assets_ref` input if you ever need to point it at a non-default `jithub-vs-code` ref for testing, but it now defaults to `master`.
 
 If the publish step fails with Partner Center authorization errors, the remaining fix is not in GitHub Actions itself: the linked Microsoft Entra application still needs the correct Partner Center access for the individual developer account.
 


### PR DESCRIPTION
## Summary
- default the Store workflow's editor asset ref back to master now that jithub-vs-code PR #1 is merged
- force MSBuild to use an installed Windows SDK version on the GitHub runner
- add an explicit SDK availability check so runner image changes fail clearly

## Why
The latest Store run got past restore and asset generation, then failed compiling UWP helper projects because the runner did not have the hardcoded 10.0.22621.0 SDK those projects defaulted to. This change aligns the workflow to the installed runner SDK and keeps the failure diagnosable if runner images change again.