### PR TITLE
Fix Store workflow Labs package restore

### DIFF
--- a/JitHub/JitHub.csproj
+++ b/JitHub/JitHub.csproj
@@ -1308,10 +1308,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="CommunityToolkit.Labs.Uwp.Controls.MarkdownTextBlock">
-      <Version>0.1.250811-build.2202</Version>
-    </PackageReference>
-    <PackageReference Include="CommunityToolkit.Labs.Uwp.Shimmer">
-      <Version>0.1.250811-build.2202</Version>
+      <Version>0.1.260319-build.2547</Version>
     </PackageReference>
     <PackageReference Include="CommunityToolkit.Mvvm">
       <Version>8.4.0</Version>

--- a/JitHub/Services/GitHubService.cs
+++ b/JitHub/Services/GitHubService.cs
@@ -1,4 +1,4 @@
-﻿using CommunityToolkit.Labs.WinUI.MarkdownTextBlock;
+using CommunityToolkit.WinUI.Controls;
 using CommunityToolkit.Mvvm.DependencyInjection;
 using JitHub.Models;
 using JitHub.Models.Base;

--- a/JitHub/Services/IGitHubService.cs
+++ b/JitHub/Services/IGitHubService.cs
@@ -1,4 +1,4 @@
-﻿using CommunityToolkit.Labs.WinUI.MarkdownTextBlock;
+using CommunityToolkit.WinUI.Controls;
 using JitHub.Models;
 using JitHub.Models.Base;
 using JitHub.Models.PRConversation;

--- a/JitHub/ViewModels/ActivityViewModels/ActivityViewModel.cs
+++ b/JitHub/ViewModels/ActivityViewModels/ActivityViewModel.cs
@@ -1,4 +1,4 @@
-﻿using CommunityToolkit.Labs.WinUI.MarkdownTextBlock;
+using CommunityToolkit.WinUI.Controls;
 using JitHub.ViewModels.Base;
 using Octokit;
 using System;

--- a/JitHub/ViewModels/MarkdownFormViewModel.cs
+++ b/JitHub/ViewModels/MarkdownFormViewModel.cs
@@ -1,4 +1,4 @@
-﻿using CommunityToolkit.Labs.WinUI.MarkdownTextBlock;
+using CommunityToolkit.WinUI.Controls;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.DependencyInjection;
 using JitHub.Services;

--- a/JitHub/ViewModels/UserViewModel/UserCommentBlockViewModel.cs
+++ b/JitHub/ViewModels/UserViewModel/UserCommentBlockViewModel.cs
@@ -11,7 +11,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using System.Windows.Input;
 using Windows.ApplicationModel.DataTransfer;
-using CommunityToolkit.Labs.WinUI.MarkdownTextBlock;
+using CommunityToolkit.WinUI.Controls;
 
 namespace JitHub.ViewModels.UserViewModel
 {

--- a/JitHub/Views/Controls/Activity/IssueCommentActivity.xaml
+++ b/JitHub/Views/Controls/Activity/IssueCommentActivity.xaml
@@ -7,7 +7,7 @@
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:issue="using:JitHub.Views.Controls.Issue"
     xmlns:local="using:JitHub.Views.Controls.Activity"
-    xmlns:markdown="using:CommunityToolkit.Labs.WinUI.MarkdownTextBlock"
+    xmlns:markdown="using:CommunityToolkit.WinUI.Controls"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:usercontrol="using:JitHub.Views.Controls.Common"
     d:DesignHeight="300"

--- a/JitHub/Views/Controls/Activity/ReleaseActivity.xaml
+++ b/JitHub/Views/Controls/Activity/ReleaseActivity.xaml
@@ -6,7 +6,7 @@
     xmlns:controls="using:Microsoft.Toolkit.Uwp.UI.Controls"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:local="using:JitHub.Views.Controls.Activity"
-    xmlns:markdown="using:CommunityToolkit.Labs.WinUI.MarkdownTextBlock"
+    xmlns:markdown="using:CommunityToolkit.WinUI.Controls"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:usercontrol="using:JitHub.Views.Controls.Common"
     d:DesignHeight="300"

--- a/JitHub/Views/Controls/Common/MarkdownForm.xaml
+++ b/JitHub/Views/Controls/Common/MarkdownForm.xaml
@@ -5,7 +5,7 @@
     xmlns:controls="using:Microsoft.Toolkit.Uwp.UI.Controls"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:local="using:JitHub.Views.Controls.Common"
-    xmlns:markdown="using:CommunityToolkit.Labs.WinUI.MarkdownTextBlock"
+    xmlns:markdown="using:CommunityToolkit.WinUI.Controls"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
     xmlns:viewmodels="using:JitHub.ViewModels"

--- a/JitHub/Views/Controls/Common/MarkdownForm.xaml.cs
+++ b/JitHub/Views/Controls/Common/MarkdownForm.xaml.cs
@@ -1,4 +1,4 @@
-﻿using CommunityToolkit.Labs.WinUI.MarkdownTextBlock;
+using CommunityToolkit.WinUI.Controls;
 using CommunityToolkit.Mvvm.DependencyInjection;
 using JitHub.Services;
 using System.ComponentModel;

--- a/JitHub/Views/Controls/Common/MarkdownViewer.xaml
+++ b/JitHub/Views/Controls/Common/MarkdownViewer.xaml
@@ -2,7 +2,7 @@
     x:Class="JitHub.Views.Controls.Common.MarkdownViewer"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:controls="using:CommunityToolkit.Labs.WinUI.MarkdownTextBlock"
+    xmlns:controls="using:CommunityToolkit.WinUI.Controls"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:local="using:JitHub.Views.Controls.Common"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"

--- a/JitHub/Views/Controls/Common/MarkdownViewer.xaml.cs
+++ b/JitHub/Views/Controls/Common/MarkdownViewer.xaml.cs
@@ -1,4 +1,4 @@
-﻿using CommunityToolkit.Labs.WinUI.MarkdownTextBlock;
+using CommunityToolkit.WinUI.Controls;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 

--- a/JitHub/Views/Controls/UserCommentBlock.xaml
+++ b/JitHub/Views/Controls/UserCommentBlock.xaml
@@ -7,7 +7,7 @@
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:interactivity="using:Microsoft.Xaml.Interactivity"
     xmlns:local="using:JitHub.Views.Controls"
-    xmlns:markdowntextblock="using:CommunityToolkit.Labs.WinUI.MarkdownTextBlock"
+    xmlns:markdowntextblock="using:CommunityToolkit.WinUI.Controls"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
     d:DesignHeight="300"


### PR DESCRIPTION
## Summary
- pin the Labs markdown package to an available feed version and remove the unused Shimmer package
- update markdown imports from the stale Labs namespace to the current CommunityToolkit.WinUI.Controls namespace
- keep the Store workflow build path stable by aligning the app code with the package surface that actually restores in CI

## Validation
- built JitHub\\JitHub.csproj successfully with MSBuild using TargetPlatformVersion=10.0.26100.0
- built an unsigned Store upload package successfully with the same StoreUpload/AppxBundle properties used by the workflow, producing an .msixupload artifact