### PR TITLE
Fix Store publish CLI arguments

### DIFF
--- a/.github/workflows/jithub-store-release.yml
+++ b/.github/workflows/jithub-store-release.yml
@@ -190,6 +190,7 @@ jobs:
           }
 
           "upload_package=$($package.FullName)" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+          "upload_package_dir=$($package.DirectoryName)" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
 
       - name: Upload release artifacts
         uses: actions/upload-artifact@v4
@@ -211,7 +212,7 @@ jobs:
         shell: pwsh
         run: >
           msstore publish "${{ github.workspace }}\${{ env.PROJECT_ROOT }}"
-          --inputFile "${{ steps.package.outputs.upload_package }}"
+          --inputDirectory "${{ steps.package.outputs.upload_package_dir }}"
           --appId "$env:STORE_PRODUCT_ID"
 
       - name: Remove transient signing certificate


### PR DESCRIPTION
## Summary
- fix the final Store publish step to use the CLI argument the current `msstore` tool actually supports
- expose the discovered package directory from the package-finding step
- pass that directory to `msstore publish` instead of the unsupported `--inputFile` argument

## Why
The failed run completed package build, artifact upload, and credential configuration successfully. The only remaining failure was:
- `Unrecognized command or argument ''--inputFile''`

The same run's CLI help output showed the supported option is `--inputDirectory`.