### PR TITLE
[codex] Fix dev OAuth and website polish

### DIFF
--- a/JitHub.Web/JitHub.Web.csproj
+++ b/JitHub.Web/JitHub.Web.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
+    <UserSecretsId>jithub-web-local-oauth</UserSecretsId>
   </PropertyGroup>
 
 </Project>

--- a/JitHub.Web/Layout/MainLayout.razor.css
+++ b/JitHub.Web/Layout/MainLayout.razor.css
@@ -12,13 +12,13 @@
     align-items: center;
     justify-content: space-between;
     gap: 1rem;
-    width: min(1200px, calc(100% - 2rem));
+    width: min(var(--site-frame-width), calc(100% - 2rem));
     margin: 0.75rem auto 0;
     padding: 0.7rem 0.9rem;
     border: 1px solid var(--border-soft);
     border-radius: var(--radius-lg);
-    background: color-mix(in oklch, var(--paper) 96%, white 4%);
-    box-shadow: 0 1px 0 color-mix(in oklch, white 70%, transparent);
+    background: linear-gradient(180deg, color-mix(in oklch, var(--surface) 94%, var(--surface-tint) 6%), var(--surface));
+    box-shadow: inset 0 1px 0 var(--surface-inner-highlight), 0 8px 18px var(--shadow-soft);
     backdrop-filter: blur(10px);
 }
 
