### PR TITLE
[codex] Fix Store bundle publishing

### DIFF
--- a/.github/workflows/jithub-store-release.yml
+++ b/.github/workflows/jithub-store-release.yml
@@ -232,7 +232,7 @@ jobs:
             "$env:STORE_PRODUCT_ID"
           )
 
-          if ($submissionMode -eq 'draft') {
+          if ($submissionMode -in @('draft', 'public')) {
             $publishArgs += '--noCommit'
           }
 
@@ -254,5 +254,25 @@ jobs:
           & msstore @publishArgs
           if ($LASTEXITCODE -ne 0) {
             throw 'msstore publish failed.'
+          }
+
+          if ($submissionMode -ne 'flight') {
+            .\eng\Normalize-JitHubStoreSubmissionDeviceFamilies.ps1 `
+              -ProductId "$env:STORE_PRODUCT_ID" `
+              -TenantId "$env:STORE_TENANT_ID" `
+              -ClientId "$env:STORE_CLIENT_ID" `
+              -ClientSecret "$env:STORE_CLIENT_SECRET"
+          }
+
+          if ($submissionMode -eq 'public') {
+            & msstore submission publish "$env:STORE_PRODUCT_ID"
+            if ($LASTEXITCODE -ne 0) {
+              throw 'msstore submission publish failed.'
+            }
+
+            & msstore submission poll "$env:STORE_PRODUCT_ID"
+            if ($LASTEXITCODE -ne 0) {
+              throw 'msstore submission poll failed.'
+            }
           }
 

--- a/eng/Build-JitHubWinUIStorePackage.ps1
+++ b/eng/Build-JitHubWinUIStorePackage.ps1
@@ -79,13 +79,123 @@ function Get-WindowsPackageUploadFiles {
         Sort-Object FullName
 }
 
-function New-MultiArchitectureUploadPackage {
+function Get-MakeAppxPath {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$TargetPlatformVersion
+    )
+
+    $windowsKitRoots = @(
+        "${env:ProgramFiles(x86)}\Windows Kits\10\bin",
+        "${env:ProgramFiles}\Windows Kits\10\bin"
+    ) | Where-Object { -not [string]::IsNullOrWhiteSpace($_) -and (Test-Path -LiteralPath $_) }
+
+    $candidatePaths = foreach ($windowsKitRoot in $windowsKitRoots) {
+        Join-Path $windowsKitRoot "$TargetPlatformVersion\x64\makeappx.exe"
+        Join-Path $windowsKitRoot "$TargetPlatformVersion\x86\makeappx.exe"
+    }
+
+    foreach ($candidatePath in $candidatePaths) {
+        if (Test-Path -LiteralPath $candidatePath) {
+            return $candidatePath
+        }
+    }
+
+    $availableVersions = foreach ($windowsKitRoot in $windowsKitRoots) {
+        Get-ChildItem -Path $windowsKitRoot -Directory -ErrorAction SilentlyContinue |
+            Where-Object { Test-Path -LiteralPath (Join-Path $_.FullName 'x64\makeappx.exe') } |
+            Select-Object -ExpandProperty Name
+    }
+
+    throw "makeappx.exe for Windows SDK $TargetPlatformVersion was not found. Available SDK versions: $($availableVersions -join ', ')"
+}
+
+function Get-PackageIdentityVersion {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$PackagePath
+    )
+
+    Add-Type -AssemblyName System.IO.Compression.FileSystem
+
+    $archive = [System.IO.Compression.ZipFile]::OpenRead($PackagePath)
+    try {
+        $manifestEntry = $archive.Entries | Where-Object { $_.FullName -eq 'AppxManifest.xml' } | Select-Object -First 1
+        if (-not $manifestEntry) {
+            throw "Package does not contain AppxManifest.xml: $PackagePath"
+        }
+
+        $manifestStream = $manifestEntry.Open()
+        try {
+            $reader = [System.IO.StreamReader]::new($manifestStream)
+            try {
+                [xml]$manifest = $reader.ReadToEnd()
+                $version = $manifest.Package.Identity.Version
+                if ([string]::IsNullOrWhiteSpace($version)) {
+                    throw "Package manifest does not contain an Identity Version: $PackagePath"
+                }
+
+                return $version
+            }
+            finally {
+                $reader.Dispose()
+            }
+        }
+        finally {
+            $manifestStream.Dispose()
+        }
+    }
+    finally {
+        $archive.Dispose()
+    }
+}
+
+function Assert-StoreUploadPackageContainsBundle {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$PackagePath
+    )
+
+    Add-Type -AssemblyName System.IO.Compression.FileSystem
+
+    $archive = [System.IO.Compression.ZipFile]::OpenRead($PackagePath)
+    try {
+        $rootEntries = $archive.Entries |
+            Where-Object { [string]::IsNullOrWhiteSpace([System.IO.Path]::GetDirectoryName($_.FullName)) }
+
+        $bundleEntries = $rootEntries |
+            Where-Object { [System.IO.Path]::GetExtension($_.FullName) -in '.appxbundle', '.msixbundle' }
+
+        if (-not $bundleEntries) {
+            $entries = $archive.Entries | ForEach-Object { $_.FullName }
+            throw "Store upload package must contain a root .appxbundle or .msixbundle because this Store app previously shipped as a bundle. Package '$PackagePath' only contains: $($entries -join ', ')"
+        }
+
+        $looseArchitecturePackages = $rootEntries |
+            Where-Object { [System.IO.Path]::GetExtension($_.FullName) -in '.appx', '.msix' }
+
+        if ($looseArchitecturePackages) {
+            $loosePackageNames = $looseArchitecturePackages | ForEach-Object { $_.FullName }
+            throw "Store upload package contains loose architecture packages instead of a bundle: $($loosePackageNames -join ', ')"
+        }
+
+        Write-Host "Verified Store upload package contains bundle: $($bundleEntries[0].FullName)"
+    }
+    finally {
+        $archive.Dispose()
+    }
+}
+
+function New-BundledStoreUploadPackage {
     param(
         [Parameter(Mandatory = $true)]
         [string]$PackageOutputDirectory,
 
         [Parameter(Mandatory = $true)]
-        [string[]]$Platforms
+        [string[]]$Platforms,
+
+        [Parameter(Mandatory = $true)]
+        [string]$TargetPlatformVersion
     )
 
     Add-Type -AssemblyName System.IO.Compression.FileSystem
@@ -98,11 +208,16 @@ function New-MultiArchitectureUploadPackage {
     }
 
     $uploadStageDirectory = Join-Path $PackageOutputDirectory 'upload-stage'
-    if (Test-Path -LiteralPath $uploadStageDirectory) {
-        Remove-Item -LiteralPath $uploadStageDirectory -Recurse -Force
-    }
+    $bundleInputDirectory = Join-Path $PackageOutputDirectory 'bundle-input'
+    $combinedUploadStageDirectory = Join-Path $PackageOutputDirectory 'combined-upload-stage'
 
-    New-Item -ItemType Directory -Path $uploadStageDirectory -Force | Out-Null
+    foreach ($stageDirectory in @($uploadStageDirectory, $bundleInputDirectory, $combinedUploadStageDirectory)) {
+        if (Test-Path -LiteralPath $stageDirectory) {
+            Remove-Item -LiteralPath $stageDirectory -Recurse -Force
+        }
+
+        New-Item -ItemType Directory -Path $stageDirectory -Force | Out-Null
+    }
 
     foreach ($singleArchitectureUpload in $singleArchitectureUploads) {
         $archive = [System.IO.Compression.ZipFile]::OpenRead($singleArchitectureUpload.FullName)
@@ -138,21 +253,69 @@ function New-MultiArchitectureUploadPackage {
         throw "Expected architecture packages for $expected, but only staged: $($actual -join ', ')"
     }
 
+    foreach ($architecturePackage in $architecturePackages) {
+        Copy-Item -LiteralPath $architecturePackage.FullName -Destination $bundleInputDirectory -Force
+    }
+
     $firstPackageName = $architecturePackages[0].BaseName
     $packagePrefix = $firstPackageName -replace '_(x86|x64|arm|arm64)$', ''
     $platformLabel = ($Platforms | ForEach-Object { $_.Trim() }) -join '_'
     $uploadExtension = $singleArchitectureUploads[0].Extension
-    $combinedUploadPath = Join-Path $PackageOutputDirectory "$packagePrefix`_$platformLabel$uploadExtension"
+    $combinedBundlePath = Join-Path $PackageOutputDirectory "$packagePrefix`_$platformLabel.msixbundle"
+    $combinedUploadPath = Join-Path $PackageOutputDirectory "$packagePrefix`_$platformLabel`_bundle$uploadExtension"
 
-    if (Test-Path -LiteralPath $combinedUploadPath) {
-        Remove-Item -LiteralPath $combinedUploadPath -Force
+    foreach ($outputPath in @($combinedBundlePath, $combinedUploadPath)) {
+        if (Test-Path -LiteralPath $outputPath) {
+            Remove-Item -LiteralPath $outputPath -Force
+        }
     }
 
-    [System.IO.Compression.ZipFile]::CreateFromDirectory($uploadStageDirectory, $combinedUploadPath)
+    $bundleVersion = Get-PackageIdentityVersion -PackagePath $architecturePackages[0].FullName
+    $makeAppxPath = Get-MakeAppxPath -TargetPlatformVersion $TargetPlatformVersion
+    $makeAppxArguments = @(
+        'bundle'
+        '/d'
+        $bundleInputDirectory
+        '/p'
+        $combinedBundlePath
+        '/o'
+        '/bv'
+        $bundleVersion
+    )
+
+    Write-Host "Creating Store app bundle with $makeAppxPath."
+    & $makeAppxPath @makeAppxArguments
+    if ($LASTEXITCODE -ne 0) {
+        throw 'makeappx bundle failed.'
+    }
+
+    Copy-Item -LiteralPath $combinedBundlePath -Destination $combinedUploadStageDirectory -Force
+
+    $symbolPackages = Get-ChildItem -Path $uploadStageDirectory -File |
+        Where-Object { $_.Extension -eq '.appxsym' } |
+        Sort-Object Name
+
+    foreach ($symbolPackage in $symbolPackages) {
+        Copy-Item -LiteralPath $symbolPackage.FullName -Destination $combinedUploadStageDirectory -Force
+    }
+
+    [System.IO.Compression.ZipFile]::CreateFromDirectory($combinedUploadStageDirectory, $combinedUploadPath)
+
+    if (Test-Path -LiteralPath $combinedBundlePath) {
+        Remove-Item -LiteralPath $combinedBundlePath -Force
+    }
 
     foreach ($singleArchitectureUpload in $singleArchitectureUploads) {
         Remove-Item -LiteralPath $singleArchitectureUpload.FullName -Force
     }
+
+    foreach ($stageDirectory in @($uploadStageDirectory, $bundleInputDirectory, $combinedUploadStageDirectory)) {
+        if (Test-Path -LiteralPath $stageDirectory) {
+            Remove-Item -LiteralPath $stageDirectory -Recurse -Force
+        }
+    }
+
+    Assert-StoreUploadPackageContainsBundle -PackagePath $combinedUploadPath
 
     return Get-Item -LiteralPath $combinedUploadPath
 }
@@ -279,10 +442,8 @@ try {
         Invoke-StoreUploadBuild @buildParameters
     }
 
-    if ($platforms.Count -gt 1) {
-        Write-Host "Creating multi-architecture Store upload package for $($platforms -join ', ')."
-        $null = New-MultiArchitectureUploadPackage -PackageOutputDirectory $resolvedOutputDirectory -Platforms $platforms
-    }
+    Write-Host "Creating bundled Store upload package for $($platforms -join ', ')."
+    $null = New-BundledStoreUploadPackage -PackageOutputDirectory $resolvedOutputDirectory -Platforms $platforms -TargetPlatformVersion $TargetPlatformVersion
 
     $uploadPackages = Get-WindowsPackageUploadFiles -Path $resolvedOutputDirectory
 
@@ -290,9 +451,13 @@ try {
         throw "No .appxupload or .msixupload file was created under $resolvedOutputDirectory."
     }
 
-    if ($platforms.Count -gt 1 -and $uploadPackages.Count -ne 1) {
+    if ($uploadPackages.Count -ne 1) {
         $actual = $uploadPackages | ForEach-Object { $_.Name }
-        throw "Expected exactly one combined Store upload package, but found: $($actual -join ', ')"
+        throw "Expected exactly one bundled Store upload package, but found: $($actual -join ', ')"
+    }
+
+    foreach ($uploadPackage in $uploadPackages) {
+        Assert-StoreUploadPackageContainsBundle -PackagePath $uploadPackage.FullName
     }
 
     Write-Host 'Created Store upload packages:'

--- a/eng/Normalize-JitHubStoreSubmissionDeviceFamilies.ps1
+++ b/eng/Normalize-JitHubStoreSubmissionDeviceFamilies.ps1
@@ -1,0 +1,136 @@
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$ProductId,
+
+    [Parameter(Mandatory = $true)]
+    [string]$TenantId,
+
+    [Parameter(Mandatory = $true)]
+    [string]$ClientId,
+
+    [Parameter(Mandatory = $true)]
+    [string]$ClientSecret
+)
+
+$ErrorActionPreference = 'Stop'
+
+function Test-RequiredValue {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Name,
+
+        [string]$Value
+    )
+
+    if ([string]::IsNullOrWhiteSpace($Value)) {
+        throw "$Name is required."
+    }
+}
+
+function Invoke-DevCenterJson {
+    param(
+        [Parameter(Mandatory = $true)]
+        [ValidateSet('GET', 'POST', 'PUT')]
+        [string]$Method,
+
+        [Parameter(Mandatory = $true)]
+        [string]$Path,
+
+        [object]$Body,
+
+        [Parameter(Mandatory = $true)]
+        [hashtable]$Headers
+    )
+
+    $uri = "https://manage.devcenter.microsoft.com$Path"
+    $parameters = @{
+        Method = $Method
+        Uri = $uri
+        Headers = $Headers
+    }
+
+    if ($null -ne $Body) {
+        $parameters.Body = $Body | ConvertTo-Json -Depth 100
+        $parameters.ContentType = 'application/json'
+    }
+
+    try {
+        return Invoke-RestMethod @parameters
+    }
+    catch {
+        $message = $_.Exception.Message
+        $response = $_.Exception.Response
+        if (-not [string]::IsNullOrWhiteSpace($_.ErrorDetails.Message)) {
+            $message = "$message Response: $($_.ErrorDetails.Message)"
+        }
+        elseif ($response -and ($response | Get-Member -Name 'Content' -MemberType Property) -and $response.Content) {
+            $responseBody = $response.Content.ReadAsStringAsync().GetAwaiter().GetResult()
+            if (-not [string]::IsNullOrWhiteSpace($responseBody)) {
+                $message = "$message Response: $responseBody"
+            }
+        }
+        elseif ($response -and ($response | Get-Member -Name 'GetResponseStream' -MemberType Method) -and $response.GetResponseStream()) {
+            $reader = [System.IO.StreamReader]::new($response.GetResponseStream())
+            try {
+                $responseBody = $reader.ReadToEnd()
+                if (-not [string]::IsNullOrWhiteSpace($responseBody)) {
+                    $message = "$message Response: $responseBody"
+                }
+            }
+            finally {
+                $reader.Dispose()
+            }
+        }
+
+        throw $message
+    }
+}
+
+Test-RequiredValue -Name 'ProductId' -Value $ProductId
+Test-RequiredValue -Name 'TenantId' -Value $TenantId
+Test-RequiredValue -Name 'ClientId' -Value $ClientId
+Test-RequiredValue -Name 'ClientSecret' -Value $ClientSecret
+
+$tokenResponse = Invoke-RestMethod `
+    -Method Post `
+    -Uri "https://login.microsoftonline.com/$TenantId/oauth2/v2.0/token" `
+    -ContentType 'application/x-www-form-urlencoded' `
+    -Body @{
+        client_id = $ClientId
+        client_secret = $ClientSecret
+        scope = 'https://manage.devcenter.microsoft.com/.default'
+        grant_type = 'client_credentials'
+    }
+
+if ([string]::IsNullOrWhiteSpace($tokenResponse.access_token)) {
+    throw 'Could not retrieve a Dev Center access token.'
+}
+
+$headers = @{
+    Authorization = "Bearer $($tokenResponse.access_token)"
+}
+
+$application = Invoke-DevCenterJson -Method GET -Path "/v1.0/my/applications/$ProductId" -Headers $headers
+$submissionId = $application.PendingApplicationSubmission.Id
+
+if ([string]::IsNullOrWhiteSpace($submissionId)) {
+    throw "No pending Store submission was found for product $ProductId."
+}
+
+$submission = Invoke-DevCenterJson -Method GET -Path "/v1.0/my/applications/$ProductId/submissions/$submissionId" -Headers $headers
+
+$desktopOnlyDeviceFamilies = [ordered]@{
+    Desktop = $true
+    Mobile = $false
+    Holographic = $false
+    Xbox = $false
+    Team = $false
+    Core = $false
+}
+
+$submission | Add-Member -NotePropertyName 'AllowMicrosoftDecideAppAvailabilityToFutureDeviceFamilies' -NotePropertyValue $false -Force
+$submission | Add-Member -NotePropertyName 'AllowTargetFutureDeviceFamilies' -NotePropertyValue $desktopOnlyDeviceFamilies -Force
+
+$null = Invoke-DevCenterJson -Method PUT -Path "/v1.0/my/applications/$ProductId/submissions/$submissionId" -Headers $headers -Body $submission
+
+Write-Host "Normalized Store submission device families to Desktop-only for submission $submissionId."


### PR DESCRIPTION
## Summary

- build a real bundled Store upload package for WinUI releases instead of zipping loose architecture `.msix` files into `.msixupload`
- validate generated Store upload packages so CI fails before upload if the archive does not contain a root `.msixbundle` or `.appxbundle`
- normalize pending public/draft Partner Center submissions to Desktop-only device families before committing, clearing inherited Team/Core availability from the old UWP package lineage

## Root Cause

The Store workflow uploaded `JitHub.WinUI_1.7.0.0_x64_ARM64.msixupload`, but that archive contained loose x64 and ARM64 `.msix` files. Previous Store submissions shipped a Windows bundle, so Partner Center requires subsequent submissions to contain a real `.msixbundle`/`.appxbundle`. Partner Center also retained Team/Core device family availability from the previous Universal package, while the new WinUI package targets Windows.Desktop only.

## Validation

- Parsed the updated PowerShell scripts successfully.
- Ran `eng\Build-JitHubWinUIStorePackage.ps1 -ProjectPath .\JitHub.WinUI\JitHub.WinUI.csproj -OutputDirectory .\artifacts\store-bundle-fix-local -BundlePlatforms 'x64|ARM64' -TargetPlatformVersion '10.0.26100.0'`.
- Verified the generated `.msixupload` contains `JitHub.WinUI_1.6.2.0_x64_ARM64.msixbundle` at the root.
- Extracted the bundle manifest and confirmed it contains x64 and ARM64 application packages targeting `Windows.Desktop`.
