### PR TITLE
fix(packaging): register WinUIEditor activatable classes in MSIX mani…

### DIFF
--- a/JitHub.WinUI/JitHub.WinUI.csproj
+++ b/JitHub.WinUI/JitHub.WinUI.csproj
@@ -115,4 +115,27 @@
     <PublishAot Condition="'$(Configuration)' != 'Debug'">True</PublishAot>
     <SelfContained Condition="'$(Configuration)' != 'Debug'">True</SelfContained>
   </PropertyGroup>
+
+  <!--
+    WinUIEditorCsWinRT.dll (net8.0) and CommunityToolkit DataGrid (net5.0) were not built for AOT
+    or IL trimming. Preserve them entirely so the trimmer/AOT compiler doesn't remove types that
+    WinUI XAML resolves at runtime via XamlTypeInfo.
+  -->
+  <ItemGroup>
+    <TrimmerRootAssembly Include="WinUIEditorCsWinRT" />
+    <TrimmerRootAssembly Include="CommunityToolkit.WinUI.UI.Controls.DataGrid" />
+  </ItemGroup>
+
+  <!--
+    WinUIEdit uses build\native\*.targets which is not imported for managed .NET projects, so the
+    MSIX tooling never auto-generates activatable class entries for WinUIEditor.dll. We add the
+    WinMD reference explicitly so the MSIX tooling generates the required <Extension
+    Category="windows.activatableClass.inProcessServer"> entries. Without these entries, the
+    runtime cannot find WinUIEditor's activation factory and the app crashes at launch with
+    STATUS_STOWED_EXCEPTION (0xC000027B) in Microsoft.UI.Xaml.dll.
+  -->
+  <ItemGroup>
+    <WindowsMetadataReference Include="$(NuGetPackageRoot)\winuiedit\0.0.4-prerelease\lib\uap10.0\WinUIEditor.winmd"
+                              Implementation="WinUIEditor.dll" />
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
…fest

WinUIEdit's targets live in build\native\, which NuGet does not import for managed .NET projects, so the MSIX tooling never generated the required <Extension Category='windows.activatableClass.inProcessServer'> entries for WinUIEditor.dll.

Without those entries the OS cannot locate WinUIEditor's activation factory at runtime, causing a STATUS_STOWED_EXCEPTION (0xC000027B) crash inside Microsoft.UI.Xaml.dll on first launch — exactly the failure seen in the Microsoft Partner Center certification report.

Fix: add an explicit <WindowsMetadataReference> item pointing at the native WinMD from the WinUIEdit NuGet package.  The MSIX tooling's _AddWindowsMetadataReferecesToPackagingOutputs target picks this up and passes it to WinAppSdkGenerateAppxManifest, which harvests all WinRT activatable class IDs (CodeEditorControl, EditorBaseControl, XamlMetaDataProvider) from the WinMD and writes them into the generated AppxManifest.xml.

Also add TrimmerRootAssembly directives for WinUIEditorCsWinRT (net8.0) and CommunityToolkit.WinUI.UI.Controls.DataGrid (net5.0) so the AOT/IL trimmer does not strip types that WinUI resolves dynamically through XamlTypeInfo.