@@ -129,7 +129,7 @@
 }
 
 .site-footer {
-    width: min(1200px, calc(100% - 2rem));
+    width: min(var(--site-frame-width), calc(100% - 2rem));
     margin: 1rem auto 2rem;
     padding: 0.9rem 0.2rem 0;
     border-top: 1px solid var(--border-soft);

--- a/JitHub.Web/Pages/Authorize.razor
+++ b/JitHub.Web/Pages/Authorize.razor
@@ -14,7 +14,7 @@
             <div class="auth-spinner" aria-hidden="true"></div>
             <h1>Finishing sign-in</h1>
             <p>
-                We are exchanging the temporary GitHub approval code and sending the result back to the desktop app.
+                JitHub is finishing sign-in. You can close this tab after the desktop app opens.
             </p>
         </div>
 
@@ -34,14 +34,14 @@
             <img class="auth-illustration" src="login_fail.svg" alt="" />
             <h1>We could not complete sign-in</h1>
             <p data-auth-error>
-                Try handing control back to the app and starting the GitHub login flow one more time.
+                Please return to JitHub and start sign-in again.
             </p>
             <div class="button-row">
-                <a class="button button--primary" href="jithub://">Return to JitHub</a>
+                <a class="button button--primary" href="jithub://">Open JitHub</a>
                 <a class="button button--ghost" href="/">Back to site</a>
             </div>
         </div>
     </div>
 </section>
 
-<script type="module" src="js/authorize.js"></script>
+<script type="module" src="js/authorize.js?v=20260507-redirect-uri"></script>

--- a/JitHub.Web/Program.cs
+++ b/JitHub.Web/Program.cs
@@ -60,19 +60,23 @@ RouteGroupBuilder api = app.MapGroup("/api")
 
 api.MapGet("/GithubCodeToToken", async Task<IResult> (
     string? tempCode,
+    string? redirectUri,
+    HttpContext httpContext,
     GithubAuthService githubAuth,
     ILogger<Program> logger,
     CancellationToken cancellationToken) =>
 {
     try
     {
-        string token = await githubAuth.ExchangeCodeForTokenAsync(tempCode, cancellationToken);
+        string? effectiveRedirectUri = ResolveOAuthRedirectUri(redirectUri, httpContext);
+        string token = await githubAuth.ExchangeCodeForTokenAsync(tempCode, effectiveRedirectUri, cancellationToken);
         return TypedResults.Text(token, "text/plain");
     }
     catch (InvalidOperationException ex)
     {
+        logger.LogWarning(ex, "GitHub OAuth token exchange failed.");
         return TypedResults.Json(
-            new WebErrorMessage { Message = ex.Message },
+            new WebErrorMessage { Message = "We could not complete sign-in. Please try again." },
             statusCode: StatusCodes.Status400BadRequest);
     }
     catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
@@ -102,6 +106,61 @@ static string ResolveCallerIdentity(HttpContext httpContext)
     }
 
     return "unknown";
+}
+
+static string? ResolveOAuthRedirectUri(string? redirectUri, HttpContext httpContext)
+{
+    if (TryNormalizeOAuthRedirectUri(redirectUri, out string normalizedRedirectUri))
+    {
+        return normalizedRedirectUri;
+    }
+
+    string? referer = httpContext.Request.Headers.Referer.FirstOrDefault();
+    if (TryNormalizeOAuthRedirectUri(referer, out normalizedRedirectUri))
+    {
+        return normalizedRedirectUri;
+    }
+
+    HostString host = httpContext.Request.Host;
+    if (!host.HasValue)
+    {
+        return null;
+    }
+
+    PathString pathBase = httpContext.Request.PathBase;
+    string inferredRedirectUri = $"{httpContext.Request.Scheme}://{host}{pathBase}/authorize";
+    return TryNormalizeOAuthRedirectUri(inferredRedirectUri, out normalizedRedirectUri)
+        ? normalizedRedirectUri
+        : null;
+}
+
+static bool TryNormalizeOAuthRedirectUri(string? redirectUri, out string normalizedRedirectUri)
+{
+    normalizedRedirectUri = string.Empty;
+    if (string.IsNullOrWhiteSpace(redirectUri))
+    {
+        return false;
+    }
+
+    if (!Uri.TryCreate(redirectUri, UriKind.Absolute, out Uri? uri))
+    {
+        return false;
+    }
+
+    if (!string.Equals(uri.Scheme, Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase) &&
+        !string.Equals(uri.Scheme, Uri.UriSchemeHttp, StringComparison.OrdinalIgnoreCase))
+    {
+        return false;
+    }
+
+    string path = uri.AbsolutePath.TrimEnd('/');
+    if (!path.EndsWith("/authorize", StringComparison.OrdinalIgnoreCase))
+    {
+        return false;
+    }
+
+    normalizedRedirectUri = uri.GetLeftPart(UriPartial.Path);
+    return true;
 }
 
 static void AddAzurePrivateProxyNetwork(ForwardedHeadersOptions options, string address, int prefixLength, int mappedPrefixLength)

--- a/JitHub.Web/Services/GithubAuthService.cs
+++ b/JitHub.Web/Services/GithubAuthService.cs
@@ -5,36 +5,58 @@ namespace JitHub.Web.Services;
 
 internal sealed class GithubAuthService
 {
+    private const string DevelopmentClientId = "Ov23libqduSlPx5TcCne";
+    private const string UseProductionOAuthInDevelopmentSetting = "JITHUB_WEB_USE_PRODUCTION_OAUTH";
+
     private readonly HttpClient _httpClient;
     private readonly ILogger<GithubAuthService> _logger;
+    private readonly IConfiguration _configuration;
+    private readonly IHostEnvironment _environment;
 
-    public GithubAuthService(HttpClient httpClient, ILogger<GithubAuthService> logger)
+    public GithubAuthService(
+        HttpClient httpClient,
+        ILogger<GithubAuthService> logger,
+        IConfiguration configuration,
+        IHostEnvironment environment)
     {
         _httpClient = httpClient;
         _logger = logger;
+        _configuration = configuration;
+        _environment = environment;
     }
 
-    public async Task<string> ExchangeCodeForTokenAsync(string? code, CancellationToken cancellationToken)
+    public async Task<string> ExchangeCodeForTokenAsync(
+        string? code,
+        string? redirectUri,
+        CancellationToken cancellationToken)
     {
         if (string.IsNullOrWhiteSpace(code))
         {
             throw new InvalidOperationException("Missing temporary code.");
         }
 
-        string clientId = GetRequiredEnvironmentVariable(
-            "JitHubClientId",
-            "Missing client information.",
-            "JithubClientId");
-        string appSecret = GetRequiredEnvironmentVariable("JithubAppSecret", "Missing app secret.");
+        OAuthApplication oauthApplication = GetOAuthApplication();
+
+        Dictionary<string, string> tokenRequestFields = new()
+        {
+            ["client_id"] = oauthApplication.ClientId,
+            ["client_secret"] = oauthApplication.ClientSecret,
+            ["code"] = code
+        };
+
+        if (TryNormalizeRedirectUri(redirectUri, out string normalizedRedirectUri))
+        {
+            tokenRequestFields["redirect_uri"] = normalizedRedirectUri;
+            _logger.LogInformation("Exchanging GitHub OAuth code with redirect URI {RedirectUri}.", normalizedRedirectUri);
+        }
+        else
+        {
+            _logger.LogWarning("Exchanging GitHub OAuth code without a redirect URI.");
+        }
 
         using HttpRequestMessage request = new(HttpMethod.Post, "login/oauth/access_token")
         {
-            Content = new FormUrlEncodedContent(new Dictionary<string, string>
-            {
-                ["client_id"] = clientId,
-                ["client_secret"] = appSecret,
-                ["code"] = code
-            })
+            Content = new FormUrlEncodedContent(tokenRequestFields)
         };
 
         GitHubTokenResponse? token;
@@ -66,33 +88,121 @@ internal sealed class GithubAuthService
             throw new InvalidOperationException("GitHub request error.", ex);
         }
 
-        if (token is null || string.IsNullOrWhiteSpace(token.AccessToken) || !string.IsNullOrWhiteSpace(token.Error))
+        if (token is not null && !string.IsNullOrWhiteSpace(token.Error))
         {
+            string error = token.Error;
+            string? errorDescription = token.ErrorDescription;
             _logger.LogWarning(
                 "GitHub OAuth token response was invalid. Error: {Error}; Description: {Description}",
-                token?.Error,
-                token?.ErrorDescription);
+                error,
+                errorDescription);
+            string detail = string.IsNullOrWhiteSpace(errorDescription)
+                ? error
+                : errorDescription;
+            throw new InvalidOperationException($"GitHub rejected the OAuth code: {detail}");
+        }
+
+        if (token is null || string.IsNullOrWhiteSpace(token.AccessToken))
+        {
+            _logger.LogWarning("GitHub OAuth token response was missing an access token.");
             throw new InvalidOperationException("GitHub returned missing token information.");
         }
 
         return token.AccessToken;
     }
 
