### PR TITLE
Include Store build appsettings defaults

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -433,5 +433,6 @@ $RECYCLE.BIN/
 !.vscode/extensions.json
 appsettings.json
 appsettings.development.json
+!JitHub/appsettings.json
 **/dist
 **/output

--- a/JitHub/JitHub.csproj
+++ b/JitHub/JitHub.csproj
@@ -616,7 +616,7 @@
     <Content Include="Assets\StoreLogo.scale-200.png" />
     <Content Include="Assets\StoreLogo.scale-400.png" />
     <Content Include="Assets\Fonts\FluentIcons.ttf" />
-    <Content Include="appsettings.development.json">
+    <Content Include="appsettings.development.json" Condition="Exists('appsettings.development.json')">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="appsettings.json">

--- a/JitHub/appsettings.json
+++ b/JitHub/appsettings.json
@@ -1,0 +1,5 @@
+{
+  "Credential": {
+    "ClientId": "095ff0297fef36faef33"
+  }
+}


### PR DESCRIPTION
## Summary
- commit the required default `JitHub/appsettings.json` used by the app at runtime and during packaging
- make `appsettings.development.json` optional in the project so CI does not depend on an ignored local file
- stop `.gitignore` from excluding the shipped `JitHub/appsettings.json`

## Validation
- built the Store upload package on this fresh branch with the same unsigned StoreUpload/AppxBundle settings used by the workflow
- repeated that build with `JitHub/appsettings.development.json` temporarily removed to match the GitHub runner checkout
- verified the build produced `JitHub_1.6.2.0_x86_x64_arm64_bundle.msixupload`