### PR TITLE
[codex] Fix Store device family normalizer

### DIFF
--- a/eng/Normalize-JitHubStoreSubmissionDeviceFamilies.ps1
+++ b/eng/Normalize-JitHubStoreSubmissionDeviceFamilies.ps1
@@ -119,13 +119,15 @@ if ([string]::IsNullOrWhiteSpace($submissionId)) {
 
 $submission = Invoke-DevCenterJson -Method GET -Path "/v1.0/my/applications/$ProductId/submissions/$submissionId" -Headers $headers
 
+# The Dev Center write API only accepts the Windows10DeviceFamily enum values
+# below. Partner Center validation can mention inherited Team/Core availability,
+# but sending those strings back makes the PUT fail before it can replace the
+# inherited availability dictionary.
 $desktopOnlyDeviceFamilies = [ordered]@{
     Desktop = $true
     Mobile = $false
     Holographic = $false
     Xbox = $false
-    Team = $false
-    Core = $false
 }
 
 $submission | Add-Member -NotePropertyName 'AllowMicrosoftDecideAppAvailabilityToFutureDeviceFamilies' -NotePropertyValue $false -Force


### PR DESCRIPTION
## Summary

- stop sending `Team` and `Core` in the Dev Center device-family normalizer
- keep the submission replacement dictionary limited to the writable Windows10DeviceFamily enum keys: `Desktop`, `Mobile`, `Holographic`, and `Xbox`
- leave the normalizer focused on Desktop-only availability for WinUI Store submissions

## Root Cause

Partner Center reports inherited `Team`/`Core` availability in package validation errors, but the Dev Center write API does not accept `Core` as an `AllowTargetFutureDeviceFamilies` dictionary key. The previous normalizer tried to explicitly set `Core = false`, so the PUT failed before it could replace the inherited availability settings.

## Validation

- Parsed `eng\Normalize-JitHubStoreSubmissionDeviceFamilies.ps1` with PowerShell parser.
- Verified the script no longer writes `Team =` or `Core =` device family keys.