-    private static string GetRequiredEnvironmentVariable(string name, string errorMessage, params string[] fallbackNames)
+    private OAuthApplication GetOAuthApplication()
     {
-        foreach (string candidate in EnumerateEnvironmentVariableNames(name, fallbackNames))
+        if (ShouldUseDevelopmentOAuthApplication())
         {
-            string? value = Environment.GetEnvironmentVariable(candidate);
-            if (!string.IsNullOrWhiteSpace(value))
-            {
-                return value;
-            }
+            string clientId = GetSetting(
+                    "JITHUB_DEV_OAUTH_CLIENT_ID",
+                    "GitHubOAuth:DevelopmentClientId",
+                    "GitHubOAuth:DevClientId")
+                ?? DevelopmentClientId;
+            string developmentClientSecret = GetRequiredSetting(
+                "JITHUB_DEV_OAUTH_CLIENT_SECRET",
+                "Missing development app secret.",
+                "JitHubDevelopmentAppSecret",
+                "JithubDevelopmentAppSecret",
+                "GitHubOAuth:DevelopmentClientSecret",
+                "GitHubOAuth:DevClientSecret");
+            _logger.LogInformation("Using the development GitHub OAuth app for local token exchange.");
+            return new OAuthApplication(clientId, developmentClientSecret);
+        }
+
+        string configuredClientId = GetRequiredSetting(
+            "JitHubClientId",
+            "Missing client information.",
+            "JithubClientId",
+            "GitHubOAuth:ClientId");
+        string productionClientSecret = GetRequiredSetting(
+            "JithubAppSecret",
+            "Missing app secret.",
+            "GitHubOAuth:ClientSecret");
+        return new OAuthApplication(configuredClientId, productionClientSecret);
+    }
+
+    private bool ShouldUseDevelopmentOAuthApplication()
+    {
+        if (!_environment.IsDevelopment())
+        {
+            return false;
+        }
+
+        string? useProductionOAuth = GetSetting(UseProductionOAuthInDevelopmentSetting);
+        return !string.Equals(useProductionOAuth, "true", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static bool TryNormalizeRedirectUri(string? redirectUri, out string normalizedRedirectUri)
+    {
+        normalizedRedirectUri = string.Empty;
+        if (string.IsNullOrWhiteSpace(redirectUri))
+        {
+            return false;
+        }
+
+        if (!Uri.TryCreate(redirectUri, UriKind.Absolute, out Uri? uri))
+        {
+            return false;
+        }
+
+        if (!string.Equals(uri.Scheme, Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase) &&
+            !string.Equals(uri.Scheme, Uri.UriSchemeHttp, StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        normalizedRedirectUri = uri.GetLeftPart(UriPartial.Path);
+        return true;
+    }
+
+    private string GetRequiredSetting(string name, string errorMessage, params string[] fallbackNames)
+    {
+        string? value = GetSetting(name, fallbackNames);
+        if (!string.IsNullOrWhiteSpace(value))
+        {
+            return value;
         }
 
         throw new InvalidOperationException(errorMessage);
     }
 
-    private static IEnumerable<string> EnumerateEnvironmentVariableNames(string primaryName, IEnumerable<string> fallbackNames)
+    private string? GetSetting(string primaryName, params string[] fallbackNames)
+    {
+        foreach (string candidate in EnumerateSettingNames(primaryName, fallbackNames))
+        {
+            string? value = Environment.GetEnvironmentVariable(candidate) ?? _configuration[candidate];
+            if (!string.IsNullOrWhiteSpace(value))
+            {
+                return value.Trim();
+            }
+        }
+
+        return null;
+    }
+
+    private static IEnumerable<string> EnumerateSettingNames(string primaryName, IEnumerable<string> fallbackNames)
     {
         yield return primaryName;
 
@@ -116,4 +226,6 @@ internal sealed class GithubAuthService
         [JsonPropertyName("error_description")]
         public string? ErrorDescription { get; set; }
     }
+
+    private sealed record OAuthApplication(string ClientId, string ClientSecret);
 }

--- a/JitHub.Web/wwwroot/app.css
+++ b/JitHub.Web/wwwroot/app.css
@@ -68,10 +68,13 @@
     --brand-gold: oklch(0.6 0.12 90);
     --brand-violet: oklch(0.55 0.07 315);
     --border-soft: oklch(0.88 0.03 95 / 0.96);
+    --surface-tint: white;
+    --surface-inner-highlight: oklch(1 0 0 / 0.62);
     --shadow-soft: oklch(0.25 0.02 140 / 0.08);
     --font-body: "IBM Plex Mono", ui-monospace, monospace;
     --font-display: "Instrument Serif", Georgia, serif;
     --font-mono: "IBM Plex Mono", ui-monospace, monospace;
+    --site-frame-width: 1240px;
     --radius-sm: 0.5rem;
     --radius-md: 0.625rem;
     --radius-lg: 0.875rem;
@@ -92,6 +95,8 @@
     --brand-gold: oklch(0.78 0.11 88);
     --brand-violet: oklch(0.72 0.09 315);
     --border-soft: oklch(0.39 0.035 145 / 0.86);
+    --surface-tint: oklch(0.3 0.024 145);
+    --surface-inner-highlight: oklch(0.48 0.036 145 / 0.22);
     --shadow-soft: oklch(0.04 0.01 145 / 0.38);
 }
 
@@ -110,6 +115,8 @@
         --brand-gold: oklch(0.78 0.11 88);
         --brand-violet: oklch(0.72 0.09 315);
         --border-soft: oklch(0.39 0.035 145 / 0.86);
+        --surface-tint: oklch(0.3 0.024 145);
+        --surface-inner-highlight: oklch(0.48 0.036 145 / 0.22);
         --shadow-soft: oklch(0.04 0.01 145 / 0.38);
     }
 }
@@ -157,8 +164,8 @@ a {
 
 .surface-card {
     border: 1px solid var(--border-soft);
-    background: linear-gradient(180deg, color-mix(in oklch, var(--surface) 94%, white 6%), var(--surface));
-    box-shadow: 0 1px 0 color-mix(in oklch, white 65%, transparent), 0 8px 18px var(--shadow-soft);
+    background: linear-gradient(180deg, color-mix(in oklch, var(--surface) 94%, var(--surface-tint) 6%), var(--surface));
+    box-shadow: inset 0 1px 0 var(--surface-inner-highlight), 0 8px 18px var(--shadow-soft);
 }
 
 .eyebrow {
@@ -221,7 +228,7 @@ a {
 .page-frame,
 .auth-page,
 .not-found-shell {
-    width: min(1240px, calc(100% - 2rem));
+    width: min(var(--site-frame-width), calc(100% - 2rem));
     margin: 1.4rem auto 0;
 }
 
@@ -402,7 +409,7 @@ a {
     overflow: hidden;
     border-radius: 0.95rem;
     border: 1px solid color-mix(in oklch, var(--brand-violet) 7%, var(--border-soft));
-    box-shadow: inset 0 1px 0 color-mix(in oklch, white 60%, transparent);
+    box-shadow: inset 0 1px 0 var(--surface-inner-highlight);
 }
 
 .showcase-card__frame img {

--- a/JitHub.Web/wwwroot/js/authorize.js
+++ b/JitHub.Web/wwwroot/js/authorize.js
@@ -13,6 +13,24 @@ if (authRoot) {
         }
     };
 
+    const readErrorMessage = async (response) => {
+        const fallback = `Token exchange failed with status ${response.status}.`;
+        try {
+            const contentType = response.headers.get("content-type") ?? "";
+            if (contentType.includes("application/json")) {
+                const payload = await response.json();
+                return payload?.message || payload?.Message || fallback;
+            }
+
+            const text = (await response.text()).trim();
+            return text || fallback;
+        } catch {
+            return fallback;
+        }
+    };
+
+    const genericFailureMessage = "We could not complete sign-in. Please return to JitHub and start sign-in again.";
+
     const fail = (message) => {
         if (errorText && message) {
             errorText.textContent = message;
@@ -29,19 +47,20 @@ if (authRoot) {
         const state = params.get("state");
 
         if (!code || !state) {
-            fail("The GitHub callback is missing the temporary code or state value.");
+            fail(genericFailureMessage);
             return;
         }
 
         try {
-            const response = await fetch(`${tokenEndpoint}?tempCode=${encodeURIComponent(code)}`, {
+            const redirectUri = `${window.location.origin}${window.location.pathname}`;
+            const response = await fetch(`${tokenEndpoint}?tempCode=${encodeURIComponent(code)}&redirectUri=${encodeURIComponent(redirectUri)}`, {
                 headers: {
                     "Accept": "text/plain"
                 }
             });
 
             if (!response.ok) {
-                throw new Error(`Token exchange failed with status ${response.status}.`);
+                throw new Error(await readErrorMessage(response));
             }
 
             const token = (await response.text()).trim();
@@ -65,8 +84,7 @@ if (authRoot) {
                 window.location.assign(protocolUri);
             }, 120);
         } catch (error) {
-            console.error("Failed to complete JitHub authorization.", error);
-            fail("GitHub approved the request, but the site could not complete the handoff back to JitHub.");
+            fail(genericFailureMessage);
         }
     };
 

--- a/JitHub.WinUI/Models/Credential.cs
+++ b/JitHub.WinUI/Models/Credential.cs
@@ -3,4 +3,10 @@ namespace JitHub.Models;
 public class Credential
 {
     public string ClientId { get; set; } = string.Empty;
+
+    public string? DevelopmentClientId { get; set; }
+
+    public string? AuthorizationCallbackUrl { get; set; }
+
+    public string? DevelopmentAuthorizationCallbackUrl { get; set; }
 }

--- a/JitHub.WinUI/Services/AppConfig.cs
+++ b/JitHub.WinUI/Services/AppConfig.cs
@@ -6,6 +6,9 @@ namespace JitHub.Services;
 
 public class AppConfig : IAppConfig
 {
+    private const string OAuthClientIdEnvironmentVariable = "JITHUB_OAUTH_CLIENT_ID";
+    private const string OAuthCallbackUrlEnvironmentVariable = "JITHUB_OAUTH_CALLBACK_URL";
+
     private readonly IConfigurationRoot _configurationRoot;
 
     public AppConfig()
@@ -17,5 +20,46 @@ public class AppConfig : IAppConfig
         _configurationRoot = builder.Build();
     }
 
-    public Credential Credential => _configurationRoot.GetSection(nameof(Credential)).Get<Credential>() ?? new Credential();
+    public Credential Credential
+    {
+        get
+        {
+            Credential credential = _configurationRoot.GetSection(nameof(Credential)).Get<Credential>() ?? new Credential();
+            bool useDevelopmentCredential = ShouldUseDevelopmentCredential();
+            string? environmentClientId = Environment.GetEnvironmentVariable(OAuthClientIdEnvironmentVariable);
+            if (!string.IsNullOrWhiteSpace(environmentClientId))
+            {
+                credential.ClientId = environmentClientId.Trim();
+            }
+            else if (useDevelopmentCredential && !string.IsNullOrWhiteSpace(credential.DevelopmentClientId))
+            {
+                credential.ClientId = credential.DevelopmentClientId.Trim();
+            }
+
+            string? environmentCallbackUrl = Environment.GetEnvironmentVariable(OAuthCallbackUrlEnvironmentVariable);
+            if (!string.IsNullOrWhiteSpace(environmentCallbackUrl))
+            {
+                credential.AuthorizationCallbackUrl = environmentCallbackUrl.Trim();
+            }
+            else if (useDevelopmentCredential &&
+                !string.IsNullOrWhiteSpace(credential.DevelopmentAuthorizationCallbackUrl))
+            {
+                credential.AuthorizationCallbackUrl = credential.DevelopmentAuthorizationCallbackUrl.Trim();
+            }
+
+            return credential;
+        }
+    }
+
+    private static bool ShouldUseDevelopmentCredential()
+    {
+#if DEBUG
+        return true;
+#else
+        return string.Equals(
+            Environment.GetEnvironmentVariable("JITHUB_USE_DEV_OAUTH_APP"),
+            "true",
+            StringComparison.OrdinalIgnoreCase);
+#endif
+    }
 }

--- a/JitHub.WinUI/Services/AuthService.cs
+++ b/JitHub.WinUI/Services/AuthService.cs
@@ -3,6 +3,7 @@ using System.Net;
 using System.Net.Http;
 using System.Security.Cryptography;
 using System.Threading.Tasks;
+using JitHub.Models;
 using JitHub.Models.GitHub;
 using JitHub.WinUI;
 using Windows.Security.Credentials;
@@ -62,7 +63,11 @@ public sealed class AuthService : IAuthService
 
         SavePendingAuthState(authState);
 
-        Uri oauthLoginUrl = _gitHubClientService.CreateLoginUri(_appConfigService.Credential.ClientId, authState);
+        Credential credential = _appConfigService.Credential;
+        Uri oauthLoginUrl = _gitHubClientService.CreateLoginUri(
+            credential.ClientId,
+            authState,
+            credential.AuthorizationCallbackUrl);
         bool launched = await Windows.System.Launcher.LaunchUriAsync(oauthLoginUrl);
         if (!launched)
         {

--- a/JitHub.WinUI/Services/GitHubClientService.cs
+++ b/JitHub.WinUI/Services/GitHubClientService.cs
@@ -30,13 +30,18 @@ public sealed class GitHubClientService : IGitHubClientService
         _httpClient.DefaultRequestHeaders.Add("X-GitHub-Api-Version", "2022-11-28");
     }
 
-    public Uri CreateLoginUri(string clientId, string? state = null)
+    public Uri CreateLoginUri(string clientId, string? state = null, string? redirectUri = null)
     {
         List<string> queryParts =
         [
             $"client_id={Uri.EscapeDataString(clientId)}",
             $"scope={Uri.EscapeDataString("user repo delete_repo")}"
         ];
+
+        if (!string.IsNullOrWhiteSpace(redirectUri))
+        {
+            queryParts.Add($"redirect_uri={Uri.EscapeDataString(redirectUri)}");
+        }
 
         if (!string.IsNullOrWhiteSpace(state))
         {

--- a/JitHub.WinUI/Services/IGitHubClientService.cs
+++ b/JitHub.WinUI/Services/IGitHubClientService.cs
@@ -8,7 +8,7 @@ namespace JitHub.Services;
 
 public interface IGitHubClientService
 {
-    Uri CreateLoginUri(string clientId, string? state = null);
+    Uri CreateLoginUri(string clientId, string? state = null, string? redirectUri = null);
 
     Task<GitHubUser> GetCurrentUserAsync(string token, CancellationToken cancellationToken = default);
 

--- a/JitHub.WinUI/appsettings.json
+++ b/JitHub.WinUI/appsettings.json
@@ -1,5 +1,7 @@
 {
   "Credential": {
-    "ClientId": "095ff0297fef36faef33"
+    "ClientId": "095ff0297fef36faef33",
+    "DevelopmentClientId": "Ov23libqduSlPx5TcCne",
+    "DevelopmentAuthorizationCallbackUrl": "https://localhost:7284/authorize"
   }
 }

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 </p>
 
 <p align="center">
-  JitHub is a packaged WinAppSDK / WinUI 3 app for GitHub lovers. It lets you browse repositories, issues, pull requests, and code from a Windows-native shell that stays smooth, touch-friendly, and fast.
+  JitHub is a packaged Windows App SDK / WinUI 3 GitHub client for Windows. It brings repositories, issues, pull requests, activity, and code browsing into a quieter native desktop app.
 </p>
 
 <p align="center">
@@ -13,27 +13,47 @@
   </a>
 </p>
 
-## Features
+## What JitHub Does
 
-- Browse GitHub repositories by topics, languages, or keywords
-- View repository details, files, commits, issues, pull requests, and actions
-- Star, fork, watch, or clone repositories
-- Create, edit, or close issues and pull requests
-- Comment on issues and pull requests with Markdown support
-- Manage your notifications and profile
-- Browse code in an embedded VS Code-based surface
+- Browse public, private, and forked repositories from a native Windows shell
+- Search GitHub repositories and open exact `owner/name` matches quickly
+- Read repository activity, issues, pull requests, comments, reactions, labels, and timelines
+- Star, fork, watch, create, edit, close, merge, and react without leaving the app
+- Browse files, branches, commits, and repository content in an embedded VS Code-based surface
+- Use a calm app-owned design system with light and dark themes, design-lab coverage, and screenshot automation
 
 ## Screenshots
 
-<img src="https://github.com/JitHubApp/JitHubV2/blob/main/ScreenShots/screenshot1.png" width="640" />
-<img src="https://github.com/JitHubApp/JitHubV2/blob/main/ScreenShots/screenshot2.png" width="640" />
-<img src="https://github.com/JitHubApp/JitHubV2/blob/main/ScreenShots/screenshot3.png" width="640" />
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="JitHub.Web/wwwroot/ss1-dark.png">
+  <img src="JitHub.Web/wwwroot/ss1.png" alt="JitHub home dashboard and repository workspace." width="900">
+</picture>
 
-## Repository layout
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="JitHub.Web/wwwroot/ss2-dark.png">
+  <img src="JitHub.Web/wwwroot/ss2.png" alt="JitHub code page with the embedded VS Code experience." width="900">
+</picture>
 
-- `JitHub.WinUI`: the desktop app
-- `JitHub.Web`: the server-rendered public website and GitHub OAuth callback bridge
-- `artifacts/EditorAssets/dist`: generated editor assets copied from `jithub-vs-code` during development and CI
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="JitHub.Web/wwwroot/ss3-dark.png">
+  <img src="JitHub.Web/wwwroot/ss3.png" alt="JitHub pull request and issue management surfaces." width="900">
+</picture>
+
+## Current Architecture
+
+- `JitHub.WinUI`: the desktop app, built with .NET 10, Windows App SDK, WinUI 3, packaged MSIX identity, and Native AOT-friendly service/model patterns
+- `JitHub.Web`: the unified ASP.NET Core website, landing page, OAuth callback page, and `/api/GithubCodeToToken` token-exchange API
+- `JitHub.WinUI.Automation`: the FlaUI-based screenshot and smoke-test harness used with the in-app design lab
+- `artifacts/EditorAssets/dist`: generated editor assets copied from `jithub-vs-code` during development and CI; these files are not checked in
+- `eng`: repeatable local and CI scripts for Windows App CLI, Microsoft Store CLI, App Service provisioning, editor asset sync, and release packaging
+
+## Runtime Shape
+
+- The desktop app authenticates through a browser-based GitHub OAuth flow, then receives the token through the `jithub://auth/v2` protocol callback.
+- The public website is static server-rendered by default. The `/authorize` route uses a tiny JavaScript bridge only for OAuth handoff; it does not ship Blazor WebAssembly.
+- The web project is deployed as a normal Azure App Service Web App. It replaces the old split Static Web App plus Function App shape.
+- The desktop release workflow builds Store packages for `x64` and `ARM64`, prepares editor assets from `jithub-vs-code`, and publishes through Microsoft Store Developer CLI.
+- The app UI is driven by semantic WinUI resource dictionaries and reusable app-owned controls, with design-lab screenshot proof for light and dark themes.
 
 `global.json` pins the repo to .NET SDK `10.0.202`.
 
@@ -65,20 +85,26 @@ Check or install the tools with:
 
 ### Desktop app setup
 
-Create `JitHub.WinUI/appsettings.json` with your GitHub OAuth client ID. This file is gitignored and must never be committed.
+`JitHub.WinUI/appsettings.json` is checked in with public OAuth client IDs only. GitHub OAuth client IDs are not secrets; client secrets must stay in user secrets, environment variables, Azure App Service settings, or GitHub Actions secrets.
 
 ```json
 {
   "Credential": {
-    "ClientId": "<your client ID>"
+    "ClientId": "<production client ID>",
+    "DevelopmentClientId": "Ov23libqduSlPx5TcCne",
+    "DevelopmentAuthorizationCallbackUrl": "https://localhost:7284/authorize"
   }
 }
 ```
 
-Set these environment variables for the web callback token exchange:
+Debug builds use `DevelopmentClientId` and `DevelopmentAuthorizationCallbackUrl` automatically so local app launches authenticate against the development GitHub OAuth app. Release builds keep using `ClientId`. To force the development app in a non-Debug local run, set `JITHUB_USE_DEV_OAUTH_APP=true`; to override either path with a specific OAuth app, set `JITHUB_OAUTH_CLIENT_ID` and optionally `JITHUB_OAUTH_CALLBACK_URL`.
 
-- `JitHubClientId` or legacy fallback `JithubClientId`
-- `JithubAppSecret`
+Set these settings for the web callback token exchange:
+
+- Local Development uses the development GitHub OAuth app automatically and ignores production-style `JitHubClientId` / `JithubAppSecret` environment variables.
+- Set the development app secret with `dotnet user-secrets set JITHUB_DEV_OAUTH_CLIENT_SECRET "<secret>" --project .\JitHub.Web\JitHub.Web.csproj`.
+- Production uses `JitHubClientId` or legacy fallback `JithubClientId`, plus `JithubAppSecret` or `GitHubOAuth__ClientSecret`.
+- To intentionally test the production OAuth app from a local Development web host, set `JITHUB_WEB_USE_PRODUCTION_OAUTH=true`.
 
 ### Editor assets
 
@@ -95,7 +121,21 @@ The public website is now an ASP.NET Core server app. It serves the landing page
 Run it locally with:
 
 ```powershell
-dotnet run --project .\JitHub.Web\JitHub.Web.csproj
+dotnet run --project .\JitHub.Web\JitHub.Web.csproj --launch-profile https
+```
+
+For the development GitHub OAuth app, set the callback URL to:
+
+```text
+https://localhost:7284/authorize
+```
+
+The callback route is `/authorize`, not `/auth/callback`. The authorize page calls the same-origin `/api/GithubCodeToToken` endpoint to exchange the temporary GitHub code, then launches the app through the `jithub://` protocol callback.
+
+The local callback host needs the development OAuth app secret before sign-in can complete:
+
+```powershell
+dotnet user-secrets set JITHUB_DEV_OAUTH_CLIENT_SECRET "<secret>" --project .\JitHub.Web\JitHub.Web.csproj
 ```
 
 The website does not require `wasm-tools`. The landing page is static SSR, and the authorize flow uses a tiny JavaScript bridge instead of Blazor WebAssembly.


### PR DESCRIPTION
## Summary

- Make local WinUI debug auth use the development GitHub OAuth app and callback URL consistently.
- Make the unified web callback exchange use a development-specific OAuth secret in Development, avoiding accidental pairing with production environment variables.
- Keep OAuth failure details in server logs while showing generic user-facing sign-in failure copy on the public website.
- Refresh README architecture/setup docs and replace README screenshots with the website screenshot set.
- Polish website dark-mode surfaces and align the top banner/footer width with the main content frame.

## Root Cause

Local WinUI debug builds were launching GitHub OAuth with the development client id, but `JitHub.Web` could still pick up existing production-style `JitHubClientId` / `JithubAppSecret` environment variables during token exchange. GitHub issues authorization codes for one OAuth app and rejects exchange attempts made as another app, which surfaced as `bad_verification_code`.

## Validation

- `dotnet build .\JitHub.slnx -c Debug -p:Platform=x64`
- `dotnet build .\JitHub.Web\JitHub.Web.csproj -c Debug -o %TEMP%\JitHubWebBuildCodex`
- Local OAuth retry confirmed working after setting `JITHUB_DEV_OAUTH_CLIENT_SECRET`.
- `git diff --check`