### PR TITLE
[codex] Fix release-mode binding regressions

### DIFF
--- a/JitHub.WinUI.Tests/XamlBindingPatternTests.cs
+++ b/JitHub.WinUI.Tests/XamlBindingPatternTests.cs
@@ -1,0 +1,112 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+using Xunit;
+
+namespace JitHub.WinUI.Tests;
+
+public sealed class XamlBindingPatternTests
+{
+    [Fact]
+    public void CodeBackedTemplatesDoNotUseUntypedPropertyPathBindings()
+    {
+        string winuiRoot = FindWinUIProjectRoot();
+        string viewsRoot = Path.Combine(winuiRoot, "Views");
+        string looseTemplatesRoot = Path.Combine(viewsRoot, "DataTemplates");
+        List<string> violations = [];
+
+        foreach (string path in Directory.EnumerateFiles(viewsRoot, "*.xaml", SearchOption.AllDirectories)
+            .Where(path => !path.StartsWith(looseTemplatesRoot, StringComparison.OrdinalIgnoreCase))
+            .Order())
+        {
+            string relativePath = Path.GetRelativePath(winuiRoot, path);
+            string text = File.ReadAllText(path);
+
+            foreach (Match template in Regex.Matches(
+                text,
+                "<DataTemplate(?<attrs>[^>]*)>(?<body>.*?)</DataTemplate>",
+                RegexOptions.Singleline))
+            {
+                string attrs = template.Groups["attrs"].Value;
+                if (attrs.Contains("x:DataType", StringComparison.Ordinal))
+                {
+                    continue;
+                }
+
+                string body = template.Groups["body"].Value;
+                foreach (Match binding in Regex.Matches(body, "\\{Binding(?<expr>[^}]*)\\}"))
+                {
+                    string expression = binding.Groups["expr"].Value.Trim();
+                    if (IsWholeObjectOrFrameworkBinding(expression))
+                    {
+                        continue;
+                    }
+
+                    int line = GetLineNumber(text, template.Index + body.IndexOf(binding.Value, StringComparison.Ordinal));
+                    violations.Add($"{relativePath}:{line}: {binding.Value}");
+                }
+            }
+        }
+
+        Assert.True(
+            violations.Count == 0,
+            "Untyped property-path bindings in code-backed DataTemplates are trim-fragile in Release; use x:Bind or a whole-object Binding:" +
+            Environment.NewLine +
+            string.Join(Environment.NewLine, violations));
+    }
+
+    [Fact]
+    public void LooseResourceDictionariesDoNotUseXBind()
+    {
+        string winuiRoot = FindWinUIProjectRoot();
+        string dataTemplatesRoot = Path.Combine(winuiRoot, "Views", "DataTemplates");
+
+        List<string> violations = Directory
+            .EnumerateFiles(dataTemplatesRoot, "*.xaml", SearchOption.AllDirectories)
+            .Where(path => File.ReadAllText(path).Contains("{x:Bind", StringComparison.Ordinal))
+            .Select(path => Path.GetRelativePath(winuiRoot, path))
+            .Order()
+            .ToList();
+
+        Assert.True(
+            violations.Count == 0,
+            "Loose ResourceDictionary files should not use x:Bind; use a code-backed control instead:" +
+            Environment.NewLine +
+            string.Join(Environment.NewLine, violations));
+    }
+
+    private static bool IsWholeObjectOrFrameworkBinding(string expression)
+    {
+        if (string.IsNullOrWhiteSpace(expression))
+        {
+            return true;
+        }
+
+        return expression.StartsWith("Mode", StringComparison.Ordinal)
+            || expression.StartsWith("Converter", StringComparison.Ordinal)
+            || expression.Contains("ElementName=", StringComparison.Ordinal)
+            || expression.Contains("RelativeSource=", StringComparison.Ordinal);
+    }
+
+    private static int GetLineNumber(string text, int index)
+        => text[..Math.Max(0, index)].Count(character => character == '\n') + 1;
+
+    private static string FindWinUIProjectRoot()
+    {
+        DirectoryInfo? current = new(AppContext.BaseDirectory);
+        while (current is not null)
+        {
+            string candidate = Path.Combine(current.FullName, "JitHub.WinUI");
+            if (Directory.Exists(candidate))
+            {
+                return candidate;
+            }
+
+            current = current.Parent;
+        }
+
+        throw new DirectoryNotFoundException("Could not locate JitHub.WinUI from the test output directory.");
+    }
+}

--- a/JitHub.WinUI/Converters/Common/ListToShorterListConverter.cs
+++ b/JitHub.WinUI/Converters/Common/ListToShorterListConverter.cs
@@ -14,7 +14,7 @@ namespace JitHub.WinUI.Converters.Common
             var arr = value as IEnumerable<object> ?? Array.Empty<object>();
             int amount = 0;
             _ = int.TryParse(parameter?.ToString(), out amount);
-            return arr.Take(amount);
+            return amount <= 0 ? new List<object>() : arr.Take(amount).ToList();
         }
 
         public object ConvertBack(object value, Type targetType, object parameter, string language)

--- a/JitHub.WinUI/Converters/Issues/ReactionDictionaryToUserNameListConverter.cs
+++ b/JitHub.WinUI/Converters/Issues/ReactionDictionaryToUserNameListConverter.cs
@@ -16,11 +16,11 @@ namespace JitHub.WinUI.Converters.Issues
         {
             if (value is not Dictionary<ReactionType, ICollection<string>> userReactions || parameter is not string reactionName)
             {
-                return Array.Empty<string>();
+                return new List<string>();
             }
 
             var type = reactionName.ToReactionType();
-            return userReactions.GetValueOrDefault(type) ?? Array.Empty<string>();
+            return userReactions.GetValueOrDefault(type)?.ToList() ?? new List<string>();
         }
 
         public object ConvertBack(object value, Type targetType, object parameter, string language)

--- a/JitHub.WinUI/JitHub.WinUI.csproj
+++ b/JitHub.WinUI/JitHub.WinUI.csproj
@@ -114,6 +114,14 @@
     <PublishTrimmed Condition="'$(Configuration)' != 'Debug'">True</PublishTrimmed>
     <PublishAot Condition="'$(Configuration)' != 'Debug'">True</PublishAot>
     <SelfContained Condition="'$(Configuration)' != 'Debug'">True</SelfContained>
+    <GenerateAppInstallerFile>False</GenerateAppInstallerFile>
+    <AppxPackageSigningEnabled>True</AppxPackageSigningEnabled>
+    <PackageCertificateKeyFile>JitHub.WinUI_TemporaryKey.pfx</PackageCertificateKeyFile>
+    <AppxPackageSigningTimestampDigestAlgorithm>SHA256</AppxPackageSigningTimestampDigestAlgorithm>
+    <AppxAutoIncrementPackageRevision>False</AppxAutoIncrementPackageRevision>
+    <GenerateTestArtifacts>False</GenerateTestArtifacts>
+    <AppxBundle>Never</AppxBundle>
+    <HoursBetweenUpdateChecks>0</HoursBetweenUpdateChecks>
   </PropertyGroup>
 
   <!--
@@ -135,7 +143,6 @@
     STATUS_STOWED_EXCEPTION (0xC000027B) in Microsoft.UI.Xaml.dll.
   -->
   <ItemGroup>
-    <WindowsMetadataReference Include="$(NuGetPackageRoot)\winuiedit\0.0.4-prerelease\lib\uap10.0\WinUIEditor.winmd"
-                              Implementation="WinUIEditor.dll" />
+    <WindowsMetadataReference Include="$(NuGetPackageRoot)\winuiedit\0.0.4-prerelease\lib\uap10.0\WinUIEditor.winmd" Implementation="WinUIEditor.dll" />
   </ItemGroup>
 </Project>

--- a/JitHub.WinUI/JitHub.WinUI.csproj
+++ b/JitHub.WinUI/JitHub.WinUI.csproj
@@ -114,14 +114,6 @@
     <PublishTrimmed Condition="'$(Configuration)' != 'Debug'">True</PublishTrimmed>
     <PublishAot Condition="'$(Configuration)' != 'Debug'">True</PublishAot>
     <SelfContained Condition="'$(Configuration)' != 'Debug'">True</SelfContained>
-    <GenerateAppInstallerFile>False</GenerateAppInstallerFile>
-    <AppxPackageSigningEnabled>True</AppxPackageSigningEnabled>
-    <PackageCertificateKeyFile>JitHub.WinUI_TemporaryKey.pfx</PackageCertificateKeyFile>
-    <AppxPackageSigningTimestampDigestAlgorithm>SHA256</AppxPackageSigningTimestampDigestAlgorithm>
-    <AppxAutoIncrementPackageRevision>False</AppxAutoIncrementPackageRevision>
-    <GenerateTestArtifacts>False</GenerateTestArtifacts>
-    <AppxBundle>Never</AppxBundle>
-    <HoursBetweenUpdateChecks>0</HoursBetweenUpdateChecks>
   </PropertyGroup>
 
   <!--
@@ -143,6 +135,7 @@
     STATUS_STOWED_EXCEPTION (0xC000027B) in Microsoft.UI.Xaml.dll.
   -->
   <ItemGroup>
-    <WindowsMetadataReference Include="$(NuGetPackageRoot)\winuiedit\0.0.4-prerelease\lib\uap10.0\WinUIEditor.winmd" Implementation="WinUIEditor.dll" />
+    <WindowsMetadataReference Include="$(NuGetPackageRoot)\winuiedit\0.0.4-prerelease\lib\uap10.0\WinUIEditor.winmd"
+                              Implementation="WinUIEditor.dll" />
   </ItemGroup>
 </Project>

--- a/JitHub.WinUI/Models/Activities/ActivityModels.cs
+++ b/JitHub.WinUI/Models/Activities/ActivityModels.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Windows.Input;
 using JitHub.Models.GitHub;
@@ -24,7 +25,8 @@ public enum ActivityCardTone
     Purple
 }
 
-public sealed class ActivityNavigationTarget
+[WinRT.GeneratedBindableCustomProperty]
+public sealed partial class ActivityNavigationTarget
 {
     public ActivityNavigationTargetKind Kind { get; set; }
 
@@ -43,7 +45,8 @@ public sealed class ActivityNavigationTarget
     public GitHubRepository? Repository { get; set; }
 }
 
-public sealed class ActivityCardActionViewModel
+[WinRT.GeneratedBindableCustomProperty]
+public sealed partial class ActivityCardActionViewModel
 {
     public string Label { get; set; } = string.Empty;
 
@@ -54,7 +57,8 @@ public sealed class ActivityCardActionViewModel
     public ICommand? Command { get; set; }
 }
 
-public sealed class ActivityCardDetailViewModel
+[WinRT.GeneratedBindableCustomProperty]
+public sealed partial class ActivityCardDetailViewModel
 {
     public string Text { get; set; } = string.Empty;
 
@@ -63,7 +67,8 @@ public sealed class ActivityCardDetailViewModel
     public bool IsEmphasized { get; set; }
 }
 
-public sealed class ActivitySentencePartViewModel
+[WinRT.GeneratedBindableCustomProperty]
+public sealed partial class ActivitySentencePartViewModel
 {
     public string Text { get; set; } = string.Empty;
 
@@ -80,7 +85,8 @@ public sealed class ActivitySentencePartViewModel
         && Command is not null;
 }
 
-public sealed class ActivityCardViewModel
+[WinRT.GeneratedBindableCustomProperty]
+public sealed partial class ActivityCardViewModel
 {
     public string EventId { get; set; } = string.Empty;
 
@@ -102,13 +108,13 @@ public sealed class ActivityCardViewModel
 
     public ActivityCardTone Tone { get; set; }
 
-    public IReadOnlyList<ActivitySentencePartViewModel> SentenceParts { get; set; } = [];
+    public List<ActivitySentencePartViewModel> SentenceParts { get; set; } = [];
 
-    public IReadOnlyList<ActivityCardDetailViewModel> Details { get; set; } = [];
+    public List<ActivityCardDetailViewModel> Details { get; set; } = [];
 
-    public IReadOnlyList<ActivityCardActionViewModel> Actions { get; set; } = [];
+    public List<ActivityCardActionViewModel> Actions { get; set; } = [];
 
-    public IReadOnlyList<ActivityNavigationTarget> UnsupportedTodos { get; set; } = [];
+    public List<ActivityNavigationTarget> UnsupportedTodos { get; set; } = [];
 
     public bool HasDetails => Details.Count > 0;
 

--- a/JitHub.WinUI/Models/Base/RepoSelectableItemModel.cs
+++ b/JitHub.WinUI/Models/Base/RepoSelectableItemModel.cs
@@ -4,7 +4,8 @@ using JitHub.Models.LegacyGitHub;
 
 namespace JitHub.Models.Base
 {
-    public class RepoSelectableItemModel<T> : ObservableObject
+    [WinRT.GeneratedBindableCustomProperty]
+    public partial class RepoSelectableItemModel<T> : ObservableObject
     {
         private T _model = default!;
         private Repository _repo = null!;

--- a/JitHub.WinUI/Models/Base/SelectableItem.cs
+++ b/JitHub.WinUI/Models/Base/SelectableItem.cs
@@ -1,9 +1,10 @@
-﻿using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.ComponentModel;
 using System.Windows.Input;
 
 namespace JitHub.Models.Base
 {
-    public class SelectableItem : ObservableObject
+    [WinRT.GeneratedBindableCustomProperty]
+    public partial class SelectableItem : ObservableObject
     {
         private bool _selected;
         private bool _selectable = true;

--- a/JitHub.WinUI/Models/CodeViewer/RepoFileBlob.cs
+++ b/JitHub.WinUI/Models/CodeViewer/RepoFileBlob.cs
@@ -1,6 +1,7 @@
 namespace JitHub.Models.CodeViewer;
 
-public sealed class RepoFileBlob
+[WinRT.GeneratedBindableCustomProperty]
+public sealed partial class RepoFileBlob
 {
     public string? Sha { get; init; }
     public string? Encoding { get; init; }

--- a/JitHub.WinUI/Models/CodeViewer/RepoFileCacheEntry.cs
+++ b/JitHub.WinUI/Models/CodeViewer/RepoFileCacheEntry.cs
@@ -2,7 +2,8 @@ using System;
 
 namespace JitHub.Models.CodeViewer;
 
-public sealed class RepoFileCacheEntry
+[WinRT.GeneratedBindableCustomProperty]
+public sealed partial class RepoFileCacheEntry
 {
     public required string Sha { get; init; }
     public required long ByteLength { get; init; }

--- a/JitHub.WinUI/Models/CodeViewer/RepoTree.cs
+++ b/JitHub.WinUI/Models/CodeViewer/RepoTree.cs
@@ -1,6 +1,7 @@
 namespace JitHub.Models.CodeViewer;
 
-public sealed class RepoTree
+[WinRT.GeneratedBindableCustomProperty]
+public sealed partial class RepoTree
 {
     public string? Sha { get; init; }
     public bool Truncated { get; init; }

--- a/JitHub.WinUI/Models/CodeViewer/RepoTreeNode.cs
+++ b/JitHub.WinUI/Models/CodeViewer/RepoTreeNode.cs
@@ -2,7 +2,8 @@ using System.Collections.Generic;
 
 namespace JitHub.Models.CodeViewer;
 
-public sealed class RepoTreeNode
+[WinRT.GeneratedBindableCustomProperty]
+public sealed partial class RepoTreeNode
 {
     public string Name { get; init; } = string.Empty;
     public string Path { get; init; } = string.Empty;

--- a/JitHub.WinUI/Models/CommandableCommit.cs
+++ b/JitHub.WinUI/Models/CommandableCommit.cs
@@ -7,7 +7,8 @@ using System.Windows.Input;
 
 namespace JitHub.Models
 {
-    public class CommandableCommit : RepoSelectableItemModel<Commit>
+    [WinRT.GeneratedBindableCustomProperty]
+    public partial class CommandableCommit : RepoSelectableItemModel<Commit>
     {
         private ICommand _copy = null!;
         private ICommand _viewCode = null!;

--- a/JitHub.WinUI/Models/CreditPersonale.cs
+++ b/JitHub.WinUI/Models/CreditPersonale.cs
@@ -1,22 +1,23 @@
 using System;
-using System.Collections;
 using System.Collections.Generic;
+using System.Linq;
 using Windows.UI;
 using Microsoft.UI.Xaml.Media;
 using Microsoft.UI.Xaml.Media.Imaging;
 
 namespace JitHub.Models
 {
-    public class CreditPersonale
+    [WinRT.GeneratedBindableCustomProperty]
+    public partial class CreditPersonale
     {
-        public ImageSource ImageSource { get; set; }
-        public ICollection<PersonalLink> Links { get; set; }
-        public string PersonaleName { get; set; }
-        public string Role { get; set; }
-        public string Description { get; set; }
-        public Brush BackgroundBrush { get; set; }
+        public ImageSource ImageSource { get; set; } = new BitmapImage(new Uri("ms-appx:///Assets/Octocat.png"));
+        public List<PersonalLink> Links { get; set; } = new();
+        public string PersonaleName { get; set; } = string.Empty;
+        public string Role { get; set; } = string.Empty;
+        public string Description { get; set; } = string.Empty;
+        public Brush BackgroundBrush { get; set; } = new SolidColorBrush(Microsoft.UI.Colors.Transparent);
 
-        public CreditPersonale(string url, string name, string role, string description, Color color, ICollection<PersonalLink> links)
+        public CreditPersonale(string url, string name, string role, string description, Color color, IEnumerable<PersonalLink> links)
         {
             try
             {
@@ -30,18 +31,19 @@ namespace JitHub.Models
             Role = role;
             Description = description;
             BackgroundBrush = new SolidColorBrush(color);
-            Links = links;
+            Links = links.ToList();
         }
     }
 
-    public class PersonalLink
+    [WinRT.GeneratedBindableCustomProperty]
+    public partial class PersonalLink
     {
-        public string Link { get; set; }
-        public ImageSource LogoSource { get; set; }
-        public static string LinkedInLogo = "ms-appx:///Assets/LinkLogos/LinkedIn.png";
-        public static string TwitterLogo = "ms-appx:///Assets/LinkLogos/Twitter.png";
-        public static string GitHubLogo = "ms-appx:///Assets/LinkLogos/GitHub.png";
-        public static string GoogleScholarLogo = "ms-appx:///Assets/LinkLogos/GoogleScholar.png";
+        public string Link { get; set; } = string.Empty;
+        public ImageSource LogoSource { get; set; } = new BitmapImage(new Uri("ms-appx:///Assets/Octocat.png"));
+        public const string LinkedInLogo = "ms-appx:///Assets/LinkLogos/LinkedIn.png";
+        public const string TwitterLogo = "ms-appx:///Assets/LinkLogos/Twitter.png";
+        public const string GitHubLogo = "ms-appx:///Assets/LinkLogos/GitHub.png";
+        public const string GoogleScholarLogo = "ms-appx:///Assets/LinkLogos/GoogleScholar.png";
 
         public PersonalLink(string link, string logoPath)
         {

--- a/JitHub.WinUI/Models/EventfulCollection.cs
+++ b/JitHub.WinUI/Models/EventfulCollection.cs
@@ -8,7 +8,7 @@ namespace JitHub.Models
     public class EventfulCollection<T>
     {
         public Action<T>? Action;
-        public ICollection<T> Instance { get; set; }
+        public ObservableCollection<T> Instance { get; set; }
 
         public EventfulCollection()
         {

--- a/JitHub.WinUI/Models/FailedRepo.cs
+++ b/JitHub.WinUI/Models/FailedRepo.cs
@@ -1,9 +1,10 @@
-﻿namespace JitHub.Models
+namespace JitHub.Models
 {
-    public class FailedRepo
+    [WinRT.GeneratedBindableCustomProperty]
+    public partial class FailedRepo
     {
         public RepoModel Repo { get; set; }
-        public string Reason { get; set; }
+        public string Reason { get; set; } = string.Empty;
         public FailedRepo(RepoModel repo, string reason)
         {
             Repo = repo;

--- a/JitHub.WinUI/Models/Filter/DateFilter.cs
+++ b/JitHub.WinUI/Models/Filter/DateFilter.cs
@@ -1,8 +1,9 @@
-﻿using System;
+using System;
 
 namespace JitHub.Models.Filter
 {
-    public class DateFilter : FilterUnit
+    [WinRT.GeneratedBindableCustomProperty]
+    public partial class DateFilter : FilterUnit
     {
         private DateTimeOffset _startDate;
         private DateTimeOffset _defaultDate;

--- a/JitHub.WinUI/Models/Filter/DropdownFilter.cs
+++ b/JitHub.WinUI/Models/Filter/DropdownFilter.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
@@ -7,10 +7,11 @@ using System.Threading.Tasks;
 
 namespace JitHub.Models.Filter
 {
-    public class DropdownFilter : FilterUnit
+    [WinRT.GeneratedBindableCustomProperty]
+    public partial class DropdownFilter : FilterUnit
     {
         private bool _editable;
-        private ICollection<Selection> _selections = new ObservableCollection<Selection>();
+        private ObservableCollection<Selection> _selections = new();
         private Selection _selected = null!;
         private Selection _defaultSelection = null!;
         public bool Editable
@@ -18,7 +19,7 @@ namespace JitHub.Models.Filter
             get => _editable;
             set => SetProperty(ref _editable, value);
         }
-        public ICollection<Selection> Selections
+        public ObservableCollection<Selection> Selections
         {
             get => _selections;
             set => SetProperty(ref _selections, value);

--- a/JitHub.WinUI/Models/Filter/FilterUnit.cs
+++ b/JitHub.WinUI/Models/Filter/FilterUnit.cs
@@ -1,4 +1,4 @@
-﻿using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.ComponentModel;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -7,7 +7,8 @@ using System.Threading.Tasks;
 
 namespace JitHub.Models.Filter
 {
-    public abstract class FilterUnit : ObservableObject
+    [WinRT.GeneratedBindableCustomProperty]
+    public abstract partial class FilterUnit : ObservableObject
     {
         private string _name = string.Empty;
         public string Name

--- a/JitHub.WinUI/Models/Filter/Selection.cs
+++ b/JitHub.WinUI/Models/Filter/Selection.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -6,7 +6,8 @@ using System.Threading.Tasks;
 
 namespace JitHub.Models.Filter
 {
-    public class Selection
+    [WinRT.GeneratedBindableCustomProperty]
+    public partial class Selection
     {
         public string DisplayMember { get; set; } = string.Empty;
         public string SelectedValue { get; set; } = string.Empty;

--- a/JitHub.WinUI/Models/Filter/TextFilter.cs
+++ b/JitHub.WinUI/Models/Filter/TextFilter.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -6,7 +6,8 @@ using System.Threading.Tasks;
 
 namespace JitHub.Models.Filter
 {
-    public class TextFilter : FilterUnit
+    [WinRT.GeneratedBindableCustomProperty]
+    public partial class TextFilter : FilterUnit
     {
         private string _text = string.Empty;
         private string _defaultValue = string.Empty;

--- a/JitHub.WinUI/Models/GitHub/GitHubActivityEvent.cs
+++ b/JitHub.WinUI/Models/GitHub/GitHubActivityEvent.cs
@@ -4,7 +4,8 @@ using System.Text.Json.Serialization;
 
 namespace JitHub.Models.GitHub;
 
-public sealed class GitHubActivityEvent
+[WinRT.GeneratedBindableCustomProperty]
+public sealed partial class GitHubActivityEvent
 {
     [JsonPropertyName("id")]
     public string Id { get; set; } = string.Empty;
@@ -300,7 +301,8 @@ public sealed class GitHubActivityEvent
     }
 }
 
-public sealed class GitHubActivityRepository
+[WinRT.GeneratedBindableCustomProperty]
+public sealed partial class GitHubActivityRepository
 {
     [JsonPropertyName("id")]
     public long Id { get; set; }

--- a/JitHub.WinUI/Models/GitHub/GitHubActivityPayloads.cs
+++ b/JitHub.WinUI/Models/GitHub/GitHubActivityPayloads.cs
@@ -9,14 +9,16 @@ public interface IGitHubActivityPayload
 {
 }
 
-public sealed class UnknownActivityPayload : IGitHubActivityPayload
+[WinRT.GeneratedBindableCustomProperty]
+public sealed partial class UnknownActivityPayload : IGitHubActivityPayload
 {
     public string EventType { get; set; } = string.Empty;
 
     public JsonElement RawPayload { get; set; }
 }
 
-public sealed class CommitCommentEventPayload : IGitHubActivityPayload
+[WinRT.GeneratedBindableCustomProperty]
+public sealed partial class CommitCommentEventPayload : IGitHubActivityPayload
 {
     [JsonPropertyName("action")]
     public string? Action { get; set; }
@@ -25,7 +27,8 @@ public sealed class CommitCommentEventPayload : IGitHubActivityPayload
     public GitHubCommitComment? Comment { get; set; }
 }
 
-public sealed class CreateEventPayload : IGitHubActivityPayload
+[WinRT.GeneratedBindableCustomProperty]
+public sealed partial class CreateEventPayload : IGitHubActivityPayload
 {
     [JsonPropertyName("ref")]
     public string? Ref { get; set; }
@@ -46,7 +49,8 @@ public sealed class CreateEventPayload : IGitHubActivityPayload
     public string? PusherType { get; set; }
 }
 
-public sealed class DeleteEventPayload : IGitHubActivityPayload
+[WinRT.GeneratedBindableCustomProperty]
+public sealed partial class DeleteEventPayload : IGitHubActivityPayload
 {
     [JsonPropertyName("ref")]
     public string? Ref { get; set; }
@@ -61,7 +65,8 @@ public sealed class DeleteEventPayload : IGitHubActivityPayload
     public string? PusherType { get; set; }
 }
 
-public sealed class DiscussionEventPayload : IGitHubActivityPayload
+[WinRT.GeneratedBindableCustomProperty]
+public sealed partial class DiscussionEventPayload : IGitHubActivityPayload
 {
     [JsonPropertyName("action")]
     public string? Action { get; set; }
@@ -70,7 +75,8 @@ public sealed class DiscussionEventPayload : IGitHubActivityPayload
     public GitHubActivityDiscussion? Discussion { get; set; }
 }
 
-public sealed class ForkEventPayload : IGitHubActivityPayload
+[WinRT.GeneratedBindableCustomProperty]
+public sealed partial class ForkEventPayload : IGitHubActivityPayload
 {
     [JsonPropertyName("action")]
     public string? Action { get; set; }
@@ -79,13 +85,15 @@ public sealed class ForkEventPayload : IGitHubActivityPayload
     public GitHubRepository? Forkee { get; set; }
 }
 
-public sealed class GollumEventPayload : IGitHubActivityPayload
+[WinRT.GeneratedBindableCustomProperty]
+public sealed partial class GollumEventPayload : IGitHubActivityPayload
 {
     [JsonPropertyName("pages")]
     public GitHubActivityWikiPage[] Pages { get; set; } = [];
 }
 
-public sealed class IssueCommentEventPayload : IGitHubActivityPayload
+[WinRT.GeneratedBindableCustomProperty]
+public sealed partial class IssueCommentEventPayload : IGitHubActivityPayload
 {
     [JsonPropertyName("action")]
     public string? Action { get; set; }
@@ -97,7 +105,8 @@ public sealed class IssueCommentEventPayload : IGitHubActivityPayload
     public GitHubIssueComment? Comment { get; set; }
 }
 
-public sealed class IssuesEventPayload : IGitHubActivityPayload
+[WinRT.GeneratedBindableCustomProperty]
+public sealed partial class IssuesEventPayload : IGitHubActivityPayload
 {
     [JsonPropertyName("action")]
     public string? Action { get; set; }
@@ -118,7 +127,8 @@ public sealed class IssuesEventPayload : IGitHubActivityPayload
     public GitHubLabel[] Labels { get; set; } = [];
 }
 
-public sealed class MemberEventPayload : IGitHubActivityPayload
+[WinRT.GeneratedBindableCustomProperty]
+public sealed partial class MemberEventPayload : IGitHubActivityPayload
 {
     [JsonPropertyName("action")]
     public string? Action { get; set; }
@@ -127,11 +137,13 @@ public sealed class MemberEventPayload : IGitHubActivityPayload
     public GitHubActor? Member { get; set; }
 }
 
-public sealed class PublicEventPayload : IGitHubActivityPayload
+[WinRT.GeneratedBindableCustomProperty]
+public sealed partial class PublicEventPayload : IGitHubActivityPayload
 {
 }
 
-public sealed class PullRequestEventPayload : IGitHubActivityPayload
+[WinRT.GeneratedBindableCustomProperty]
+public sealed partial class PullRequestEventPayload : IGitHubActivityPayload
 {
     [JsonPropertyName("action")]
     public string? Action { get; set; }
@@ -155,7 +167,8 @@ public sealed class PullRequestEventPayload : IGitHubActivityPayload
     public GitHubLabel[] Labels { get; set; } = [];
 }
 
-public sealed class PullRequestReviewEventPayload : IGitHubActivityPayload
+[WinRT.GeneratedBindableCustomProperty]
+public sealed partial class PullRequestReviewEventPayload : IGitHubActivityPayload
 {
     [JsonPropertyName("action")]
     public string? Action { get; set; }
@@ -167,7 +180,8 @@ public sealed class PullRequestReviewEventPayload : IGitHubActivityPayload
     public GitHubPullRequestReview? Review { get; set; }
 }
 
-public sealed class PullRequestReviewCommentEventPayload : IGitHubActivityPayload
+[WinRT.GeneratedBindableCustomProperty]
+public sealed partial class PullRequestReviewCommentEventPayload : IGitHubActivityPayload
 {
     [JsonPropertyName("action")]
     public string? Action { get; set; }
@@ -179,7 +193,8 @@ public sealed class PullRequestReviewCommentEventPayload : IGitHubActivityPayloa
     public GitHubPullRequestReviewComment? Comment { get; set; }
 }
 
-public sealed class PushEventPayload : IGitHubActivityPayload
+[WinRT.GeneratedBindableCustomProperty]
+public sealed partial class PushEventPayload : IGitHubActivityPayload
 {
     [JsonPropertyName("repository_id")]
     public long RepositoryId { get; set; }
@@ -217,7 +232,8 @@ public sealed class PushEventPayload : IGitHubActivityPayload
     private static int? PositiveOrNull(int? value) => value.GetValueOrDefault() > 0 ? value : null;
 }
 
-public sealed class ReleaseEventPayload : IGitHubActivityPayload
+[WinRT.GeneratedBindableCustomProperty]
+public sealed partial class ReleaseEventPayload : IGitHubActivityPayload
 {
     [JsonPropertyName("action")]
     public string? Action { get; set; }
@@ -226,13 +242,15 @@ public sealed class ReleaseEventPayload : IGitHubActivityPayload
     public GitHubActivityRelease? Release { get; set; }
 }
 
-public sealed class WatchEventPayload : IGitHubActivityPayload
+[WinRT.GeneratedBindableCustomProperty]
+public sealed partial class WatchEventPayload : IGitHubActivityPayload
 {
     [JsonPropertyName("action")]
     public string? Action { get; set; }
 }
 
-public sealed class GitHubActivityDiscussion
+[WinRT.GeneratedBindableCustomProperty]
+public sealed partial class GitHubActivityDiscussion
 {
     [JsonPropertyName("number")]
     public int? Number { get; set; }
@@ -244,7 +262,8 @@ public sealed class GitHubActivityDiscussion
     public string? HtmlUrl { get; set; }
 }
 
-public sealed class GitHubActivityWikiPage
+[WinRT.GeneratedBindableCustomProperty]
+public sealed partial class GitHubActivityWikiPage
 {
     [JsonPropertyName("page_name")]
     public string? PageName { get; set; }
@@ -265,7 +284,8 @@ public sealed class GitHubActivityWikiPage
     public string? HtmlUrl { get; set; }
 }
 
-public sealed class GitHubActivityPushCommit
+[WinRT.GeneratedBindableCustomProperty]
+public sealed partial class GitHubActivityPushCommit
 {
     [JsonPropertyName("sha")]
     public string? Sha { get; set; }
@@ -283,7 +303,8 @@ public sealed class GitHubActivityPushCommit
     public GitHubActivityCommitAuthor? Author { get; set; }
 }
 
-public sealed class GitHubActivityCommitAuthor
+[WinRT.GeneratedBindableCustomProperty]
+public sealed partial class GitHubActivityCommitAuthor
 {
     [JsonPropertyName("name")]
     public string? Name { get; set; }
@@ -292,7 +313,8 @@ public sealed class GitHubActivityCommitAuthor
     public string? Email { get; set; }
 }
 
-public sealed class GitHubActivityRelease
+[WinRT.GeneratedBindableCustomProperty]
+public sealed partial class GitHubActivityRelease
 {
     [JsonPropertyName("id")]
     public long Id { get; set; }

--- a/JitHub.WinUI/Models/GitHub/GitHubActor.cs
+++ b/JitHub.WinUI/Models/GitHub/GitHubActor.cs
@@ -2,7 +2,8 @@ using System.Text.Json.Serialization;
 
 namespace JitHub.Models.GitHub;
 
-public sealed class GitHubActor
+[WinRT.GeneratedBindableCustomProperty]
+public sealed partial class GitHubActor
 {
     [JsonPropertyName("id")]
     public long Id { get; set; }

--- a/JitHub.WinUI/Models/GitHub/GitHubBlob.cs
+++ b/JitHub.WinUI/Models/GitHub/GitHubBlob.cs
@@ -2,7 +2,8 @@ using System.Text.Json.Serialization;
 
 namespace JitHub.Models.GitHub;
 
-public sealed class GitHubBlob
+[WinRT.GeneratedBindableCustomProperty]
+public sealed partial class GitHubBlob
 {
     [JsonPropertyName("node_id")]
     public string? NodeId { get; set; }

--- a/JitHub.WinUI/Models/GitHub/GitHubBranch.cs
+++ b/JitHub.WinUI/Models/GitHub/GitHubBranch.cs
@@ -2,7 +2,8 @@ using System.Text.Json.Serialization;
 
 namespace JitHub.Models.GitHub;
 
-public sealed class GitHubBranch
+[WinRT.GeneratedBindableCustomProperty]
+public sealed partial class GitHubBranch
 {
     [JsonPropertyName("name")]
     public string Name { get; set; } = string.Empty;

--- a/JitHub.WinUI/Models/GitHub/GitHubCheckRun.cs
+++ b/JitHub.WinUI/Models/GitHub/GitHubCheckRun.cs
@@ -3,7 +3,8 @@ using System.Text.Json.Serialization;
 
 namespace JitHub.Models.GitHub;
 
-public sealed class GitHubCheckRun
+[WinRT.GeneratedBindableCustomProperty]
+public sealed partial class GitHubCheckRun
 {
     [JsonPropertyName("id")]
     public long Id { get; set; }
@@ -39,7 +40,8 @@ public sealed class GitHubCheckRun
     public GitHubCheckRunApp? App { get; set; }
 }
 
-public sealed class GitHubCheckRunApp
+[WinRT.GeneratedBindableCustomProperty]
+public sealed partial class GitHubCheckRunApp
 {
     [JsonPropertyName("name")]
     public string? Name { get; set; }

--- a/JitHub.WinUI/Models/GitHub/GitHubCommit.cs
+++ b/JitHub.WinUI/Models/GitHub/GitHubCommit.cs
@@ -3,7 +3,8 @@ using System.Text.Json.Serialization;
 
 namespace JitHub.Models.GitHub;
 
-public sealed class GitHubCommit
+[WinRT.GeneratedBindableCustomProperty]
+public sealed partial class GitHubCommit
 {
     [JsonPropertyName("node_id")]
     public string? NodeId { get; set; }
@@ -56,7 +57,8 @@ public sealed class GitHubCommit
     public string ShortSha => Sha[..Math.Min(7, Sha.Length)];
 }
 
-public sealed class GitHubCommitInfo
+[WinRT.GeneratedBindableCustomProperty]
+public sealed partial class GitHubCommitInfo
 {
     [JsonPropertyName("message")]
     public string Message { get; set; } = string.Empty;
@@ -71,7 +73,8 @@ public sealed class GitHubCommitInfo
     public GitHubCommitSignature Committer { get; set; } = new();
 }
 
-public sealed class GitHubCommitSignature
+[WinRT.GeneratedBindableCustomProperty]
+public sealed partial class GitHubCommitSignature
 {
     [JsonPropertyName("name")]
     public string? Name { get; set; }
@@ -83,7 +86,8 @@ public sealed class GitHubCommitSignature
     public DateTimeOffset? Date { get; set; }
 }
 
-public sealed class GitHubCommitStats
+[WinRT.GeneratedBindableCustomProperty]
+public sealed partial class GitHubCommitStats
 {
     [JsonPropertyName("total")]
     public int Total { get; set; }
@@ -98,7 +102,8 @@ public sealed class GitHubCommitStats
     public string SummaryText => $"+{Additions}  -{Deletions}  ({Total} changes)";
 }
 
-public sealed class GitHubCommitFile
+[WinRT.GeneratedBindableCustomProperty]
+public sealed partial class GitHubCommitFile
 {
     [JsonPropertyName("sha")]
     public string? Sha { get; set; }

--- a/JitHub.WinUI/Models/GitHub/GitHubCommitComment.cs
+++ b/JitHub.WinUI/Models/GitHub/GitHubCommitComment.cs
@@ -3,7 +3,8 @@ using System.Text.Json.Serialization;
 
 namespace JitHub.Models.GitHub;
 
-public sealed class GitHubCommitComment
+[WinRT.GeneratedBindableCustomProperty]
+public sealed partial class GitHubCommitComment
 {
     [JsonPropertyName("node_id")]
     public string? NodeId { get; set; }

--- a/JitHub.WinUI/Models/GitHub/GitHubCompareResult.cs
+++ b/JitHub.WinUI/Models/GitHub/GitHubCompareResult.cs
@@ -2,7 +2,8 @@ using System.Text.Json.Serialization;
 
 namespace JitHub.Models.GitHub;
 
-public sealed class GitHubCompareResult
+[WinRT.GeneratedBindableCustomProperty]
+public sealed partial class GitHubCompareResult
 {
     [JsonPropertyName("status")]
     public string? Status { get; set; }

--- a/JitHub.WinUI/Models/GitHub/GitHubIssue.cs
+++ b/JitHub.WinUI/Models/GitHub/GitHubIssue.cs
@@ -3,7 +3,8 @@ using System.Text.Json.Serialization;
 
 namespace JitHub.Models.GitHub;
 
-public sealed class GitHubIssue
+[WinRT.GeneratedBindableCustomProperty]
+public sealed partial class GitHubIssue
 {
     [JsonPropertyName("id")]
     public long Id { get; set; }
@@ -56,13 +57,15 @@ public sealed class GitHubIssue
     public bool IsPullRequest => PullRequest is not null;
 }
 
-public sealed class GitHubIssuePullRequestMarker
+[WinRT.GeneratedBindableCustomProperty]
+public sealed partial class GitHubIssuePullRequestMarker
 {
     [JsonPropertyName("html_url")]
     public string? HtmlUrl { get; set; }
 }
 
-public sealed class GitHubLabel
+[WinRT.GeneratedBindableCustomProperty]
+public sealed partial class GitHubLabel
 {
     [JsonPropertyName("id")]
     public long Id { get; set; }
@@ -77,7 +80,8 @@ public sealed class GitHubLabel
     public string? Description { get; set; }
 }
 
-public sealed class GitHubMilestone
+[WinRT.GeneratedBindableCustomProperty]
+public sealed partial class GitHubMilestone
 {
     [JsonPropertyName("number")]
     public int Number { get; set; }

--- a/JitHub.WinUI/Models/GitHub/GitHubIssueComment.cs
+++ b/JitHub.WinUI/Models/GitHub/GitHubIssueComment.cs
@@ -4,7 +4,8 @@ using JitHub.WinUI.Helpers;
 
 namespace JitHub.Models.GitHub;
 
-public sealed class GitHubIssueComment
+[WinRT.GeneratedBindableCustomProperty]
+public sealed partial class GitHubIssueComment
 {
     [JsonPropertyName("node_id")]
     public string? NodeId { get; set; }

--- a/JitHub.WinUI/Models/GitHub/GitHubIssueEvent.cs
+++ b/JitHub.WinUI/Models/GitHub/GitHubIssueEvent.cs
@@ -4,7 +4,8 @@ using JitHub.WinUI.Helpers;
 
 namespace JitHub.Models.GitHub;
 
-public sealed class GitHubIssueEvent
+[WinRT.GeneratedBindableCustomProperty]
+public sealed partial class GitHubIssueEvent
 {
     [JsonPropertyName("node_id")]
     public string? NodeId { get; set; }
@@ -134,7 +135,8 @@ public sealed class GitHubIssueEvent
     }
 }
 
-public sealed class GitHubIssueEventRequestedTeam
+[WinRT.GeneratedBindableCustomProperty]
+public sealed partial class GitHubIssueEventRequestedTeam
 {
     [JsonPropertyName("name")]
     public string Name { get; set; } = string.Empty;
@@ -143,7 +145,8 @@ public sealed class GitHubIssueEventRequestedTeam
     public string Slug { get; set; } = string.Empty;
 }
 
-public sealed class GitHubIssueEventRename
+[WinRT.GeneratedBindableCustomProperty]
+public sealed partial class GitHubIssueEventRename
 {
     [JsonPropertyName("from")]
     public string From { get; set; } = string.Empty;
@@ -152,7 +155,8 @@ public sealed class GitHubIssueEventRename
     public string To { get; set; } = string.Empty;
 }
 
-public sealed class GitHubIssueEventDismissedReview
+[WinRT.GeneratedBindableCustomProperty]
+public sealed partial class GitHubIssueEventDismissedReview
 {
     [JsonPropertyName("dismissal_message")]
     public string? DismissalMessage { get; set; }

--- a/JitHub.WinUI/Models/GitHub/GitHubPullRequest.cs
+++ b/JitHub.WinUI/Models/GitHub/GitHubPullRequest.cs
@@ -3,7 +3,8 @@ using System.Text.Json.Serialization;
 
 namespace JitHub.Models.GitHub;
 
-public sealed class GitHubPullRequest
+[WinRT.GeneratedBindableCustomProperty]
+public sealed partial class GitHubPullRequest
 {
     [JsonPropertyName("id")]
     public long Id { get; set; }
@@ -57,7 +58,8 @@ public sealed class GitHubPullRequest
     public GitHubActor[] RequestedReviewers { get; set; } = [];
 }
 
-public sealed class GitHubPullRequestBranch
+[WinRT.GeneratedBindableCustomProperty]
+public sealed partial class GitHubPullRequestBranch
 {
     [JsonPropertyName("label")]
     public string Label { get; set; } = string.Empty;

--- a/JitHub.WinUI/Models/GitHub/GitHubPullRequestMergeResult.cs
+++ b/JitHub.WinUI/Models/GitHub/GitHubPullRequestMergeResult.cs
@@ -2,7 +2,8 @@ using System.Text.Json.Serialization;
 
 namespace JitHub.Models.GitHub;
 
-public sealed class GitHubPullRequestMergeResult
+[WinRT.GeneratedBindableCustomProperty]
+public sealed partial class GitHubPullRequestMergeResult
 {
     [JsonPropertyName("sha")]
     public string? Sha { get; set; }

--- a/JitHub.WinUI/Models/GitHub/GitHubPullRequestReview.cs
+++ b/JitHub.WinUI/Models/GitHub/GitHubPullRequestReview.cs
@@ -3,7 +3,8 @@ using System.Text.Json.Serialization;
 
 namespace JitHub.Models.GitHub;
 
-public sealed class GitHubPullRequestReview
+[WinRT.GeneratedBindableCustomProperty]
+public sealed partial class GitHubPullRequestReview
 {
     [JsonPropertyName("node_id")]
     public string? NodeId { get; set; }
@@ -39,7 +40,8 @@ public sealed class GitHubPullRequestReview
     public GitHubReactionSummary Reactions { get; set; } = new();
 }
 
-public sealed class GitHubPullRequestReviewComment
+[WinRT.GeneratedBindableCustomProperty]
+public sealed partial class GitHubPullRequestReviewComment
 {
     [JsonPropertyName("node_id")]
     public string? NodeId { get; set; }

--- a/JitHub.WinUI/Models/GitHub/GitHubQueryOptions.cs
+++ b/JitHub.WinUI/Models/GitHub/GitHubQueryOptions.cs
@@ -2,7 +2,8 @@ using System;
 
 namespace JitHub.Models.GitHub;
 
-public sealed class GitHubIssueQueryOptions
+[WinRT.GeneratedBindableCustomProperty]
+public sealed partial class GitHubIssueQueryOptions
 {
     public string State { get; set; } = "open";
 
@@ -25,7 +26,8 @@ public sealed class GitHubIssueQueryOptions
     public string? Filter { get; set; }
 }
 
-public sealed class GitHubPullRequestQueryOptions
+[WinRT.GeneratedBindableCustomProperty]
+public sealed partial class GitHubPullRequestQueryOptions
 {
     public string State { get; set; } = "open";
 

--- a/JitHub.WinUI/Models/GitHub/GitHubReaction.cs
+++ b/JitHub.WinUI/Models/GitHub/GitHubReaction.cs
@@ -4,7 +4,8 @@ using JitHub.WinUI.Helpers;
 
 namespace JitHub.Models.GitHub;
 
-public sealed class GitHubReaction
+[WinRT.GeneratedBindableCustomProperty]
+public sealed partial class GitHubReaction
 {
     [JsonPropertyName("id")]
     public long Id { get; set; }
@@ -16,7 +17,8 @@ public sealed class GitHubReaction
     public GitHubActor User { get; set; } = new();
 }
 
-public sealed class GitHubReactionSummary
+[WinRT.GeneratedBindableCustomProperty]
+public sealed partial class GitHubReactionSummary
 {
     [JsonPropertyName("total_count")]
     public int TotalCount { get; set; }

--- a/JitHub.WinUI/Models/GitHub/GitHubRepository.cs
+++ b/JitHub.WinUI/Models/GitHub/GitHubRepository.cs
@@ -3,7 +3,8 @@ using System.Text.Json.Serialization;
 
 namespace JitHub.Models.GitHub;
 
-public sealed class GitHubRepository
+[WinRT.GeneratedBindableCustomProperty]
+public sealed partial class GitHubRepository
 {
     [JsonPropertyName("id")]
     public long Id { get; set; }
@@ -51,7 +52,8 @@ public sealed class GitHubRepository
     public GitHubRepositoryOwner Owner { get; set; } = new();
 }
 
-public sealed class GitHubRepositoryOwner
+[WinRT.GeneratedBindableCustomProperty]
+public sealed partial class GitHubRepositoryOwner
 {
     [JsonPropertyName("login")]
     public string Login { get; set; } = string.Empty;

--- a/JitHub.WinUI/Models/GitHub/GitHubRepositoryContent.cs
+++ b/JitHub.WinUI/Models/GitHub/GitHubRepositoryContent.cs
@@ -2,7 +2,8 @@ using System.Text.Json.Serialization;
 
 namespace JitHub.Models.GitHub;
 
-public sealed class GitHubRepositoryContent
+[WinRT.GeneratedBindableCustomProperty]
+public sealed partial class GitHubRepositoryContent
 {
     [JsonPropertyName("type")]
     public string Type { get; set; } = string.Empty;

--- a/JitHub.WinUI/Models/GitHub/GitHubRepositoryCreateOptions.cs
+++ b/JitHub.WinUI/Models/GitHub/GitHubRepositoryCreateOptions.cs
@@ -1,6 +1,7 @@
 namespace JitHub.Models.GitHub;
 
-public sealed class GitHubRepositoryCreateOptions
+[WinRT.GeneratedBindableCustomProperty]
+public sealed partial class GitHubRepositoryCreateOptions
 {
     public string Name { get; set; } = string.Empty;
 

--- a/JitHub.WinUI/Models/GitHub/GitHubRepositorySearchResponse.cs
+++ b/JitHub.WinUI/Models/GitHub/GitHubRepositorySearchResponse.cs
@@ -2,7 +2,8 @@ using System.Text.Json.Serialization;
 
 namespace JitHub.Models.GitHub;
 
-public sealed class GitHubRepositorySearchResponse
+[WinRT.GeneratedBindableCustomProperty]
+public sealed partial class GitHubRepositorySearchResponse
 {
     [JsonPropertyName("items")]
     public GitHubRepository[] Items { get; init; } = [];

--- a/JitHub.WinUI/Models/GitHub/GitHubRepositorySelectionItem.cs
+++ b/JitHub.WinUI/Models/GitHub/GitHubRepositorySelectionItem.cs
@@ -2,7 +2,8 @@ using CommunityToolkit.Mvvm.ComponentModel;
 
 namespace JitHub.Models.GitHub;
 
-public class GitHubRepositorySelectionItem : ObservableObject
+[WinRT.GeneratedBindableCustomProperty]
+public partial class GitHubRepositorySelectionItem : ObservableObject
 {
     private bool _selected;
 

--- a/JitHub.WinUI/Models/GitHub/GitHubRepositorySubscription.cs
+++ b/JitHub.WinUI/Models/GitHub/GitHubRepositorySubscription.cs
@@ -2,7 +2,8 @@ using System.Text.Json.Serialization;
 
 namespace JitHub.Models.GitHub;
 
-public sealed class GitHubRepositorySubscription
+[WinRT.GeneratedBindableCustomProperty]
+public sealed partial class GitHubRepositorySubscription
 {
     [JsonPropertyName("subscribed")]
     public bool Subscribed { get; set; }

--- a/JitHub.WinUI/Models/GitHub/GitHubTree.cs
+++ b/JitHub.WinUI/Models/GitHub/GitHubTree.cs
@@ -2,7 +2,8 @@ using System.Text.Json.Serialization;
 
 namespace JitHub.Models.GitHub;
 
-public sealed class GitHubTree
+[WinRT.GeneratedBindableCustomProperty]
+public sealed partial class GitHubTree
 {
     [JsonPropertyName("sha")]
     public string? Sha { get; init; }

--- a/JitHub.WinUI/Models/GitHub/GitHubTreeEntry.cs
+++ b/JitHub.WinUI/Models/GitHub/GitHubTreeEntry.cs
@@ -2,7 +2,8 @@ using System.Text.Json.Serialization;
 
 namespace JitHub.Models.GitHub;
 
-public sealed class GitHubTreeEntry
+[WinRT.GeneratedBindableCustomProperty]
+public sealed partial class GitHubTreeEntry
 {
     [JsonPropertyName("path")]
     public string? Path { get; init; }

--- a/JitHub.WinUI/Models/GitHub/GitHubUser.cs
+++ b/JitHub.WinUI/Models/GitHub/GitHubUser.cs
@@ -2,7 +2,8 @@ using System.Text.Json.Serialization;
 
 namespace JitHub.Models.GitHub;
 
-public sealed class GitHubUser
+[WinRT.GeneratedBindableCustomProperty]
+public sealed partial class GitHubUser
 {
     [JsonPropertyName("id")]
     public long Id { get; init; }

--- a/JitHub.WinUI/Models/IssueSidePanelItem.cs
+++ b/JitHub.WinUI/Models/IssueSidePanelItem.cs
@@ -1,18 +1,20 @@
-﻿using JitHub.Models.Base;
+using JitHub.Models.Base;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace JitHub.Models
 {
-    public class IssueSidePanelItem
+    [WinRT.GeneratedBindableCustomProperty]
+    public partial class IssueSidePanelItem
     {
         public string Header { get; }
-        public ICollection<SelectableItem> Items { get; }
+        public List<SelectableItem> Items { get; }
         public bool Show { get; }
 
-        public IssueSidePanelItem(string header, ICollection<SelectableItem> items)
+        public IssueSidePanelItem(string header, IEnumerable<SelectableItem> items)
         {
             Header = header;
-            Items = items ?? [];
+            Items = items?.ToList() ?? new List<SelectableItem>();
             Show = Items.Count > 0;
         }
     }

--- a/JitHub.WinUI/Models/LegacyGitHub/LegacyGitHubModels.cs
+++ b/JitHub.WinUI/Models/LegacyGitHub/LegacyGitHubModels.cs
@@ -84,16 +84,16 @@ internal static class CompatValueReader
         return index < values.Length ? values[index] as T : null;
     }
 
-    public static IReadOnlyList<T> ListAt<T>(object?[] values, int index)
+    public static List<T> ListAt<T>(object?[] values, int index)
     {
         if (index >= values.Length || values[index] is null)
         {
-            return Array.Empty<T>();
+            return [];
         }
 
         if (values[index] is IReadOnlyList<T> typedReadOnlyList)
         {
-            return typedReadOnlyList;
+            return typedReadOnlyList.ToList();
         }
 
         if (values[index] is ICollection<T> typedCollection)
@@ -106,7 +106,7 @@ internal static class CompatValueReader
             return typedEnumerable.ToList();
         }
 
-        return Array.Empty<T>();
+        return [];
     }
 
     public static StringEnum<TEnum> StringEnumAt<TEnum>(object?[] values, int index)
@@ -467,7 +467,8 @@ public enum StarredSort
     Updated
 }
 
-public sealed class Team
+[WinRT.GeneratedBindableCustomProperty]
+public sealed partial class Team
 {
     public string Name { get; set; } = string.Empty;
 
@@ -478,11 +479,13 @@ public sealed class CollaboratorPermissions
 {
 }
 
-public sealed class ActivityPayload
+[WinRT.GeneratedBindableCustomProperty]
+public sealed partial class ActivityPayload
 {
 }
 
-public sealed class RenameInfo
+[WinRT.GeneratedBindableCustomProperty]
+public sealed partial class RenameInfo
 {
     public RenameInfo()
     {
@@ -499,14 +502,16 @@ public sealed class RenameInfo
     public string To { get; set; } = string.Empty;
 }
 
-public class Account
+[WinRT.GeneratedBindableCustomProperty]
+public partial class Account
 {
     public Account()
     {
     }
 }
 
-public class User : Account
+[WinRT.GeneratedBindableCustomProperty]
+public partial class User : Account
 {
     public User()
     : this([])
@@ -624,7 +629,8 @@ public class Collaborator : User
     public string Type { get; set; } = string.Empty;
 }
 
-public class RepositoryContributor : User
+[WinRT.GeneratedBindableCustomProperty]
+public partial class RepositoryContributor : User
 {
     public RepositoryContributor()
     : this([])
@@ -637,7 +643,8 @@ public class RepositoryContributor : User
     }
 }
 
-public class Reaction
+[WinRT.GeneratedBindableCustomProperty]
+public partial class Reaction
 {
     public Reaction()
     : this([])
@@ -658,7 +665,8 @@ public class Reaction
     public StringEnum<ReactionType> Content { get; set; } = new();
 }
 
-public class ReactionSummary
+[WinRT.GeneratedBindableCustomProperty]
+public partial class ReactionSummary
 {
     public ReactionSummary()
     : this([])
@@ -691,7 +699,8 @@ public class ReactionSummary
     public string Url { get; set; } = string.Empty;
 }
 
-public class Label
+[WinRT.GeneratedBindableCustomProperty]
+public partial class Label
 {
     public Label()
     : this([])
@@ -718,7 +727,8 @@ public class Label
     public bool Default { get; set; }
 }
 
-public class Milestone
+[WinRT.GeneratedBindableCustomProperty]
+public partial class Milestone
 {
     public Milestone()
     : this([])
@@ -761,7 +771,8 @@ public class Milestone
     public DateTimeOffset? UpdatedAt { get; set; }
 }
 
-public class GitReference
+[WinRT.GeneratedBindableCustomProperty]
+public partial class GitReference
 {
     public GitReference()
     : this([])
@@ -788,7 +799,8 @@ public class GitReference
     public Repository Repository { get; set; } = new();
 }
 
-public class Branch
+[WinRT.GeneratedBindableCustomProperty]
+public partial class Branch
 {
     public Branch()
     : this([])
@@ -807,7 +819,8 @@ public class Branch
     public bool Protected { get; set; }
 }
 
-public class Blob
+[WinRT.GeneratedBindableCustomProperty]
+public partial class Blob
 {
     public Blob()
     : this([])
@@ -830,7 +843,8 @@ public class Blob
     public int Size { get; set; }
 }
 
-public class Repository
+[WinRT.GeneratedBindableCustomProperty]
+public partial class Repository
 {
     public Repository()
     : this([])
@@ -896,10 +910,11 @@ public class Repository
     public int WatchersCount { get; set; }
     public int SubscribersCount { get; set; }
     public RepositoryVisibility Visibility { get; set; }
-    public IReadOnlyList<string> Topics { get; set; } = Array.Empty<string>();
+    public List<string> Topics { get; set; } = [];
 }
 
-public class PullRequest
+[WinRT.GeneratedBindableCustomProperty]
+public partial class PullRequest
 {
     public PullRequest()
     : this([])
@@ -974,7 +989,7 @@ public class PullRequest
     public GitReference Base { get; set; } = new();
     public User User { get; set; } = new();
     public User? Assignee { get; set; }
-    public IReadOnlyList<User> Assignees { get; set; } = Array.Empty<User>();
+    public List<User> Assignees { get; set; } = [];
     public bool Draft { get; set; }
     public bool? Mergeable { get; set; }
     public StringEnum<MergeableState> MergeableState { get; set; } = new();
@@ -988,13 +1003,14 @@ public class PullRequest
     public Milestone? Milestone { get; set; }
     public bool Locked { get; set; }
     public User? ClosedBy { get; set; }
-    public IReadOnlyList<User> RequestedReviewers { get; set; } = Array.Empty<User>();
-    public IReadOnlyList<Team> RequestedTeams { get; set; } = Array.Empty<Team>();
-    public IReadOnlyList<Label> Labels { get; set; } = Array.Empty<Label>();
+    public List<User> RequestedReviewers { get; set; } = [];
+    public List<Team> RequestedTeams { get; set; } = [];
+    public List<Label> Labels { get; set; } = [];
     public ReactionSummary Reactions { get; set; } = new();
 }
 
-public class PullRequestMerge
+[WinRT.GeneratedBindableCustomProperty]
+public partial class PullRequestMerge
 {
     public PullRequestMerge()
     : this([])
@@ -1013,7 +1029,8 @@ public class PullRequestMerge
     public string Message { get; set; } = string.Empty;
 }
 
-public class Issue
+[WinRT.GeneratedBindableCustomProperty]
+public partial class Issue
 {
     public Issue()
     : this([])
@@ -1060,9 +1077,9 @@ public class Issue
     public string Body { get; set; } = string.Empty;
     public User? ClosedBy { get; set; }
     public User User { get; set; } = new();
-    public IReadOnlyList<Label> Labels { get; set; } = Array.Empty<Label>();
+    public List<Label> Labels { get; set; } = [];
     public User? Assignee { get; set; }
-    public IReadOnlyList<User> Assignees { get; set; } = Array.Empty<User>();
+    public List<User> Assignees { get; set; } = [];
     public Milestone? Milestone { get; set; }
     public int Comments { get; set; }
     public PullRequest? PullRequest { get; set; }
@@ -1078,7 +1095,8 @@ public class Issue
     public StringEnum<AuthorAssociation> AuthorAssociation { get; set; } = new();
 }
 
-public class IssueComment
+[WinRT.GeneratedBindableCustomProperty]
+public partial class IssueComment
 {
     public IssueComment()
     : this([])
@@ -1111,7 +1129,8 @@ public class IssueComment
     public StringEnum<AuthorAssociation> AuthorAssociation { get; set; } = new();
 }
 
-public class PullRequestReviewComment
+[WinRT.GeneratedBindableCustomProperty]
+public partial class PullRequestReviewComment
 {
     public PullRequestReviewComment()
     : this([])
@@ -1162,7 +1181,8 @@ public class PullRequestReviewComment
     public StringEnum<AuthorAssociation> AuthorAssociation { get; set; } = new();
 }
 
-public class PullRequestReview
+[WinRT.GeneratedBindableCustomProperty]
+public partial class PullRequestReview
 {
     public PullRequestReview()
     : this([])
@@ -1195,7 +1215,8 @@ public class PullRequestReview
     public DateTimeOffset SubmittedAt { get; set; }
 }
 
-public class Author
+[WinRT.GeneratedBindableCustomProperty]
+public partial class Author
 {
     public Author()
     : this([])
@@ -1242,7 +1263,8 @@ public class Author
     public bool SiteAdmin { get; set; }
 }
 
-public class Committer
+[WinRT.GeneratedBindableCustomProperty]
+public partial class Committer
 {
     public Committer()
     : this([])
@@ -1261,7 +1283,8 @@ public class Committer
     public DateTimeOffset Date { get; set; }
 }
 
-public class Commit
+[WinRT.GeneratedBindableCustomProperty]
+public partial class Commit
 {
     public Commit()
     : this([])
@@ -1297,12 +1320,13 @@ public class Commit
     public Committer Author { get; set; } = new();
     public Committer Committer { get; set; } = new();
     public GitReference Tree { get; set; } = new();
-    public IReadOnlyList<GitReference> Parents { get; set; } = Array.Empty<GitReference>();
+    public List<GitReference> Parents { get; set; } = [];
     public int CommentCount { get; set; }
     public object? Verification { get; set; }
 }
 
-public class GitHubCommitFile
+[WinRT.GeneratedBindableCustomProperty]
+public partial class GitHubCommitFile
 {
     public GitHubCommitFile()
     : this([])
@@ -1335,9 +1359,14 @@ public class GitHubCommitFile
     public string Sha { get; set; } = string.Empty;
     public string Patch { get; set; } = string.Empty;
     public string PreviousFilename { get; set; } = string.Empty;
+    public string PatchDisplayText => string.IsNullOrWhiteSpace(Patch) ? "Binary file or diff unavailable for this file." : Patch;
+    public bool HasPreviousFilename => !string.IsNullOrWhiteSpace(PreviousFilename);
+    public string PreviousFilenameDisplayText => HasPreviousFilename ? $"Renamed from {PreviousFilename}" : string.Empty;
+    public string HeaderText => HasPreviousFilename ? $"{Filename} (from {PreviousFilename})" : Filename;
 }
 
-public class GitHubCommitStats
+[WinRT.GeneratedBindableCustomProperty]
+public partial class GitHubCommitStats
 {
     public GitHubCommitStats()
     : this([])
@@ -1356,7 +1385,8 @@ public class GitHubCommitStats
     public int Total { get; set; }
 }
 
-public class GitHubCommit
+[WinRT.GeneratedBindableCustomProperty]
+public partial class GitHubCommit
 {
     public GitHubCommit()
     : this([])
@@ -1395,11 +1425,12 @@ public class GitHubCommit
     public Author? CommitAuthor { get; set; }
     public string CommitUrl { get; set; } = string.Empty;
     public GitHubCommitStats? Stats { get; set; }
-    public IReadOnlyList<GitReference> Parents { get; set; } = Array.Empty<GitReference>();
-    public IReadOnlyList<GitHubCommitFile> Files { get; set; } = Array.Empty<GitHubCommitFile>();
+    public List<GitReference> Parents { get; set; } = [];
+    public List<GitHubCommitFile> Files { get; set; } = [];
 }
 
-public class PullRequestCommit
+[WinRT.GeneratedBindableCustomProperty]
+public partial class PullRequestCommit
 {
     public PullRequestCommit()
     : this([])
@@ -1425,12 +1456,13 @@ public class PullRequestCommit
     public Commit Commit { get; set; } = new();
     public User Committer { get; set; } = new();
     public string HtmlUrl { get; set; } = string.Empty;
-    public IReadOnlyList<GitReference> Parents { get; set; } = Array.Empty<GitReference>();
+    public List<GitReference> Parents { get; set; } = [];
     public string Sha { get; set; } = string.Empty;
     public string CommitUrl { get; set; } = string.Empty;
 }
 
-public class CommitComment
+[WinRT.GeneratedBindableCustomProperty]
+public partial class CommitComment
 {
     public CommitComment()
     : this([])
@@ -1469,7 +1501,8 @@ public class CommitComment
     public ReactionSummary Reactions { get; set; } = new();
 }
 
-public class CompareResult
+[WinRT.GeneratedBindableCustomProperty]
+public partial class CompareResult
 {
     public CompareResult()
     : this([])
@@ -1504,11 +1537,12 @@ public class CompareResult
     public int AheadBy { get; set; }
     public int BehindBy { get; set; }
     public int TotalCommits { get; set; }
-    public IReadOnlyList<GitHubCommit> Commits { get; set; } = Array.Empty<GitHubCommit>();
-    public IReadOnlyList<GitHubCommitFile> Files { get; set; } = Array.Empty<GitHubCommitFile>();
+    public List<GitHubCommit> Commits { get; set; } = [];
+    public List<GitHubCommitFile> Files { get; set; } = [];
 }
 
-public class Subscription
+[WinRT.GeneratedBindableCustomProperty]
+public partial class Subscription
 {
     public Subscription()
     {
@@ -1532,7 +1566,8 @@ public class Subscription
     public string RepositoryUrl { get; set; } = string.Empty;
 }
 
-public class IssueEvent
+[WinRT.GeneratedBindableCustomProperty]
+public partial class IssueEvent
 {
     public IssueEvent()
     : this([])

--- a/JitHub.WinUI/Models/License.cs
+++ b/JitHub.WinUI/Models/License.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -6,7 +6,8 @@ using System.Threading.Tasks;
 
 namespace JitHub.Models
 {
-    public class License
+    [WinRT.GeneratedBindableCustomProperty]
+    public partial class License
     {
         public string Name { get; set; } = string.Empty;
         public string DiaplayName { get; set; } = string.Empty;

--- a/JitHub.WinUI/Models/MenuItem.cs
+++ b/JitHub.WinUI/Models/MenuItem.cs
@@ -1,8 +1,9 @@
-﻿using System.Windows.Input;
+using System.Windows.Input;
 
 namespace JitHub.Models
 {
-    public class MenuItem
+    [WinRT.GeneratedBindableCustomProperty]
+    public partial class MenuItem
     {
         public string Text { get; set; } = string.Empty;
         public ICommand Command { get; set; }

--- a/JitHub.WinUI/Models/PRConversation/CommitNode.cs
+++ b/JitHub.WinUI/Models/PRConversation/CommitNode.cs
@@ -2,7 +2,8 @@ using JitHub.Models.LegacyGitHub;
 
 namespace JitHub.Models.PRConversation
 {
-    public class CommitNode : ConversationNode
+    [WinRT.GeneratedBindableCustomProperty]
+    public partial class CommitNode : ConversationNode
     {
         public string NodeId { get; set; }
         public User Author { get; set; }

--- a/JitHub.WinUI/Models/PRConversation/ConversationNode.cs
+++ b/JitHub.WinUI/Models/PRConversation/ConversationNode.cs
@@ -3,7 +3,8 @@ using System;
 
 namespace JitHub.Models.PRConversation
 {
-    public class ConversationNode
+    [WinRT.GeneratedBindableCustomProperty]
+    public partial class ConversationNode
     {
         public Repository Repo { get; set; }
         // issue number or pr number

--- a/JitHub.WinUI/Models/PRConversation/EventNode.cs
+++ b/JitHub.WinUI/Models/PRConversation/EventNode.cs
@@ -2,7 +2,8 @@ using JitHub.Models.LegacyGitHub;
 
 namespace JitHub.Models.PRConversation
 {
-    public class EventNode : ConversationNode
+    [WinRT.GeneratedBindableCustomProperty]
+    public partial class EventNode : ConversationNode
     {
         public long Id { get; set; }
         public string NodeId { get; set; } = string.Empty;

--- a/JitHub.WinUI/Models/PRConversation/IssueCommentNode.cs
+++ b/JitHub.WinUI/Models/PRConversation/IssueCommentNode.cs
@@ -7,7 +7,8 @@ using Windows.ApplicationModel.DataTransfer;
 
 namespace JitHub.Models.PRConversation
 {
-    public class IssueCommentNode : ConversationNode
+    [WinRT.GeneratedBindableCustomProperty]
+    public partial class IssueCommentNode : ConversationNode
     {
         public long Id { get; set; }
         public string NodeId { get; set; } = string.Empty;

--- a/JitHub.WinUI/Models/PRConversation/ReviewCommentNode.cs
+++ b/JitHub.WinUI/Models/PRConversation/ReviewCommentNode.cs
@@ -12,7 +12,8 @@ using Windows.ApplicationModel.DataTransfer;
 
 namespace JitHub.Models.PRConversation
 {
-    public class ReviewCommentNode : ConversationNode
+    [WinRT.GeneratedBindableCustomProperty]
+    public partial class ReviewCommentNode : ConversationNode
     {
         public long? InReplyToId { get; set; }
         public ReactionSummary Reactions { get; set; } = new();

--- a/JitHub.WinUI/Models/PRConversation/ReviewNode.cs
+++ b/JitHub.WinUI/Models/PRConversation/ReviewNode.cs
@@ -5,7 +5,8 @@ using System.Windows.Input;
 
 namespace JitHub.Models.PRConversation
 {
-    public class ReviewNode : ConversationNode
+    [WinRT.GeneratedBindableCustomProperty]
+    public partial class ReviewNode : ConversationNode
     {
         public long Id { get; set; }
         public string NodeId { get; set; } = string.Empty;

--- a/JitHub.WinUI/Models/RepoModel.cs
+++ b/JitHub.WinUI/Models/RepoModel.cs
@@ -12,7 +12,8 @@ using System.Windows.Input;
 
 namespace JitHub.Models
 {
-    public class RepoModel : ObservableObject
+    [WinRT.GeneratedBindableCustomProperty]
+    public partial class RepoModel : ObservableObject
     {
         private Repository _repository = null!;
         private readonly NavigationService _navigationService;
@@ -20,6 +21,12 @@ namespace JitHub.Models
 
         public Repository Repository { get => _repository; set => SetProperty(ref _repository, value); }
         public ICommand DetailNavigationCommand { get => _detailNavigationCommand; set => SetProperty(ref _detailNavigationCommand, value); }
+        public string Name => Repository.Name;
+        public string FullName => Repository.FullName;
+        public string Description => Repository.Description;
+        public int StargazersCount => Repository.StargazersCount;
+        public string Language => Repository.Language;
+        public DateTimeOffset UpdatedAt => Repository.UpdatedAt;
 
         public RepoModel(Repository repo)
         {

--- a/JitHub.WinUI/Models/SelectableLabel.cs
+++ b/JitHub.WinUI/Models/SelectableLabel.cs
@@ -4,7 +4,8 @@ using System.Windows.Input;
 
 namespace JitHub.Models
 {
-    public class SelectableLabel : SelectableItem
+    [WinRT.GeneratedBindableCustomProperty]
+    public partial class SelectableLabel : SelectableItem
     {
         private Label _label = null!;
 

--- a/JitHub.WinUI/Models/SelectableRepoModel.cs
+++ b/JitHub.WinUI/Models/SelectableRepoModel.cs
@@ -1,4 +1,4 @@
-﻿using JitHub.Models.Base;
+using JitHub.Models.Base;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -8,7 +8,8 @@ using System.Windows.Input;
 
 namespace JitHub.Models
 {
-    public class SelectableRepoModel : SelectableItem
+    [WinRT.GeneratedBindableCustomProperty]
+    public partial class SelectableRepoModel : SelectableItem
     {
         private RepoModel _repo = null!;
         public RepoModel Repo
@@ -16,6 +17,9 @@ namespace JitHub.Models
             get => _repo;
             set => SetProperty(ref _repo, value);
         }
+        public string FullName => Repo.FullName;
+        public string Description => Repo.Description;
+        public int StargazersCount => Repo.StargazersCount;
 
         public SelectableRepoModel(RepoModel repo)
         {

--- a/JitHub.WinUI/Models/SelectableUser.cs
+++ b/JitHub.WinUI/Models/SelectableUser.cs
@@ -4,7 +4,8 @@ using System.Windows.Input;
 
 namespace JitHub.Models
 {
-    public class SelectableUser : SelectableItem
+    [WinRT.GeneratedBindableCustomProperty]
+    public partial class SelectableUser : SelectableItem
     {
         public string Login { get; set; } = string.Empty;
         public string AvatarUrl { get; set; } = string.Empty;

--- a/JitHub.WinUI/Models/SettingsItem.cs
+++ b/JitHub.WinUI/Models/SettingsItem.cs
@@ -5,7 +5,8 @@ using System.Collections.Generic;
 
 namespace JitHub.Models
 {
-    public class SettingsDisplayItem
+    [WinRT.GeneratedBindableCustomProperty]
+    public partial class SettingsDisplayItem
     {
         public string DisplayText { get; set; } = string.Empty;
         public object Model { get; set; }
@@ -22,7 +23,8 @@ namespace JitHub.Models
         string GetItemType();
     }
 
-    public class SettingsItem<T> : RepoSelectableItemModel<T>, SettingsItemType
+    [WinRT.GeneratedBindableCustomProperty]
+    public partial class SettingsItem<T> : RepoSelectableItemModel<T>, SettingsItemType
     {
         private string _label = string.Empty;
         private string _type = string.Empty;

--- a/JitHub.WinUI/Models/SimpleFormData.cs
+++ b/JitHub.WinUI/Models/SimpleFormData.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -6,7 +6,8 @@ using System.Threading.Tasks;
 
 namespace JitHub.Models
 {
-    public class SimpleFormData
+    [WinRT.GeneratedBindableCustomProperty]
+    public partial class SimpleFormData
     {
         public string Title { get; set; } = string.Empty;
         public string Body { get; set; } = string.Empty;

--- a/JitHub.WinUI/Package.appxmanifest
+++ b/JitHub.WinUI/Package.appxmanifest
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 
 <Package
   xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10"
@@ -10,8 +10,8 @@
 
   <Identity
     Name="54742Neromarah.JitHub"
-    Publisher="CN=E1994DBD-BBFE-40D0-AC99-9271E31610E9"
-    Version="1.6.2.0" />
+    Publisher="CN=neroc"
+    Version="1.7.2.0" />
 
   <mp:PhoneIdentity PhoneProductId="ac961a7e-34a0-4a8b-8b7b-8379271bd0ce" PhonePublisherId="00000000-0000-0000-0000-000000000000"/>
 

--- a/JitHub.WinUI/Package.appxmanifest
+++ b/JitHub.WinUI/Package.appxmanifest
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 
 <Package
   xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10"
@@ -10,8 +10,8 @@
 
   <Identity
     Name="54742Neromarah.JitHub"
-    Publisher="CN=neroc"
-    Version="1.7.2.0" />
+    Publisher="CN=E1994DBD-BBFE-40D0-AC99-9271E31610E9"
+    Version="1.6.2.0" />
 
   <mp:PhoneIdentity PhoneProductId="ac961a7e-34a0-4a8b-8b7b-8379271bd0ce" PhonePublisherId="00000000-0000-0000-0000-000000000000"/>
 

--- a/JitHub.WinUI/Services/GitHubService.Post.cs
+++ b/JitHub.WinUI/Services/GitHubService.Post.cs
@@ -361,7 +361,7 @@ namespace JitHub.Services
                 num,
                 issue => (
                     GetAssigneeLogins(issue),
-                    RemoveValues(issue.Labels.Select(currentLabel => currentLabel.Name), [label])));
+                    RemoveValues(issue.Labels.Select(currentLabel => currentLabel.Name), new[] { label })));
         }
 
         private static string? ToGitHubIssueState(ItemState? state)

--- a/JitHub.WinUI/Services/GitHubService.cs
+++ b/JitHub.WinUI/Services/GitHubService.cs
@@ -160,7 +160,7 @@ namespace JitHub.Services
                 WatchersCount = 146,
                 SubscribersCount = 15,
                 Visibility = RepositoryVisibility.Public,
-                Topics = new[] { "github", "winui", "windows", "client" }
+                Topics = ["github", "winui", "windows", "client"]
             };
         }
 
@@ -179,7 +179,7 @@ namespace JitHub.Services
             };
         }
 
-        private static IReadOnlyList<Label> CreatePublicPreviewLabels()
+        private static List<Label> CreatePublicPreviewLabels()
         {
             return
             [
@@ -209,8 +209,10 @@ namespace JitHub.Services
 
         private static IReadOnlyList<PullRequest> CreatePublicPreviewPullRequests()
         {
-            return
-            [
+            List<Label> labels = CreatePublicPreviewLabels();
+
+            return new[]
+            {
                 CreatePublicPreviewPullRequest(
                     72,
                     "Add website dark mode and unblock Store release",
@@ -219,7 +221,7 @@ namespace JitHub.Services
                     new DateTimeOffset(2026, 5, 4, 17, 10, 0, TimeSpan.Zero),
                     "website-dark-mode",
                     4,
-                    [CreatePublicPreviewLabels()[0], CreatePublicPreviewLabels()[1]]),
+                    new[] { labels[0], labels[1] }),
                 CreatePublicPreviewPullRequest(
                     62,
                     "GitHub: Improve developer experience",
@@ -228,7 +230,7 @@ namespace JitHub.Services
                     new DateTimeOffset(2024, 10, 22, 15, 45, 0, TimeSpan.Zero),
                     "github-developer-experience",
                     2,
-                    [CreatePublicPreviewLabels()[0]]),
+                    new[] { labels[0] }),
                 CreatePublicPreviewPullRequest(
                     59,
                     "Bump SkiaSharp from 2.88.3 to 2.88.6 in /JitHub.Utilities.SVG",
@@ -237,8 +239,8 @@ namespace JitHub.Services
                     new DateTimeOffset(2023, 9, 22, 11, 35, 0, TimeSpan.Zero),
                     "dependabot/nuget/JitHub.Utilities.SVG/SkiaSharp-2.88.6",
                     1,
-                    [CreatePublicPreviewLabels()[2]])
-            ];
+                    new[] { labels[2] })
+            };
         }
 
         private static PullRequest CreatePublicPreviewPullRequest(
@@ -294,7 +296,7 @@ namespace JitHub.Services
                 Additions = 420 + number,
                 Deletions = 120,
                 ChangedFiles = 12,
-                Labels = labels,
+                Labels = labels.ToList(),
                 Reactions = new ReactionSummary()
             };
         }
@@ -319,8 +321,8 @@ namespace JitHub.Services
                 Title = pullRequest.Title,
                 Body = pullRequest.Body,
                 User = pullRequest.User,
-                Labels = pullRequest.Labels,
-                Assignees = Array.Empty<User>(),
+                Labels = pullRequest.Labels.ToList(),
+                Assignees = [],
                 Comments = pullRequest.Comments,
                 PullRequest = pullRequest,
                 CreatedAt = pullRequest.CreatedAt,
@@ -769,7 +771,7 @@ namespace JitHub.Services
 
         private static Issue AdaptIssue(RestGitHubIssue issue, Repository? repository = null)
         {
-            IReadOnlyList<User> assignees = issue.Assignees.Select(AdaptUser).ToList();
+            List<User> assignees = issue.Assignees.Select(AdaptUser).ToList();
             return new Issue(
                 issue.HtmlUrl,
                 issue.HtmlUrl,
@@ -1289,17 +1291,17 @@ namespace JitHub.Services
 
         public async Task<ICollection<PullRequest>> GetPullRequests(string owner, string name, PullRequestRequest requestParam, ApiOptions apiOptions)
         {
-            if (IsPublicPreviewRepository(owner, name))
-            {
-                return CreatePublicPreviewPullRequests().ToList();
-            }
-
             int pageSize = apiOptions?.PageSize ?? 100;
             int startPage = apiOptions?.StartPage ?? 1;
             int pageCount = apiOptions?.PageCount ?? 1;
             pageSize = pageSize > 0 ? pageSize : 100;
             startPage = startPage > 0 ? startPage : 1;
             pageCount = pageCount > 0 ? pageCount : 1;
+
+            if (IsPublicPreviewRepository(owner, name))
+            {
+                return FilterPublicPreviewPullRequests(requestParam, pageSize, startPage, pageCount);
+            }
 
             string token = GetAccessTokenOrThrow();
             List<PullRequest> pullRequests = [];
@@ -1325,6 +1327,53 @@ namespace JitHub.Services
             return pullRequests;
         }
 
+        private static ICollection<PullRequest> FilterPublicPreviewPullRequests(
+            PullRequestRequest request,
+            int pageSize,
+            int startPage,
+            int pageCount)
+        {
+            IEnumerable<PullRequest> query = CreatePublicPreviewPullRequests();
+
+            query = request.State switch
+            {
+                ItemStateFilter.Open => query.Where(pullRequest => pullRequest.State.Value == ItemState.Open),
+                ItemStateFilter.Closed => query.Where(pullRequest => pullRequest.State.Value == ItemState.Closed),
+                _ => query
+            };
+
+            if (!string.IsNullOrWhiteSpace(request.Head))
+            {
+                query = query.Where(pullRequest =>
+                    string.Equals(pullRequest.Head.Ref, request.Head, StringComparison.OrdinalIgnoreCase) ||
+                    string.Equals(pullRequest.Head.Label, request.Head, StringComparison.OrdinalIgnoreCase));
+            }
+
+            if (!string.IsNullOrWhiteSpace(request.Base))
+            {
+                query = query.Where(pullRequest =>
+                    string.Equals(pullRequest.Base.Ref, request.Base, StringComparison.OrdinalIgnoreCase) ||
+                    string.Equals(pullRequest.Base.Label, request.Base, StringComparison.OrdinalIgnoreCase));
+            }
+
+            query = request.SortProperty switch
+            {
+                PullRequestSort.Updated => query.OrderBy(pullRequest => pullRequest.UpdatedAt),
+                PullRequestSort.Popularity => query.OrderBy(pullRequest => pullRequest.Comments),
+                PullRequestSort.LongRunning => query.OrderBy(pullRequest => pullRequest.CreatedAt),
+                _ => query.OrderBy(pullRequest => pullRequest.CreatedAt)
+            };
+
+            if (request.SortDirection != SortDirection.Ascending)
+            {
+                query = query.Reverse();
+            }
+
+            int skip = Math.Max(0, startPage - 1) * pageSize;
+            int take = Math.Max(0, pageSize * pageCount);
+            return query.Skip(skip).Take(take).ToList();
+        }
+
         public async Task<PullRequest> GetPullRequest(string owner, string name, int num)
         {
             if (IsPublicPreviewRepository(owner, name))
@@ -1345,6 +1394,12 @@ namespace JitHub.Services
                 pageSize = pageSize > 0 ? pageSize : 100;
                 startPage = startPage > 0 ? startPage : 1;
                 pageCount = pageCount > 0 ? pageCount : 1;
+
+                if (IsPublicPreviewRepository(owner, name))
+                {
+                    return FilterPublicPreviewIssues(repoIssueRequest, pageSize, startPage, pageCount);
+                }
+
                 string token = GetAccessTokenOrThrow();
                 List<Issue> issues = [];
 
@@ -1373,6 +1428,50 @@ namespace JitHub.Services
                 NotificationService.Push(e.Message);
                 throw new Exception(e.Message);
             }
+        }
+
+        private static ICollection<Issue> FilterPublicPreviewIssues(
+            RepositoryIssueRequest request,
+            int pageSize,
+            int startPage,
+            int pageCount)
+        {
+            IEnumerable<Issue> query = CreatePublicPreviewPullRequests()
+                .Select(pullRequest => CreatePublicPreviewIssue(pullRequest.Number));
+
+            query = request.State switch
+            {
+                ItemStateFilter.Open => query.Where(issue => issue.State.Value == ItemState.Open),
+                ItemStateFilter.Closed => query.Where(issue => issue.State.Value == ItemState.Closed),
+                _ => query
+            };
+
+            if (request.Labels.Count > 0)
+            {
+                HashSet<string> labels = request.Labels.ToHashSet(StringComparer.OrdinalIgnoreCase);
+                query = query.Where(issue => issue.Labels.Any(label => labels.Contains(label.Name)));
+            }
+
+            if (request.Since is DateTimeOffset since)
+            {
+                query = query.Where(issue => issue.UpdatedAt >= since);
+            }
+
+            query = request.SortProperty switch
+            {
+                IssueSort.Comments => query.OrderBy(issue => issue.Comments),
+                IssueSort.Updated => query.OrderBy(issue => issue.UpdatedAt),
+                _ => query.OrderBy(issue => issue.CreatedAt)
+            };
+
+            if (request.SortDirection != SortDirection.Ascending)
+            {
+                query = query.Reverse();
+            }
+
+            int skip = Math.Max(0, startPage - 1) * pageSize;
+            int take = Math.Max(0, pageSize * pageCount);
+            return query.Skip(skip).Take(take).ToList();
         }
 
         public async Task<Issue> GetIssue(string owner, string name, int number)
@@ -1843,6 +1942,11 @@ namespace JitHub.Services
 
         public async Task<ICollection<Milestone>> GetMilestonesFromRepository(long repoId)
         {
+            if (IsPublicPreviewToken() && repoId == PublicPreviewRepositoryId)
+            {
+                return [];
+            }
+
             string token = GetAccessTokenOrThrow();
             (string owner, string name) = await GetRepositoryIdentityAsync(token, repoId);
             IReadOnlyList<RestGitHubMilestone> milestones = await _gitHubClientService.GetMilestonesAsync(token, owner, name);

--- a/JitHub.WinUI/ViewModels/Activities/ActivityCardViewModelFactory.cs
+++ b/JitHub.WinUI/ViewModels/Activities/ActivityCardViewModelFactory.cs
@@ -54,7 +54,7 @@ public static class ActivityCardViewModelFactory
         };
     }
 
-    public static IReadOnlyList<ActivityCardViewModel> CreateMany(
+    public static List<ActivityCardViewModel> CreateMany(
         IEnumerable<GitHubActivityEvent> events,
         ICommand? actionCommand = null)
     {
@@ -85,7 +85,7 @@ public static class ActivityCardViewModelFactory
         ActivityCardActionViewModel? commitAction = commitCount > 0
             ? CommitAction(activityEvent, command, payload.Head)
             : null;
-        IReadOnlyList<ActivitySentencePartViewModel> sentenceParts = commitCount > 0
+        List<ActivitySentencePartViewModel> sentenceParts = commitCount > 0
             ? Sentence(
                 Strong(Actor(activityEvent)),
                 Text(" pushed "),
@@ -637,7 +637,7 @@ public static class ActivityCardViewModelFactory
                 ? ActivityCardTone.Danger
                 : ActivityCardTone.Accent;
 
-    private static IReadOnlyList<ActivityCardDetailViewModel> DetailList(params (string Glyph, string? Text)[] values)
+    private static List<ActivityCardDetailViewModel> DetailList(params (string Glyph, string? Text)[] values)
     {
         return values
             .Where(value => !string.IsNullOrWhiteSpace(value.Text))
@@ -645,10 +645,10 @@ public static class ActivityCardViewModelFactory
             .ToList();
     }
 
-    private static IReadOnlyList<ActivityCardActionViewModel> Combine(params ActivityCardActionViewModel?[] actions) =>
+    private static List<ActivityCardActionViewModel> Combine(params ActivityCardActionViewModel?[] actions) =>
         actions.Where(action => action is not null).Cast<ActivityCardActionViewModel>().ToList();
 
-    private static IReadOnlyList<ActivitySentencePartViewModel> Sentence(params ActivitySentencePartViewModel?[] parts) =>
+    private static List<ActivitySentencePartViewModel> Sentence(params ActivitySentencePartViewModel?[] parts) =>
         parts.Where(part => part is not null && !string.IsNullOrEmpty(part.Text))
             .Cast<ActivitySentencePartViewModel>()
             .ToList();
@@ -803,7 +803,7 @@ public static class ActivityCardViewModelFactory
         };
     }
 
-    private static IReadOnlyList<ActivityNavigationTarget> Unsupported(GitHubActivityEvent activityEvent, string reason)
+    private static List<ActivityNavigationTarget> Unsupported(GitHubActivityEvent activityEvent, string reason)
     {
         return
         [
@@ -853,12 +853,12 @@ public static class ActivityCardViewModelFactory
 
         public ActivityCardTone Tone { get; init; }
 
-        public IReadOnlyList<ActivitySentencePartViewModel> SentenceParts { get; init; } = [];
+        public List<ActivitySentencePartViewModel> SentenceParts { get; init; } = [];
 
-        public IReadOnlyList<ActivityCardDetailViewModel> Details { get; init; } = [];
+        public List<ActivityCardDetailViewModel> Details { get; init; } = [];
 
-        public IReadOnlyList<ActivityCardActionViewModel> Actions { get; init; } = [];
+        public List<ActivityCardActionViewModel> Actions { get; init; } = [];
 
-        public IReadOnlyList<ActivityNavigationTarget> UnsupportedTodos { get; init; } = [];
+        public List<ActivityNavigationTarget> UnsupportedTodos { get; init; } = [];
     }
 }

--- a/JitHub.WinUI/ViewModels/Activities/ActivityMockData.cs
+++ b/JitHub.WinUI/ViewModels/Activities/ActivityMockData.cs
@@ -13,7 +13,7 @@ public static class ActivityMockData
 {
     private static readonly ICommand NoOpCommand = new RelayCommand<ActivityNavigationTarget>(_ => { });
 
-    public static IReadOnlyList<ActivityCardViewModel> CreateCards(ICommand? command = null)
+    public static List<ActivityCardViewModel> CreateCards(ICommand? command = null)
     {
         command ??= NoOpCommand;
         List<GitHubActivityEvent> events =

--- a/JitHub.WinUI/ViewModels/Base/RepoListViewModel.cs
+++ b/JitHub.WinUI/ViewModels/Base/RepoListViewModel.cs
@@ -1,6 +1,7 @@
 using System;
 using CommunityToolkit.Mvvm.Input;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using System.Windows.Input;
 using CommunityToolkit.Mvvm.ComponentModel;
@@ -9,18 +10,18 @@ namespace JitHub.WinUI.ViewModels.Base;
 
 public abstract partial class RepoListViewModel<T> : LoadableViewModel<string>
 {
-    private ICollection<T> _repos = [];
+    private List<T> _repos = [];
     [ObservableProperty]
-    public partial ICollection<T> PrivateRepos { get; set; } = [];
+    public partial List<T> PrivateRepos { get; set; } = [];
 
     [ObservableProperty]
-    public partial ICollection<T> PublicRepos { get; set; } = [];
+    public partial List<T> PublicRepos { get; set; } = [];
 
     [ObservableProperty]
-    public partial ICollection<T> ForkedRepos { get; set; } = [];
+    public partial List<T> ForkedRepos { get; set; } = [];
     private bool _isEmpty;
 
-    public ICollection<T> Repos
+    public List<T> Repos
     {
         get => _repos;
         set
@@ -54,7 +55,7 @@ public abstract partial class RepoListViewModel<T> : LoadableViewModel<string>
     abstract public bool IsPrivate(T repo);
     abstract public bool IsPublic(T repo);
 
-    abstract public ICollection<T> NewRepoList();
+    abstract public List<T> NewRepoList();
 
     // Override this to get different list of repos
     virtual public async Task LoadRepos()
@@ -62,7 +63,7 @@ public abstract partial class RepoListViewModel<T> : LoadableViewModel<string>
         Load(true);
         try
         {
-            Repos = await GetRepos();
+            Repos = (await GetRepos()).ToList();
         }
         catch (InvalidOperationException ex) when (string.Equals(ex.Message, "GitHub access token is not available.", StringComparison.Ordinal))
         {

--- a/JitHub.WinUI/ViewModels/CommitViewModels/CommitDetailViewModel.cs
+++ b/JitHub.WinUI/ViewModels/CommitViewModels/CommitDetailViewModel.cs
@@ -13,11 +13,11 @@ namespace JitHub.WinUI.ViewModels.CommitViewModels
 {
     public class CommitDetailViewModel : RepoViewModel
     {
-        private ICollection<FileDiffViewModel> _files = [];
+        private List<FileDiffViewModel> _files = [];
         private CommandableCommit _commandableCommit = null!;
 
         public ICommand LoadCommand { get; }
-        public ICollection<FileDiffViewModel> Files
+        public List<FileDiffViewModel> Files
         {
             get => _files;
             set => SetProperty(ref _files, value);

--- a/JitHub.WinUI/ViewModels/CommitViewModels/RepoCommitsViewModel.cs
+++ b/JitHub.WinUI/ViewModels/CommitViewModels/RepoCommitsViewModel.cs
@@ -22,13 +22,13 @@ namespace JitHub.WinUI.ViewModels.CommitViewModels
     public class RepoCommitsViewModel : RepoViewModel
     {
         private readonly NavigationService _navigationService;
-        private ICollection<Branch> _branches = [];
+        private List<Branch> _branches = [];
         private Branch? _selectedBranch;
         private IncrementalLoadingCollection<CommitsSource, CommandableCommit> _commits = null!;
         private CommandableCommit? _selectedCommit;
         private readonly CommitPageNavArg _navArgs;
         
-        public ICollection<Branch> Branches
+        public List<Branch> Branches
         {
             get => _branches;
             set => SetProperty(ref _branches, value);
@@ -145,7 +145,7 @@ namespace JitHub.WinUI.ViewModels.CommitViewModels
         {
             Loading = true;
             Repo = await GitHubService.GetRepository(_navArgs.Repo.Id);
-            Branches = await GitHubService.GetRepoBranches(Repo.Owner.Login, Repo.Name);
+            Branches = (await GitHubService.GetRepoBranches(Repo.Owner.Login, Repo.Name)).ToList();
             if (!_navArgs.NoBranch)
             {
                 SelectedBranch = Branches.FirstOrDefault(branch => branch.Name == _navArgs.Branch);

--- a/JitHub.WinUI/ViewModels/FileDiffViewModel.cs
+++ b/JitHub.WinUI/ViewModels/FileDiffViewModel.cs
@@ -4,7 +4,8 @@ using System;
 
 namespace JitHub.WinUI.ViewModels
 {
-    public class FileDiffViewModel : RepoViewModel
+    [WinRT.GeneratedBindableCustomProperty]
+    public partial class FileDiffViewModel : RepoViewModel
     {
         private string _sha = string.Empty;
         private GitHubCommitFile _file = null!;

--- a/JitHub.WinUI/ViewModels/IssueViewModels/IssueSideBarViewModel.cs
+++ b/JitHub.WinUI/ViewModels/IssueViewModels/IssueSideBarViewModel.cs
@@ -18,13 +18,13 @@ namespace JitHub.WinUI.ViewModels.IssueViewModels
         private Issue _issue = null!;
         private bool _isPr;
         private bool _isCollaborator;
-        private ICollection<IssueSidePanelItem> _items = [];
+        private List<IssueSidePanelItem> _items = [];
 
         #region reviewers
         private readonly Dictionary<string, User> _requestedReviewers = [];
-        private ICollection<SelectableItem> _selectableReviewers = [];
+        private List<SelectableItem> _selectableReviewers = [];
 
-        public ICollection<SelectableItem> SelectableReviewers
+        public List<SelectableItem> SelectableReviewers
         {
             get => _selectableReviewers;
             set => SetProperty(ref _selectableReviewers, value);
@@ -33,8 +33,8 @@ namespace JitHub.WinUI.ViewModels.IssueViewModels
 
         #region assignee
         private readonly Dictionary<string, User> _assignees = [];
-        private ICollection<SelectableItem> _selectableAssignees = [];
-        public ICollection<SelectableItem> SelectableAssignees
+        private List<SelectableItem> _selectableAssignees = [];
+        public List<SelectableItem> SelectableAssignees
         {
             get => _selectableAssignees;
             set => SetProperty(ref _selectableAssignees, value);
@@ -43,15 +43,15 @@ namespace JitHub.WinUI.ViewModels.IssueViewModels
 
         #region label
         private readonly Dictionary<long, Label> _labels = [];
-        private ICollection<SelectableItem> _selectableLabels = [];
-        public ICollection<SelectableItem> SelectableLabels
+        private List<SelectableItem> _selectableLabels = [];
+        public List<SelectableItem> SelectableLabels
         {
             get => _selectableLabels;
             set => SetProperty(ref _selectableLabels, value);
         }
         #endregion
 
-        public ICollection<IssueSidePanelItem> Items
+        public List<IssueSidePanelItem> Items
         {
             get => _items;
             set => SetProperty(ref _items, value);

--- a/JitHub.WinUI/ViewModels/IssueViewModels/RepoIssueDetailViewModel.cs
+++ b/JitHub.WinUI/ViewModels/IssueViewModels/RepoIssueDetailViewModel.cs
@@ -26,13 +26,13 @@ namespace JitHub.WinUI.ViewModels.IssueViewModels
         private readonly NavigationService _navigationService;
         private readonly ModalService _modalService;
         private readonly ICommandService _commandService;
-        private ICollection<UserCommentBlockViewModel> _comments = [];
+        private List<UserCommentBlockViewModel> _comments = [];
         private IssueSideBarViewModel _sideBarViewModel = null!;
         private string _text = string.Empty;
         private string _closeButtonText = string.Empty;
         private bool _userIsCollaborator;
 
-        public ICollection<UserCommentBlockViewModel> Comments
+        public List<UserCommentBlockViewModel> Comments
         {
             get => _comments;
             set => SetProperty(ref _comments, value);

--- a/JitHub.WinUI/ViewModels/IssueViewModels/RepoIssueViewModel.Filter.cs
+++ b/JitHub.WinUI/ViewModels/IssueViewModels/RepoIssueViewModel.Filter.cs
@@ -196,52 +196,73 @@ namespace JitHub.WinUI.ViewModels.IssueViewModels
 
         private void SetFilterParam(Dictionary<string, FilterUnit> filters)
         {
-            if (filters["Milestone"] is DropdownFilter milestoneFilter &&
+            RepoIssueRequest = new RepositoryIssueRequest();
+
+            if (filters.TryGetValue("Labels", out FilterUnit? labelsUnit) &&
+                labelsUnit is DropdownFilter labelsFilter &&
+                !labelsFilter.DefaultSelected &&
+                labelsFilter.Selected.SelectedValue is { Length: > 0 } label)
+            {
+                RepoIssueRequest.Labels = [label];
+            }
+            if (filters.TryGetValue("Milestone", out FilterUnit? milestoneUnit) &&
+                milestoneUnit is DropdownFilter milestoneFilter &&
                 !milestoneFilter.DefaultSelected &&
-                milestoneFilter.Selected.Value is string milestone)
+                milestoneFilter.Selected.SelectedValue is { Length: > 0 } milestone)
             {
                 RepoIssueRequest.Milestone = milestone;
             }
             if (_isCollabotor)
             {
-                if (filters["Assignee"] is DropdownFilter assigneeFilter && !assigneeFilter.DefaultSelected)
+                if (filters.TryGetValue("Assignee", out FilterUnit? assigneeUnit) &&
+                    assigneeUnit is DropdownFilter assigneeFilter &&
+                    !assigneeFilter.DefaultSelected)
                 {
                     RepoIssueRequest.Assignee = assigneeFilter.Selected.SelectedValue;
                 }
-                if (filters["Creator"] is DropdownFilter creatorFilter && !creatorFilter.DefaultSelected)
+                if (filters.TryGetValue("Creator", out FilterUnit? creatorUnit) &&
+                    creatorUnit is DropdownFilter creatorFilter &&
+                    !creatorFilter.DefaultSelected)
                 {
                     RepoIssueRequest.Creator = creatorFilter.Selected.SelectedValue;
                 }
-                if (filters["Mentioned"] is DropdownFilter mentionedFilter && !mentionedFilter.DefaultSelected)
+                if (filters.TryGetValue("Mentioned", out FilterUnit? mentionedUnit) &&
+                    mentionedUnit is DropdownFilter mentionedFilter &&
+                    !mentionedFilter.DefaultSelected)
                 {
                     RepoIssueRequest.Mentioned = mentionedFilter.Selected.SelectedValue;
                 }
             }
-            if (filters["Issue Filter"] is DropdownFilter issueFilter &&
+            if (filters.TryGetValue("Issue Filter", out FilterUnit? issueFilterUnit) &&
+                issueFilterUnit is DropdownFilter issueFilter &&
                 !issueFilter.DefaultSelected &&
                 issueFilter.Selected.Value is IssueFilter selectedIssueFilter)
             {
                 RepoIssueRequest.Filter = selectedIssueFilter;
             }
-            if (filters["State"] is DropdownFilter stateFilter &&
+            if (filters.TryGetValue("State", out FilterUnit? stateUnit) &&
+                stateUnit is DropdownFilter stateFilter &&
                 !stateFilter.DefaultSelected &&
                 stateFilter.Selected.Value is ItemStateFilter selectedState)
             {
                 RepoIssueRequest.State = selectedState;
             }
-            if (filters["Sort"] is DropdownFilter sortFilter &&
+            if (filters.TryGetValue("Sort", out FilterUnit? sortUnit) &&
+                sortUnit is DropdownFilter sortFilter &&
                 !sortFilter.DefaultSelected &&
                 sortFilter.Selected.Value is IssueSort selectedSort)
             {
                 RepoIssueRequest.SortProperty = selectedSort;
             }
-            if (filters["Direction"] is DropdownFilter directionFilter &&
+            if (filters.TryGetValue("Direction", out FilterUnit? directionUnit) &&
+                directionUnit is DropdownFilter directionFilter &&
                 !directionFilter.DefaultSelected &&
                 directionFilter.Selected.Value is SortDirection selectedDirection)
             {
                 RepoIssueRequest.SortDirection = selectedDirection;
             }
-            if (filters["Date"] is DateFilter dateFilter)
+            if (filters.TryGetValue("Date", out FilterUnit? dateUnit) &&
+                dateUnit is DateFilter dateFilter)
             {
                 RepoIssueRequest.Since = dateFilter.StartDate;
             }

--- a/JitHub.WinUI/ViewModels/IssueViewModels/UserIssueListViewModel.cs
+++ b/JitHub.WinUI/ViewModels/IssueViewModels/UserIssueListViewModel.cs
@@ -20,13 +20,13 @@ public partial class UserIssueListViewModel : ObservableObject
     private readonly IAuthService _authService;
 
     [ObservableProperty]
-    public partial ICollection<GitHubIssue> CreatedIssues { get; set; } = [];
+    public partial List<GitHubIssue> CreatedIssues { get; set; } = [];
 
     [ObservableProperty]
-    public partial ICollection<GitHubIssue> AssignedIssues { get; set; } = [];
+    public partial List<GitHubIssue> AssignedIssues { get; set; } = [];
 
     [ObservableProperty]
-    public partial ICollection<GitHubIssue> MentionedIssues { get; set; } = [];
+    public partial List<GitHubIssue> MentionedIssues { get; set; } = [];
 
     public GitHubUser? User => _authService.AuthenticatedUser;
     

--- a/JitHub.WinUI/ViewModels/Pages/RepoIssuePageViewModel.cs
+++ b/JitHub.WinUI/ViewModels/Pages/RepoIssuePageViewModel.cs
@@ -63,11 +63,11 @@ public sealed partial class RepoIssuePageViewModel : ViewModelBase
 
     public ObservableCollection<GitHubIssueComment> IssueComments { get; } = [];
 
-    public IReadOnlyList<QueryOption> StateOptions { get; }
+    public List<QueryOption> StateOptions { get; }
 
-    public IReadOnlyList<QueryOption> SortOptions { get; }
+    public List<QueryOption> SortOptions { get; }
 
-    public IReadOnlyList<QueryOption> DirectionOptions { get; }
+    public List<QueryOption> DirectionOptions { get; }
 
     public string AuthenticatedLogin => _authService.AuthenticatedUser?.Login ?? string.Empty;
 
@@ -1112,7 +1112,7 @@ public sealed partial class RepoIssuePageViewModel : ViewModelBase
             AreIssueActionsEnabled,
             IsAddCommentEnabled,
             IsIssueCommentsEmptyVisible,
-            [.. IssueComments]);
+            IssueComments.ToArray());
     }
 
     private bool TryRestorePendingIssueSelectionState(int issueNumber)

--- a/JitHub.WinUI/ViewModels/Pages/RepoPullRequestPageViewModel.cs
+++ b/JitHub.WinUI/ViewModels/Pages/RepoPullRequestPageViewModel.cs
@@ -12,6 +12,7 @@ using JitHub.Services;
 
 namespace JitHub.WinUI.ViewModels.Pages;
 
+[WinRT.GeneratedBindableCustomProperty]
 public sealed partial class RepoPullRequestPageViewModel : ViewModelBase
 {
     private static readonly TimeSpan SelectionLoadDebounce = TimeSpan.FromMilliseconds(150);
@@ -72,11 +73,11 @@ public sealed partial class RepoPullRequestPageViewModel : ViewModelBase
 
     public ObservableCollection<GitHubIssueEvent> PullRequestTimelineEvents { get; } = [];
 
-    public IReadOnlyList<QueryOption> StateOptions { get; }
+    public List<QueryOption> StateOptions { get; }
 
-    public IReadOnlyList<QueryOption> SortOptions { get; }
+    public List<QueryOption> SortOptions { get; }
 
-    public IReadOnlyList<QueryOption> DirectionOptions { get; }
+    public List<QueryOption> DirectionOptions { get; }
 
     public string AuthenticatedLogin => _authService.AuthenticatedUser?.Login ?? string.Empty;
 
@@ -1592,10 +1593,10 @@ public sealed partial class RepoPullRequestPageViewModel : ViewModelBase
             IsPullRequestCommitsEmptyVisible,
             IsPullRequestReviewsEmptyVisible,
             IsPullRequestTimelineEmptyVisible,
-            [.. PullRequestComments],
-            [.. PullRequestCommits],
-            [.. PullRequestReviews],
-            [.. PullRequestTimelineEvents]);
+            PullRequestComments.ToArray(),
+            PullRequestCommits.ToArray(),
+            PullRequestReviews.ToArray(),
+            PullRequestTimelineEvents.ToArray());
     }
 
     private bool TryRestorePendingPullRequestSelectionState(int pullRequestNumber)
@@ -2383,7 +2384,8 @@ public sealed partial class RepoPullRequestPageViewModel : ViewModelBase
         ReviewComment
     }
 
-    public sealed class PullRequestReviewItem
+    [WinRT.GeneratedBindableCustomProperty]
+    public sealed partial class PullRequestReviewItem
     {
         public PullRequestReviewItem(
             GitHubPullRequestReview review,
@@ -2442,6 +2444,7 @@ public sealed partial class RepoPullRequestPageViewModel : ViewModelBase
         }
     }
 
+    [WinRT.GeneratedBindableCustomProperty]
     public sealed partial class PullRequestReviewThreadItem : ObservableObject
     {
         public PullRequestReviewThreadItem(
@@ -2523,7 +2526,8 @@ public sealed partial class RepoPullRequestPageViewModel : ViewModelBase
         }
     }
 
-    public sealed class PullRequestReviewReplyItem
+    [WinRT.GeneratedBindableCustomProperty]
+    public sealed partial class PullRequestReviewReplyItem
     {
         public PullRequestReviewReplyItem(
             GitHubPullRequestReviewComment comment,

--- a/JitHub.WinUI/ViewModels/Pages/SettingsPageViewModel.cs
+++ b/JitHub.WinUI/ViewModels/Pages/SettingsPageViewModel.cs
@@ -26,7 +26,7 @@ public sealed partial class SettingsPageViewModel : ViewModelBase
         ];
     }
 
-    public IReadOnlyList<ThemeOption> ThemeOptions { get; }
+    public List<ThemeOption> ThemeOptions { get; }
 
     public Uri SourceCodeUri { get; } = new("https://github.com/JitHubApp/JitHubV2");
 

--- a/JitHub.WinUI/ViewModels/PullRequestViewModels/ConversationViewModels/PullRequestTimelineItemViewModel.cs
+++ b/JitHub.WinUI/ViewModels/PullRequestViewModels/ConversationViewModels/PullRequestTimelineItemViewModel.cs
@@ -16,7 +16,8 @@ public enum PullRequestTimelineInlineKind
     Label
 }
 
-public sealed class PullRequestTimelineInlinePartViewModel
+[WinRT.GeneratedBindableCustomProperty]
+public sealed partial class PullRequestTimelineInlinePartViewModel
 {
     public PullRequestTimelineInlineKind Kind { get; init; }
 
@@ -35,7 +36,8 @@ public sealed class PullRequestTimelineInlinePartViewModel
         && Command?.CanExecute(Target) == true;
 }
 
-public sealed class PullRequestTimelineItemViewModel
+[WinRT.GeneratedBindableCustomProperty]
+public sealed partial class PullRequestTimelineItemViewModel
 {
     public string ActorLogin { get; init; } = string.Empty;
 
@@ -47,9 +49,9 @@ public sealed class PullRequestTimelineItemViewModel
 
     public ActivityCardTone Tone { get; init; }
 
-    public IReadOnlyList<PullRequestTimelineInlinePartViewModel> SentenceParts { get; init; } = [];
+    public List<PullRequestTimelineInlinePartViewModel> SentenceParts { get; init; } = [];
 
-    public IReadOnlyList<ActivityCardDetailViewModel> Details { get; init; } = [];
+    public List<ActivityCardDetailViewModel> Details { get; init; } = [];
 
     public bool HasDetails => Details.Count > 0;
 }
@@ -97,7 +99,7 @@ public static class PullRequestTimelineItemViewModelFactory
         string? assigner = UserName(node.Assigner);
         string? milestone = node.Milestone?.Title;
 
-        IReadOnlyList<PullRequestTimelineInlinePartViewModel> sentence = state switch
+        List<PullRequestTimelineInlinePartViewModel> sentence = state switch
         {
             EventInfoState.Closed => Sentence(Strong(actor), Text(" closed this pull request")),
             EventInfoState.Reopened => Sentence(Strong(actor), Text(" reopened this pull request")),
@@ -215,7 +217,7 @@ public static class PullRequestTimelineItemViewModelFactory
         };
     }
 
-    private static IReadOnlyList<ActivityCardDetailViewModel> DetailsFor(EventNode node)
+    private static List<ActivityCardDetailViewModel> DetailsFor(EventNode node)
     {
         List<ActivityCardDetailViewModel> details = [];
         if (!string.IsNullOrWhiteSpace(node.CommitId)
@@ -398,7 +400,7 @@ public static class PullRequestTimelineItemViewModelFactory
         };
     }
 
-    private static IReadOnlyList<PullRequestTimelineInlinePartViewModel> Sentence(
+    private static List<PullRequestTimelineInlinePartViewModel> Sentence(
         params PullRequestTimelineInlinePartViewModel?[] parts)
     {
         return parts
@@ -407,7 +409,7 @@ public static class PullRequestTimelineItemViewModelFactory
             .ToList();
     }
 
-    private static IReadOnlyList<ActivityCardDetailViewModel> DetailList(params (string Glyph, string? Text)[] values)
+    private static List<ActivityCardDetailViewModel> DetailList(params (string Glyph, string? Text)[] values)
     {
         return values
             .Where(value => !string.IsNullOrWhiteSpace(value.Text))

--- a/JitHub.WinUI/ViewModels/PullRequestViewModels/MergeFormViewModel.cs
+++ b/JitHub.WinUI/ViewModels/PullRequestViewModels/MergeFormViewModel.cs
@@ -15,7 +15,7 @@ namespace JitHub.WinUI.ViewModels.PullRequestViewModels
     {
         private string _title = string.Empty;
         private string _body = string.Empty;
-        private ICollection<PullRequestMergeMethod> _items = [];
+        private List<PullRequestMergeMethod> _items = [];
         private PullRequestMergeMethod _selectedItem;
         private PullRequest _pullRequest = null!;
         private ICommand? _callback;
@@ -31,7 +31,7 @@ namespace JitHub.WinUI.ViewModels.PullRequestViewModels
             get => _body;
             set => SetProperty(ref _body, value);
         }
-        public ICollection<PullRequestMergeMethod> Items
+        public List<PullRequestMergeMethod> Items
         {
             get => _items;
             set => SetProperty(ref _items, value);

--- a/JitHub.WinUI/ViewModels/PullRequestViewModels/PullRequestCommitsViewModel.cs
+++ b/JitHub.WinUI/ViewModels/PullRequestViewModels/PullRequestCommitsViewModel.cs
@@ -18,7 +18,7 @@ namespace JitHub.WinUI.ViewModels.PullRequestViewModels
     public class PullRequestCommitsViewModel : RepoViewModel
     {
         private PullRequest _pullRequest = null!;
-        private ICollection<CommandableCommit> _commits = [];
+        private List<CommandableCommit> _commits = [];
         private readonly DataPackage _dataPackage;
 
         public PullRequest PullRequest
@@ -26,7 +26,7 @@ namespace JitHub.WinUI.ViewModels.PullRequestViewModels
             get => _pullRequest;
             set => SetProperty(ref _pullRequest, value);
         }
-        public ICollection<CommandableCommit> Commits
+        public List<CommandableCommit> Commits
         {
             get => _commits;
             set => SetProperty(ref _commits, value);

--- a/JitHub.WinUI/ViewModels/PullRequestViewModels/PullRequestConversationViewModel.cs
+++ b/JitHub.WinUI/ViewModels/PullRequestViewModels/PullRequestConversationViewModel.cs
@@ -23,7 +23,7 @@ namespace JitHub.WinUI.ViewModels.PullRequestViewModels
         private readonly ModalService _modalService;
         private Issue _asIssue = null!;
         private PullRequest _pullRequest = null!;
-        private ICollection<ConversationNode> _comments = [];
+        private List<ConversationNode> _comments = [];
         private bool _isCollaborator;
         private IssueSideBarViewModel _prModel = null!;
         private readonly ICommand _refreshCommand;
@@ -69,7 +69,7 @@ namespace JitHub.WinUI.ViewModels.PullRequestViewModels
                 CanMerge = value.Mergeable ?? false;
             }
         }
-        public ICollection<ConversationNode> Comments
+        public List<ConversationNode> Comments
         {
             get => _comments;
             set => SetProperty(ref _comments, value);

--- a/JitHub.WinUI/ViewModels/PullRequestViewModels/RepoPullRequestPostingViewModel.cs
+++ b/JitHub.WinUI/ViewModels/PullRequestViewModels/RepoPullRequestPostingViewModel.cs
@@ -15,8 +15,8 @@ namespace JitHub.WinUI.ViewModels.PullRequestViewModels
 {
     public class RepoPullRequestPostingViewModel : RepoViewModel
     {
-        private ICollection<Branch> _branches = [];
-        private ICollection<Branch> _headBranches = [];
+        private List<Branch> _branches = [];
+        private List<Branch> _headBranches = [];
         private Branch? _selectedBase;
         private Branch? _selectedHead;
         private string _title = string.Empty;
@@ -28,12 +28,12 @@ namespace JitHub.WinUI.ViewModels.PullRequestViewModels
         private string _commentsCount = string.Empty;
         private string _authorsCount = string.Empty;
 
-        public ICollection<Branch> Branches
+        public List<Branch> Branches
         {
             get => _branches;
             set => SetProperty(ref _branches, value);
         }
-        public ICollection<Branch> HeadBranches
+        public List<Branch> HeadBranches
         {
             get => _headBranches;
             set => SetProperty(ref _headBranches, value);
@@ -105,8 +105,8 @@ namespace JitHub.WinUI.ViewModels.PullRequestViewModels
             Loading = true;
             (string owner, string name) = GetRepoRoute();
             var branches = await GitHubService.GetRepoBranches(owner, name);
-            Branches = branches;
-            HeadBranches = branches;
+            Branches = branches.ToList();
+            HeadBranches = branches.ToList();
             SelectedBase = Branches.FirstOrDefault(branch => branch.Name == Repo.DefaultBranch)
                 ?? Branches.FirstOrDefault();
             SelectedHead = SelectedBase;

--- a/JitHub.WinUI/ViewModels/PullRequestViewModels/RepoPullRequestViewModel.Filter.cs
+++ b/JitHub.WinUI/ViewModels/PullRequestViewModels/RepoPullRequestViewModel.Filter.cs
@@ -95,27 +95,36 @@ namespace JitHub.WinUI.ViewModels.PullRequestViewModels
 
         private void SetFilterParam(Dictionary<string, FilterUnit> filters)
         {
-            if (filters["State"] is DropdownFilter stateFilter &&
+            PullRequestRequest = new PullRequestRequest();
+
+            if (filters.TryGetValue("State", out FilterUnit? stateUnit) &&
+                stateUnit is DropdownFilter stateFilter &&
                 !stateFilter.DefaultSelected &&
                 stateFilter.Selected.Value is ItemStateFilter selectedState)
             {
                 PullRequestRequest.State = selectedState;
             }
-            if (filters["Head"] is TextFilter headFilter && !headFilter.DefaultSelected)
+            if (filters.TryGetValue("Head", out FilterUnit? headUnit) &&
+                headUnit is TextFilter headFilter &&
+                !headFilter.DefaultSelected)
             {
                 PullRequestRequest.Head = headFilter.Text;
             }
-            if (filters["Base"] is TextFilter baseFilter && !baseFilter.DefaultSelected)
+            if (filters.TryGetValue("Base", out FilterUnit? baseUnit) &&
+                baseUnit is TextFilter baseFilter &&
+                !baseFilter.DefaultSelected)
             {
                 PullRequestRequest.Base = baseFilter.Text;
             }
-            if (filters["Sort Property"] is DropdownFilter sortPropertyFilter &&
+            if (filters.TryGetValue("Sort Property", out FilterUnit? sortPropertyUnit) &&
+                sortPropertyUnit is DropdownFilter sortPropertyFilter &&
                 !sortPropertyFilter.DefaultSelected &&
                 sortPropertyFilter.Selected.Value is PullRequestSort sortProperty)
             {
                 PullRequestRequest.SortProperty = sortProperty;
             }
-            if (filters["Direction"] is DropdownFilter directionFilter &&
+            if (filters.TryGetValue("Direction", out FilterUnit? directionUnit) &&
+                directionUnit is DropdownFilter directionFilter &&
                 !directionFilter.DefaultSelected &&
                 directionFilter.Selected.Value is SortDirection direction)
             {

--- a/JitHub.WinUI/ViewModels/RepositoryViewModels/RepoDetailViewModel.cs
+++ b/JitHub.WinUI/ViewModels/RepositoryViewModels/RepoDetailViewModel.cs
@@ -32,8 +32,8 @@ namespace JitHub.WinUI.ViewModels.RepositoryViewModels
         private Microsoft.UI.Xaml.Controls.NavigationViewItem _commitsMenuItem = null!;
         private Microsoft.UI.Xaml.Controls.NavigationViewItem? _projectsMenuItem;
         private Microsoft.UI.Xaml.Controls.NavigationViewItem? _selectedItem;
-        private ICollection<Microsoft.UI.Xaml.Controls.NavigationViewItem> _menuItems = [];
-        private ICollection<Branch> _branches = [];
+        private List<Microsoft.UI.Xaml.Controls.NavigationViewItem> _menuItems = [];
+        private List<Branch> _branches = [];
         private Branch? _selectedBranch;
         private Visibility _branchVisible;
         private bool _updatingBranchSelection;
@@ -44,7 +44,7 @@ namespace JitHub.WinUI.ViewModels.RepositoryViewModels
             set => SetProperty(ref _branchVisible, value);
         }
 
-        public ICollection<Branch> Branches
+        public List<Branch> Branches
         {
             get => _branches;
             set => SetProperty(ref _branches, value);
@@ -115,7 +115,7 @@ namespace JitHub.WinUI.ViewModels.RepositoryViewModels
             }
         }
 
-        public ICollection<Microsoft.UI.Xaml.Controls.NavigationViewItem> MenuItems
+        public List<Microsoft.UI.Xaml.Controls.NavigationViewItem> MenuItems
         {
             get => _menuItems;
             set => SetProperty(ref _menuItems, value);
@@ -331,7 +331,7 @@ namespace JitHub.WinUI.ViewModels.RepositoryViewModels
             try
             {
                 _updatingBranchSelection = true;
-                Branches = await branchesTask;
+                Branches = (await branchesTask).ToList();
                 SelectedBranch = ResolveSelectedBranch(args);
             }
             catch (Exception)

--- a/JitHub.WinUI/ViewModels/RepositoryViewModels/RepoFormViewModel.cs
+++ b/JitHub.WinUI/ViewModels/RepositoryViewModels/RepoFormViewModel.cs
@@ -22,10 +22,10 @@ namespace JitHub.WinUI.ViewModels.RepositoryViewModels
         private string _name = string.Empty;
         private string _error = string.Empty;
         private string _description = string.Empty;
-        private ICollection<RepositoryVisibility> _visibilities = [];
+        private List<RepositoryVisibility> _visibilities = [];
         private RepositoryVisibility _selectedVisibility;
         private bool _createReadme;
-        private ICollection<Models.License> _licenses = [];
+        private List<Models.License> _licenses = [];
         private Models.License? _selectedLicense;
         private ICommand? _refreshCommand;
 
@@ -44,7 +44,7 @@ namespace JitHub.WinUI.ViewModels.RepositoryViewModels
             get => _description;
             set => SetProperty(ref _description, value);
         }
-        public ICollection<RepositoryVisibility> Visibilities
+        public List<RepositoryVisibility> Visibilities
         {
             get => _visibilities;
             set => SetProperty(ref _visibilities, value);
@@ -59,7 +59,7 @@ namespace JitHub.WinUI.ViewModels.RepositoryViewModels
             get => _createReadme;
             set => SetProperty(ref _createReadme, value);
         }
-        public ICollection<Models.License> Licenses
+        public List<Models.License> Licenses
         {
             get => _licenses;
             set => SetProperty(ref _licenses, value);
@@ -73,7 +73,7 @@ namespace JitHub.WinUI.ViewModels.RepositoryViewModels
 
         public RepoFormViewModel()
         {
-            Licenses = Models.License.GetLicenses();
+            Licenses = Models.License.GetLicenses().ToList();
             Visibilities = new List<RepositoryVisibility>()
             {
                 RepositoryVisibility.Internal,

--- a/JitHub.WinUI/ViewModels/RepositoryViewModels/RepoManageViewModel.cs
+++ b/JitHub.WinUI/ViewModels/RepositoryViewModels/RepoManageViewModel.cs
@@ -158,7 +158,7 @@ namespace JitHub.WinUI.ViewModels.RepositoryViewModels
             return !repo.Repo.Repository.Private;
         }
 
-        public override ICollection<SelectableRepoModel> NewRepoList()
+        public override List<SelectableRepoModel> NewRepoList()
         {
             return new List<SelectableRepoModel>();
         }

--- a/JitHub.WinUI/ViewModels/RepositoryViewModels/RepoSearchResultViewModel.cs
+++ b/JitHub.WinUI/ViewModels/RepositoryViewModels/RepoSearchResultViewModel.cs
@@ -13,13 +13,13 @@ namespace JitHub.WinUI.ViewModels.RepositoryViewModels
 {
     public class RepoSearchResultViewModel : LoadableViewModel<string>
     {
-        private ICollection<RepoModel> _items = [];
+        private List<RepoModel> _items = [];
         public string Term
         {
             get => Model;
             set => Model = value;
         }
-        public ICollection<RepoModel> Items
+        public List<RepoModel> Items
         {
             get => _items;
             set => SetProperty(ref _items, value);

--- a/JitHub.WinUI/ViewModels/RepositoryViewModels/RepoSideBarViewModel.cs
+++ b/JitHub.WinUI/ViewModels/RepositoryViewModels/RepoSideBarViewModel.cs
@@ -85,7 +85,7 @@ public partial class RepoSideBarViewModel : RepoListViewModel<RepoModel>
         return !repo.Repository.Private;
     }
 
-    public override ICollection<RepoModel> NewRepoList()
+    public override List<RepoModel> NewRepoList()
     {
         return new List<RepoModel>();
     }

--- a/JitHub.WinUI/ViewModels/SettingsViewModel.cs
+++ b/JitHub.WinUI/ViewModels/SettingsViewModel.cs
@@ -15,9 +15,10 @@ using JitHub.WinUI.Views.Pages;
 
 namespace JitHub.WinUI.ViewModels
 {
-    public class SettingsViewModel : ObservableObject
+    [WinRT.GeneratedBindableCustomProperty]
+    public partial class SettingsViewModel : ObservableObject
     {
-        private ICollection<string> _themes = [];
+        private IList<string> _themes = new List<string>();
         private string _selectedTheme = ThemeConst.System;
         private bool _restartRequired;
         private readonly IThemeService _themeService;
@@ -27,7 +28,7 @@ namespace JitHub.WinUI.ViewModels
         private string _version = string.Empty;
         private int _clickedTime;
 
-        public ICollection<string> Themes
+        public IList<string> Themes
         {
             get => _themes;
             set => SetProperty(ref _themes, value);

--- a/JitHub.WinUI/ViewModels/ShellViewModel.cs
+++ b/JitHub.WinUI/ViewModels/ShellViewModel.cs
@@ -43,7 +43,7 @@ namespace JitHub.WinUI.ViewModels
         private bool _useHeader;
         private ObservableCollection<TabViewItem> _pages = [];
         private TabViewItem? _selectedTab;
-        private ICollection<GitHubRepository> _searchResults = [];
+        private List<GitHubRepository> _searchResults = [];
         private int _slideUpPanelHeight;
         private bool _searching;
         private IDisposable? _searchSubscription;
@@ -80,7 +80,7 @@ namespace JitHub.WinUI.ViewModels
             get => _selectedTab;
             set => SetProperty(ref _selectedTab, value);
         }
-        public ICollection<GitHubRepository> SearchResults
+        public List<GitHubRepository> SearchResults
         {
             get => _searchResults;
             set => SetProperty(ref _searchResults, value);

--- a/JitHub.WinUI/ViewModels/UserViewModel/UserCommentBlockViewModel.cs
+++ b/JitHub.WinUI/ViewModels/UserViewModel/UserCommentBlockViewModel.cs
@@ -15,23 +15,25 @@ using CommunityToolkit.WinUI.Controls;
 
 namespace JitHub.WinUI.ViewModels.UserViewModel
 {
-    public class ReactionWithUsers
+    [WinRT.GeneratedBindableCustomProperty]
+    public partial class ReactionWithUsers
     {
         public ReactionType Type { get; set; }
-        public ICollection<string> Users { get; set; } = [];
+        public List<string> Users { get; set; } = [];
         public bool Voted { get; set; }
         public ICommand ReactionCommand { get; set; } = null!;
 
-        public ReactionWithUsers(ReactionType type, ICollection<string> users, bool voted, ICommand reactionCommand)
+        public ReactionWithUsers(ReactionType type, IEnumerable<string> users, bool voted, ICommand reactionCommand)
         {
             Type = type;
-            Users = users;
+            Users = users.ToList();
             Voted = voted;
             ReactionCommand = reactionCommand;
         }
     }
 
-    public class UserCommentBlockViewModel : RepoViewModel
+    [WinRT.GeneratedBindableCustomProperty]
+    public partial class UserCommentBlockViewModel : RepoViewModel
     {
         private string _body = string.Empty;
         private MarkdownConfig _markdownConfig = null!;
@@ -48,7 +50,7 @@ namespace JitHub.WinUI.ViewModels.UserViewModel
         private MenuItem _quoteReplyMenuItem = null!;
         private EmojiPanelViewModel? _emojiPanelViewModel;
         private Dictionary<ReactionType, Reaction> _votesMap = [];
-        private ICollection<ReactionWithUsers> _reactionWithUsers = [];
+        private List<ReactionWithUsers> _reactionWithUsers = [];
 
         public string Body
         {
@@ -111,7 +113,7 @@ namespace JitHub.WinUI.ViewModels.UserViewModel
             set => SetProperty(ref _emojiPanelViewModel, value);
         }
 
-        public ICollection<ReactionWithUsers> ReactionWithUsers
+        public List<ReactionWithUsers> ReactionWithUsers
         {
             get => _reactionWithUsers;
             set => SetProperty(ref _reactionWithUsers, value);

--- a/JitHub.WinUI/Views/Controls/App/ActivityCard.xaml
+++ b/JitHub.WinUI/Views/Controls/App/ActivityCard.xaml
@@ -2,6 +2,7 @@
     x:Class="JitHub.WinUI.Views.Controls.App.ActivityCard"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:activities="using:JitHub.Models.Activities"
     xmlns:common="using:JitHub.WinUI.Views.Controls.Common"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
@@ -41,7 +42,7 @@
         Padding="16"
         HorizontalAlignment="Stretch"
         Background="{ThemeResource AppSurfaceBrush}"
-        BorderBrush="{Binding Tone, Converter={StaticResource ActivityToneToBrushConverter}, ConverterParameter=Border}"
+        BorderBrush="{x:Bind ViewModel.Tone, Converter={StaticResource ActivityToneToBrushConverter}, ConverterParameter=Border, Mode=OneWay}"
         BorderThickness="1"
         CornerRadius="{ThemeResource AppRadiusLarge}">
         <Grid ColumnSpacing="12">
@@ -53,10 +54,10 @@
             <common:Avatar
                 Margin="0,3,0,0"
                 VerticalAlignment="Top"
-                Login="{Binding ActorLogin, Mode=OneWay}"
+                Login="{x:Bind ViewModel.ActorLogin, Mode=OneWay}"
                 ShowLogin="False"
                 Size="SMALL"
-                Url="{Binding ActorAvatarUrl, Mode=OneWay}" />
+                Url="{x:Bind ViewModel.ActorAvatarUrl, Mode=OneWay}" />
 
             <StackPanel
                 Grid.Column="1"
@@ -73,14 +74,14 @@
                         Margin="0,1,0,0"
                         VerticalAlignment="Top"
                         Background="{ThemeResource AppSurfaceSubtleBrush}"
-                        BorderBrush="{Binding Tone, Converter={StaticResource ActivityToneToBrushConverter}, ConverterParameter=Border}"
+                        BorderBrush="{x:Bind ViewModel.Tone, Converter={StaticResource ActivityToneToBrushConverter}, ConverterParameter=Border, Mode=OneWay}"
                         BorderThickness="1"
                         CornerRadius="{ThemeResource AppRadiusSmall}">
                         <FontIcon
                             FontFamily="{StaticResource SegoeFluentIcons}"
                             FontSize="13"
-                            Foreground="{Binding Tone, Converter={StaticResource ActivityToneToBrushConverter}}"
-                            Glyph="{Binding Glyph}" />
+                            Foreground="{x:Bind ViewModel.Tone, Converter={StaticResource ActivityToneToBrushConverter}, Mode=OneWay}"
+                            Glyph="{x:Bind ViewModel.Glyph, Mode=OneWay}" />
                     </Border>
 
                     <RichTextBlock
@@ -106,21 +107,21 @@
                 <TextBlock
                     Margin="34,-4,0,0"
                     Style="{StaticResource SectionSecondaryTextBlockStyle}"
-                    Text="{Binding TimestampText, Mode=OneWay}" />
+                    Text="{x:Bind ViewModel.TimestampText, Mode=OneWay}" />
 
                 <Border
                     Padding="12,0,0,0"
-                    BorderBrush="{Binding Tone, Converter={StaticResource ActivityToneToBrushConverter}, ConverterParameter=Border}"
+                    BorderBrush="{x:Bind ViewModel.Tone, Converter={StaticResource ActivityToneToBrushConverter}, ConverterParameter=Border, Mode=OneWay}"
                     BorderThickness="2,0,0,0"
-                    Visibility="{Binding HasDetails, Converter={StaticResource BoolToVisibilityConverter}}">
-                    <ItemsControl ItemsSource="{Binding Details}">
+                    Visibility="{x:Bind ViewModel.HasDetails, Converter={StaticResource BoolToVisibilityConverter}, Mode=OneWay}">
+                    <ItemsControl ItemsSource="{x:Bind ViewModel.Details, Mode=OneWay}">
                         <ItemsControl.ItemsPanel>
                             <ItemsPanelTemplate>
                                 <StackPanel Spacing="4" />
                             </ItemsPanelTemplate>
                         </ItemsControl.ItemsPanel>
                         <ItemsControl.ItemTemplate>
-                            <DataTemplate>
+                            <DataTemplate x:DataType="activities:ActivityCardDetailViewModel">
                                 <Grid ColumnSpacing="8">
                                     <Grid.ColumnDefinitions>
                                         <ColumnDefinition Width="Auto" />
@@ -132,11 +133,11 @@
                                         FontFamily="{StaticResource SegoeFluentIcons}"
                                         FontSize="11"
                                         Foreground="{ThemeResource AppInkMutedBrush}"
-                                        Glyph="{Binding Glyph}" />
+                                        Glyph="{x:Bind Glyph, Mode=OneWay}" />
                                     <TextBlock
                                         Grid.Column="1"
                                         Style="{StaticResource SectionSecondaryTextBlockStyle}"
-                                        Text="{Binding Text}"
+                                        Text="{x:Bind Text, Mode=OneWay}"
                                         TextTrimming="CharacterEllipsis"
                                         TextWrapping="NoWrap" />
                                 </Grid>

--- a/JitHub.WinUI/Views/Controls/App/ActivityCard.xaml.cs
+++ b/JitHub.WinUI/Views/Controls/App/ActivityCard.xaml.cs
@@ -10,6 +10,8 @@ namespace JitHub.WinUI.Views.Controls.App;
 
 public sealed partial class ActivityCard : UserControl
 {
+    public ActivityCardViewModel? ViewModel { get; private set; }
+
     public ActivityCard()
     {
         InitializeComponent();
@@ -18,6 +20,8 @@ public sealed partial class ActivityCard : UserControl
 
     private void OnDataContextChanged(FrameworkElement sender, DataContextChangedEventArgs args)
     {
+        ViewModel = args.NewValue as ActivityCardViewModel;
+        Bindings.Update();
         RenderSentence();
     }
 
@@ -29,15 +33,18 @@ public sealed partial class ActivityCard : UserControl
         }
 
         SentenceRichTextBlock.Blocks.Clear();
-        if (DataContext is not ActivityCardViewModel activity)
+        if (ViewModel is not ActivityCardViewModel activity)
         {
             return;
         }
 
         var paragraph = new Paragraph();
-        IReadOnlyList<ActivitySentencePartViewModel> parts = activity.SentenceParts.Count > 0
+        List<ActivitySentencePartViewModel> parts = activity.SentenceParts.Count > 0
             ? activity.SentenceParts
-            : [new ActivitySentencePartViewModel { Text = activity.Title, IsEmphasized = true }];
+            :
+            [
+                new ActivitySentencePartViewModel { Text = activity.Title, IsEmphasized = true }
+            ];
 
         foreach (ActivitySentencePartViewModel part in parts)
         {

--- a/JitHub.WinUI/Views/Controls/App/AppIcon.xaml.cs
+++ b/JitHub.WinUI/Views/Controls/App/AppIcon.xaml.cs
@@ -14,6 +14,7 @@ public enum AppIconKind
     PrivateRepository
 }
 
+[WinRT.GeneratedBindableCustomProperty]
 public sealed partial class AppIcon : UserControl
 {
     public static readonly DependencyProperty IconKindProperty = DependencyProperty.Register(

--- a/JitHub.WinUI/Views/Controls/App/AppSectionHeader.xaml.cs
+++ b/JitHub.WinUI/Views/Controls/App/AppSectionHeader.xaml.cs
@@ -3,6 +3,7 @@ using Microsoft.UI.Xaml.Controls;
 
 namespace JitHub.WinUI.Views.Controls.App;
 
+[WinRT.GeneratedBindableCustomProperty]
 public sealed partial class AppSectionHeader : UserControl
 {
     public static readonly DependencyProperty EyebrowProperty = DependencyProperty.Register(nameof(Eyebrow), typeof(string), typeof(AppSectionHeader), new PropertyMetadata(string.Empty));

--- a/JitHub.WinUI/Views/Controls/App/AppSettingsCard.xaml.cs
+++ b/JitHub.WinUI/Views/Controls/App/AppSettingsCard.xaml.cs
@@ -3,6 +3,7 @@ using Microsoft.UI.Xaml.Controls;
 
 namespace JitHub.WinUI.Views.Controls.App;
 
+[WinRT.GeneratedBindableCustomProperty]
 public sealed partial class AppSettingsCard : UserControl
 {
     public static readonly DependencyProperty HeaderProperty = DependencyProperty.Register(nameof(Header), typeof(string), typeof(AppSettingsCard), new PropertyMetadata(string.Empty));

--- a/JitHub.WinUI/Views/Controls/App/AppSidebarSection.xaml.cs
+++ b/JitHub.WinUI/Views/Controls/App/AppSidebarSection.xaml.cs
@@ -3,6 +3,7 @@ using Microsoft.UI.Xaml.Controls;
 
 namespace JitHub.WinUI.Views.Controls.App;
 
+[WinRT.GeneratedBindableCustomProperty]
 public sealed partial class AppSidebarSection : UserControl
 {
     public static readonly DependencyProperty TitleProperty = DependencyProperty.Register(nameof(Title), typeof(string), typeof(AppSidebarSection), new PropertyMetadata(string.Empty));

--- a/JitHub.WinUI/Views/Controls/App/AppStatButton.xaml.cs
+++ b/JitHub.WinUI/Views/Controls/App/AppStatButton.xaml.cs
@@ -5,6 +5,7 @@ using Microsoft.UI.Xaml.Media;
 
 namespace JitHub.WinUI.Views.Controls.App;
 
+[WinRT.GeneratedBindableCustomProperty]
 public sealed partial class AppStatButton : UserControl
 {
     public static readonly DependencyProperty IconGlyphProperty = DependencyProperty.Register(nameof(IconGlyph), typeof(string), typeof(AppStatButton), new PropertyMetadata(string.Empty));

--- a/JitHub.WinUI/Views/Controls/App/AppSurfaceCard.xaml.cs
+++ b/JitHub.WinUI/Views/Controls/App/AppSurfaceCard.xaml.cs
@@ -4,6 +4,7 @@ using Microsoft.UI.Xaml.Controls;
 
 namespace JitHub.WinUI.Views.Controls.App;
 
+[WinRT.GeneratedBindableCustomProperty]
 public sealed partial class AppSurfaceCard : UserControl
 {
     public static readonly DependencyProperty ChildProperty = DependencyProperty.Register(

--- a/JitHub.WinUI/Views/Controls/Code/CodeButton.xaml.cs
+++ b/JitHub.WinUI/Views/Controls/Code/CodeButton.xaml.cs
@@ -27,13 +27,13 @@ namespace JitHub.WinUI.Views.Controls.Code
             nameof(Ref),
             typeof(string),
             typeof(CodeButton),
-            new PropertyMetadata(default(string), null)
+            new PropertyMetadata(default(string), OnBindablePropertyChanged)
         );
         public static DependencyProperty TextProperty = DependencyProperty.Register(
             nameof(Text),
             typeof(string),
             typeof(CodeButton),
-            new PropertyMetadata(default(string), null)
+            new PropertyMetadata(default(string), OnBindablePropertyChanged)
         );
 
         public RepositoryModel? Repo
@@ -56,6 +56,14 @@ namespace JitHub.WinUI.Views.Controls.Code
             this.InitializeComponent();
             _navigationService = Ioc.Default.GetService<NavigationService>()
                 ?? throw new InvalidOperationException("NavigationService is not registered.");
+        }
+
+        private static void OnBindablePropertyChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+        {
+            if (d is CodeButton self)
+            {
+                self.Bindings.Update();
+            }
         }
 
         private void OnClick(object sender, RoutedEventArgs args)

--- a/JitHub.WinUI/Views/Controls/CodeViewer/Renderers/JsonPreview.xaml.cs
+++ b/JitHub.WinUI/Views/Controls/CodeViewer/Renderers/JsonPreview.xaml.cs
@@ -1,4 +1,6 @@
 using System;
+using System.IO;
+using System.Text;
 using System.Text.Json;
 using System.Threading.Tasks;
 using JitHub.WinUI.ViewModels.CodeViewer;
@@ -67,8 +69,13 @@ public sealed partial class JsonPreview : UserControl
             try
             {
                 using var doc = JsonDocument.Parse(text);
-                pretty = JsonSerializer.Serialize(doc.RootElement,
-                    new JsonSerializerOptions { WriteIndented = true });
+                using var stream = new MemoryStream();
+                using (var writer = new Utf8JsonWriter(stream, new JsonWriterOptions { Indented = true }))
+                {
+                    doc.RootElement.WriteTo(writer);
+                }
+
+                pretty = Encoding.UTF8.GetString(stream.ToArray());
             }
             catch
             {

--- a/JitHub.WinUI/Views/Controls/CodeViewer/RepoCodeBreadcrumb.xaml.cs
+++ b/JitHub.WinUI/Views/Controls/CodeViewer/RepoCodeBreadcrumb.xaml.cs
@@ -12,6 +12,7 @@ namespace JitHub.WinUI.Views.Controls.CodeViewer;
 /// <see cref="CanGoBack"/>, and <see cref="CanGoForward"/> from
 /// <c>RepoCodePageViewModel</c> in the page.
 /// </summary>
+[WinRT.GeneratedBindableCustomProperty]
 public sealed partial class RepoCodeBreadcrumb : UserControl
 {
     // ── Dependency Properties ─────────────────────────────────────────────

--- a/JitHub.WinUI/Views/Controls/CodeViewer/RepoFileTreeView.xaml
+++ b/JitHub.WinUI/Views/Controls/CodeViewer/RepoFileTreeView.xaml
@@ -5,6 +5,7 @@
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:local="using:JitHub.WinUI.Views.Controls.CodeViewer"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
     xmlns:viewmodels="using:JitHub.WinUI.ViewModels.CodeViewer"
     d:DesignHeight="600"
     d:DesignWidth="280"
@@ -60,8 +61,8 @@
                     We use a ContentControl to bridge: its Content is bound (non-compiled) to
                     TreeViewNode.Content, and the typed inner DataTemplate gets our VM directly.
                 -->
-                <DataTemplate>
-                    <ContentControl Content="{Binding Content}">
+                <DataTemplate x:DataType="muxc:TreeViewNode">
+                    <ContentControl Content="{x:Bind Content, Mode=OneWay}">
                         <ContentControl.ContentTemplate>
                             <DataTemplate x:DataType="viewmodels:RepoTreeNodeViewModel">
                                 <Grid ColumnSpacing="6" HorizontalAlignment="Left">

--- a/JitHub.WinUI/Views/Controls/Commit/CommitButton.xaml.cs
+++ b/JitHub.WinUI/Views/Controls/Commit/CommitButton.xaml.cs
@@ -21,14 +21,14 @@ namespace JitHub.WinUI.Views.Controls.Commit
             nameof(CommitId),
             typeof(string),
             typeof(CommitButton),
-            new PropertyMetadata(default(string), null)
+            new PropertyMetadata(default(string), OnBindablePropertyChanged)
         );
 
         public static DependencyProperty TextProperty = DependencyProperty.Register(
             nameof(Text),
             typeof(string),
             typeof(CommitButton),
-            new PropertyMetadata(default(string), null)
+            new PropertyMetadata(default(string), OnBindablePropertyChanged)
         );
 
         public static DependencyProperty RepoProperty = DependencyProperty.Register(
@@ -58,6 +58,14 @@ namespace JitHub.WinUI.Views.Controls.Commit
             this.InitializeComponent();
             _navigationService = Ioc.Default.GetService<NavigationService>()
                 ?? throw new InvalidOperationException("NavigationService is not registered.");
+        }
+
+        private static void OnBindablePropertyChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+        {
+            if (d is CommitButton self)
+            {
+                self.Bindings.Update();
+            }
         }
 
         private void OnClick(object sender, RoutedEventArgs e)

--- a/JitHub.WinUI/Views/Controls/Commit/CommitDetail.xaml.cs
+++ b/JitHub.WinUI/Views/Controls/Commit/CommitDetail.xaml.cs
@@ -16,9 +16,8 @@ public sealed partial class CommitDetail : UserControl
 
     private static void OnCommitChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
     {
-        if (d is CommitDetail self && e.NewValue != null)
+        if (d is CommitDetail self && e.NewValue is CommandableCommit commit)
         {
-            var commit = self.DataContext as CommandableCommit;
             self.DetailPageFrame.Navigate(typeof(RepoCommitDetailPage), commit);
         }
     }

--- a/JitHub.WinUI/Views/Controls/Commit/CommitItem.xaml.cs
+++ b/JitHub.WinUI/Views/Controls/Commit/CommitItem.xaml.cs
@@ -27,6 +27,7 @@ namespace JitHub.WinUI.Views.Controls.Commit
             if (d is CommitItem self && e.NewValue != null)
             {
                 self.DataContext = e.NewValue;
+                self.Bindings.Update();
             }
         }
 

--- a/JitHub.WinUI/Views/Controls/Commit/CommitListDetailsDetailPresenter.xaml
+++ b/JitHub.WinUI/Views/Controls/Commit/CommitListDetailsDetailPresenter.xaml
@@ -1,0 +1,14 @@
+<UserControl
+    x:Class="JitHub.WinUI.Views.Controls.Commit.CommitListDetailsDetailPresenter"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:commit="using:JitHub.WinUI.Views.Controls.Commit"
+    mc:Ignorable="d"
+    d:DesignHeight="300"
+    d:DesignWidth="600">
+    <Grid Padding="4">
+        <commit:CommitDetail x:Name="CommitDetailControl" />
+    </Grid>
+</UserControl>

--- a/JitHub.WinUI/Views/Controls/Commit/CommitListDetailsDetailPresenter.xaml.cs
+++ b/JitHub.WinUI/Views/Controls/Commit/CommitListDetailsDetailPresenter.xaml.cs
@@ -1,0 +1,45 @@
+using JitHub.Models;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+
+namespace JitHub.WinUI.Views.Controls.Commit;
+
+public sealed partial class CommitListDetailsDetailPresenter : UserControl
+{
+    public static readonly DependencyProperty ItemProperty = DependencyProperty.Register(
+        nameof(Item),
+        typeof(object),
+        typeof(CommitListDetailsDetailPresenter),
+        new PropertyMetadata(default(object), OnItemChanged));
+
+    public object? Item
+    {
+        get => GetValue(ItemProperty);
+        set => SetValue(ItemProperty, value);
+    }
+
+    public CommitListDetailsDetailPresenter()
+    {
+        InitializeComponent();
+    }
+
+    private static void OnItemChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+    {
+        if (d is CommitListDetailsDetailPresenter self)
+        {
+            self.Render();
+        }
+    }
+
+    private void Render()
+    {
+        CommandableCommit? commit = ResolveCommit(Item);
+        if (commit is not null)
+        {
+            CommitDetailControl.Commit = commit;
+        }
+    }
+
+    private static CommandableCommit? ResolveCommit(object? value)
+        => value as CommandableCommit;
+}

--- a/JitHub.WinUI/Views/Controls/Commit/CommitListDetailsItemPresenter.xaml
+++ b/JitHub.WinUI/Views/Controls/Commit/CommitListDetailsItemPresenter.xaml
@@ -1,0 +1,11 @@
+<UserControl
+    x:Class="JitHub.WinUI.Views.Controls.Commit.CommitListDetailsItemPresenter"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d"
+    d:DesignHeight="96"
+    d:DesignWidth="420">
+    <Grid x:Name="PresenterRoot" />
+</UserControl>

--- a/JitHub.WinUI/Views/Controls/Commit/CommitListDetailsItemPresenter.xaml.cs
+++ b/JitHub.WinUI/Views/Controls/Commit/CommitListDetailsItemPresenter.xaml.cs
@@ -1,0 +1,78 @@
+using JitHub.Models;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+
+namespace JitHub.WinUI.Views.Controls.Commit;
+
+public sealed partial class CommitListDetailsItemPresenter : UserControl
+{
+    public static readonly DependencyProperty ItemProperty = DependencyProperty.Register(
+        nameof(Item),
+        typeof(object),
+        typeof(CommitListDetailsItemPresenter),
+        new PropertyMetadata(default(object), OnItemChanged));
+
+    public static readonly DependencyProperty ShowHoverMenuProperty = DependencyProperty.Register(
+        nameof(ShowHoverMenu),
+        typeof(bool),
+        typeof(CommitListDetailsItemPresenter),
+        new PropertyMetadata(default(bool), OnShowHoverMenuChanged));
+
+    private CommitItem? _commitItem;
+
+    public object? Item
+    {
+        get => GetValue(ItemProperty);
+        set => SetValue(ItemProperty, value);
+    }
+
+    public bool ShowHoverMenu
+    {
+        get => (bool)GetValue(ShowHoverMenuProperty);
+        set => SetValue(ShowHoverMenuProperty, value);
+    }
+
+    public CommitListDetailsItemPresenter()
+    {
+        InitializeComponent();
+    }
+
+    private static void OnItemChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+    {
+        if (d is CommitListDetailsItemPresenter self)
+        {
+            self.Render();
+        }
+    }
+
+    private static void OnShowHoverMenuChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+    {
+        if (d is CommitListDetailsItemPresenter self && self._commitItem is not null)
+        {
+            self._commitItem.ShowHoverMenu = self.ShowHoverMenu;
+        }
+    }
+
+    private void Render()
+    {
+        CommandableCommit? commit = ResolveCommit(Item);
+        if (commit is null)
+        {
+            PresenterRoot.Children.Clear();
+            _commitItem = null;
+            return;
+        }
+
+        _commitItem ??= new CommitItem();
+        _commitItem.ShowHoverMenu = ShowHoverMenu;
+        _commitItem.ViewModel = commit;
+
+        if (PresenterRoot.Children.Count == 0)
+        {
+            PresenterRoot.Children.Add(_commitItem);
+        }
+    }
+
+    private static CommandableCommit? ResolveCommit(object? value)
+        => value as CommandableCommit;
+}

--- a/JitHub.WinUI/Views/Controls/Commit/FileDiff.xaml
+++ b/JitHub.WinUI/Views/Controls/Commit/FileDiff.xaml
@@ -15,11 +15,11 @@
         <common:CommentBlock
             Margin="0 10 0 0">
             <common:CommentBlock.HeaderContent>
-                <TextBlock Text="{x:Bind ViewModel.File.Filename, Mode=OneWay}"/>
+                <TextBlock Text="{x:Bind ViewModel.File.HeaderText, Mode=OneWay}"/>
             </common:CommentBlock.HeaderContent>
             <common:CommentBlock.BodyContent>
                 <pullrequest:DiffTextBlock
-                    Patch="{x:Bind ViewModel.File.Patch, Mode=OneWay}"/>
+                    Patch="{x:Bind ViewModel.File.PatchDisplayText, Mode=OneWay}"/>
             </common:CommentBlock.BodyContent>
         </common:CommentBlock>
     </Grid>

--- a/JitHub.WinUI/Views/Controls/Commit/FileDiff.xaml.cs
+++ b/JitHub.WinUI/Views/Controls/Commit/FileDiff.xaml.cs
@@ -20,6 +20,7 @@ namespace JitHub.WinUI.Views.Controls.Commit
             if (d is FileDiff self && e.NewValue != null)
             {
                 self.DataContext = (FileDiffViewModel)e.NewValue;
+                self.Bindings.Update();
             }
         }
 

--- a/JitHub.WinUI/Views/Controls/Common/Avatar.xaml.cs
+++ b/JitHub.WinUI/Views/Controls/Common/Avatar.xaml.cs
@@ -15,7 +15,7 @@ namespace JitHub.WinUI.Views.Controls.Common
             "Size",
             typeof(UISize),
             typeof(Avatar),
-            new PropertyMetadata(default(UISize), null));
+            new PropertyMetadata(default(UISize), OnBindablePropertyChanged));
         public static DependencyProperty UrlProperty = DependencyProperty.Register(
             "Url",
             typeof(string),
@@ -25,12 +25,12 @@ namespace JitHub.WinUI.Views.Controls.Common
             "Login",
             typeof(string),
             typeof(Avatar),
-            new PropertyMetadata(default(string), null));
+            new PropertyMetadata(default(string), OnBindablePropertyChanged));
         public static DependencyProperty ShowLoginProperty = DependencyProperty.Register(
             "ShowLogin",
             typeof(bool),
             typeof(Avatar),
-            new PropertyMetadata(default(string), null));
+            new PropertyMetadata(default(bool), OnBindablePropertyChanged));
 
         private static void OnUrlChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
         {
@@ -45,6 +45,16 @@ namespace JitHub.WinUI.Views.Controls.Common
                 {
                     self.ProfilePic.Source = new BitmapImage(new Uri("ms-appx:///Assets/Octocat.png"));
                 }
+
+                self.Bindings.Update();
+            }
+        }
+
+        private static void OnBindablePropertyChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+        {
+            if (d is Avatar self)
+            {
+                self.Bindings.Update();
             }
         }
 

--- a/JitHub.WinUI/Views/Controls/Common/CommentBlock.xaml.cs
+++ b/JitHub.WinUI/Views/Controls/Common/CommentBlock.xaml.cs
@@ -11,14 +11,14 @@ namespace JitHub.WinUI.Views.Controls.Common
             nameof(HeaderContent),
             typeof(FrameworkElement),
             typeof(CommentBlock),
-            new PropertyMetadata(default(FrameworkElement), null)
+            new PropertyMetadata(default(FrameworkElement), OnBindablePropertyChanged)
             );
 
         public static DependencyProperty BodyContentProperty = DependencyProperty.Register(
             nameof(BodyContent),
             typeof(FrameworkElement),
             typeof(CommentBlock),
-            new PropertyMetadata(default(FrameworkElement), null)
+            new PropertyMetadata(default(FrameworkElement), OnBindablePropertyChanged)
             );
 
         public FrameworkElement HeaderContent
@@ -42,6 +42,14 @@ namespace JitHub.WinUI.Views.Controls.Common
         public CommentBlock()
         {
             this.InitializeComponent();
+        }
+
+        private static void OnBindablePropertyChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+        {
+            if (d is CommentBlock self)
+            {
+                self.Bindings.Update();
+            }
         }
     }
 }

--- a/JitHub.WinUI/Views/Controls/Common/CreditPersonaleButton.xaml.cs
+++ b/JitHub.WinUI/Views/Controls/Common/CreditPersonaleButton.xaml.cs
@@ -16,7 +16,7 @@ namespace JitHub.WinUI.Views.Controls.Common
             nameof(Person),
             typeof(CreditPersonale),
             typeof(CreditPersonaleButton),
-            new PropertyMetadata(default(CreditPersonale), null)
+            new PropertyMetadata(default(CreditPersonale), OnPersonChanged)
         );
 
         private readonly ModalService _modalService;
@@ -31,6 +31,14 @@ namespace JitHub.WinUI.Views.Controls.Common
             this.InitializeComponent();
             _modalService = Ioc.Default.GetService<ModalService>()
                 ?? throw new InvalidOperationException("ModalService is not registered.");
+        }
+
+        private static void OnPersonChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+        {
+            if (d is CreditPersonaleButton self)
+            {
+                self.Bindings.Update();
+            }
         }
 
         private void OnClose()

--- a/JitHub.WinUI/Views/Controls/Common/CreditPersonaleDialog.xaml
+++ b/JitHub.WinUI/Views/Controls/Common/CreditPersonaleDialog.xaml
@@ -3,6 +3,7 @@
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:local="using:JitHub.WinUI.Views.Controls.Common"
+    xmlns:models="using:JitHub.Models"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
@@ -80,14 +81,14 @@
                     <muxc:StackLayout Orientation="Horizontal" Spacing="8"/>
                 </muxc:ItemsRepeater.Layout>
                 <muxc:ItemsRepeater.ItemTemplate>
-                    <DataTemplate>
+                    <DataTemplate x:DataType="models:PersonalLink">
                         <Grid>
                             <HyperlinkButton
                                 Padding="0"
-                                NavigateUri="{Binding Link, Mode=OneWay}">
+                                NavigateUri="{x:Bind Link, Mode=OneWay}">
                                 <Image
                                     Width="32"
-                                    Source="{Binding LogoSource, Mode=OneWay}"/>
+                                    Source="{x:Bind LogoSource, Mode=OneWay}"/>
                             </HyperlinkButton>
                         </Grid>
                     </DataTemplate>

--- a/JitHub.WinUI/Views/Controls/Common/CreditPersonaleDialog.xaml.cs
+++ b/JitHub.WinUI/Views/Controls/Common/CreditPersonaleDialog.xaml.cs
@@ -1,6 +1,6 @@
 using JitHub.Models;
+using System;
 using System.Windows.Input;
-using Windows.UI;
 using Microsoft.UI.Xaml.Controls;
 
 // The User Control item template is documented at https://go.microsoft.com/fwlink/?LinkId=234236
@@ -9,13 +9,14 @@ namespace JitHub.WinUI.Views.Controls.Common
 {
     public sealed partial class CreditPersonaleDialog : UserControl
     {
-        public CreditPersonale Person { get; set; }
-        public ICommand CancelCommand { get; set; }
+        public CreditPersonale Person { get; }
+        public ICommand CancelCommand { get; }
+
         public CreditPersonaleDialog(CreditPersonale person, ICommand cancelCommand)
         {
+            Person = person ?? throw new ArgumentNullException(nameof(person));
+            CancelCommand = cancelCommand ?? throw new ArgumentNullException(nameof(cancelCommand));
             this.InitializeComponent();
-            Person = person;
-            CancelCommand = cancelCommand;
         }
     }
 }

--- a/JitHub.WinUI/Views/Controls/Common/EmojiButton.xaml.cs
+++ b/JitHub.WinUI/Views/Controls/Common/EmojiButton.xaml.cs
@@ -17,38 +17,38 @@ namespace JitHub.WinUI.Views.Controls.Common
             nameof(Reaction),
             typeof(ReactionType),
             typeof(EmojiButton),
-            new PropertyMetadata(default(ReactionType), null)
+            new PropertyMetadata(default(ReactionType), OnBindablePropertyChanged)
         );
 
         public static DependencyProperty ReactionCommandProperty = DependencyProperty.Register(
             nameof(ReactionCommand),
             typeof(ICommand),
             typeof(EmojiButton),
-            new PropertyMetadata(null));
+            new PropertyMetadata(null, OnBindablePropertyChanged));
 
         public static DependencyProperty ReactionCountProperty = DependencyProperty.Register(
             nameof(ReactionCount),
             typeof(int),
             typeof(EmojiButton),
-            new PropertyMetadata(default(int), null));
+            new PropertyMetadata(default(int), OnBindablePropertyChanged));
 
         public static DependencyProperty ShowReactionCountProperty = DependencyProperty.Register(
             nameof(ShowReactionCount),
             typeof(bool),
             typeof(EmojiButton),
-            new PropertyMetadata((bool)false, null));
+            new PropertyMetadata(false, OnBindablePropertyChanged));
 
         public static DependencyProperty VotedProperty = DependencyProperty.Register(
             nameof(Voted),
             typeof(bool),
             typeof (EmojiButton),
-            new PropertyMetadata(default(bool), null));
+            new PropertyMetadata(default(bool), OnBindablePropertyChanged));
 
         public static DependencyProperty UsersProperty = DependencyProperty.Register(
             nameof(Users),
             typeof(object),
             typeof(EmojiButton),
-            new PropertyMetadata(null));
+            new PropertyMetadata(null, OnBindablePropertyChanged));
 
 
 
@@ -91,6 +91,14 @@ namespace JitHub.WinUI.Views.Controls.Common
         public EmojiButton()
         {
             this.InitializeComponent();
+        }
+
+        private static void OnBindablePropertyChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+        {
+            if (d is EmojiButton self)
+            {
+                self.Bindings.Update();
+            }
         }
 
         public Thickness GetPadding(bool showReactionCount)

--- a/JitHub.WinUI/Views/Controls/Common/EmojiPanelButton.xaml.cs
+++ b/JitHub.WinUI/Views/Controls/Common/EmojiPanelButton.xaml.cs
@@ -17,6 +17,7 @@ namespace JitHub.WinUI.Views.Controls.Common
             if (d is EmojiPanelButton self && args.NewValue != null)
             {
                 self.DataContext = self.ViewModel;
+                self.Bindings.Update();
             }
         }
 

--- a/JitHub.WinUI/Views/Controls/Common/EmptyStateView.xaml.cs
+++ b/JitHub.WinUI/Views/Controls/Common/EmptyStateView.xaml.cs
@@ -3,6 +3,7 @@ using Microsoft.UI.Xaml.Controls;
 
 namespace JitHub.WinUI.Views.Controls.Common;
 
+[WinRT.GeneratedBindableCustomProperty]
 public sealed partial class EmptyStateView : UserControl
 {
     public static readonly DependencyProperty TitleProperty = DependencyProperty.Register(

--- a/JitHub.WinUI/Views/Controls/Common/GroupFilters.xaml.cs
+++ b/JitHub.WinUI/Views/Controls/Common/GroupFilters.xaml.cs
@@ -1,9 +1,11 @@
 using JitHub.Models;
 using JitHub.Models.Filter;
+using JitHub.WinUI.Views.Controls.Filter;
 using System.Collections.Generic;
 using System.Windows.Input;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Media;
 
 // The User Control item template is documented at https://go.microsoft.com/fwlink/?LinkId=234236
 
@@ -15,7 +17,7 @@ namespace JitHub.WinUI.Views.Controls.Common
             nameof(Filters),
             typeof(object),
             typeof(GroupFilters),
-            new PropertyMetadata(null));
+            new PropertyMetadata(null, OnFiltersChanged));
 
         public static DependencyProperty ApplyFilterCommandProperty = DependencyProperty.Register(
             nameof(ApplyFilterCommand),
@@ -29,7 +31,7 @@ namespace JitHub.WinUI.Views.Controls.Common
             typeof(GroupFilters),
             new PropertyMetadata(default(ICommand), null));
 
-        public Dictionary<string, FilterUnit> FiltersDictionary { get; }
+        public Dictionary<string, FilterUnit> FiltersDictionary { get; } = new();
 
         public ICommand ApplyFilterCommand
         {
@@ -46,40 +48,100 @@ namespace JitHub.WinUI.Views.Controls.Common
         public EventfulCollection<FilterUnit> Filters
         {
             get => (EventfulCollection<FilterUnit>)GetValue(FiltersProperty);
-            set
-            {
-                SetValue(FiltersProperty, value);
-                if (value is null)
-                {
-                    return;
-                }
-
-                Filters.Action = (item) =>
-                {
-                    FiltersDictionary.Add(item.Name, item);
-                };
-            }
+            set => SetValue(FiltersProperty, value);
         }
 
         public GroupFilters()
         {
             this.InitializeComponent();
-            FiltersDictionary = new Dictionary<string, FilterUnit>();
+        }
+
+        private static void OnFiltersChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+        {
+            if (d is not GroupFilters self)
+            {
+                return;
+            }
+
+            self.FiltersDictionary.Clear();
+            if (e.NewValue is EventfulCollection<FilterUnit> filters)
+            {
+                foreach (var item in filters.Instance)
+                {
+                    self.FiltersDictionary[item.Name] = item;
+                }
+
+                filters.Action = item =>
+                {
+                    self.FiltersDictionary[item.Name] = item;
+                };
+            }
+
+            self.Bindings.Update();
         }
 
         private void OnClearButtonClick(object sender, RoutedEventArgs e)
         {
+            CommitFilterPresenterValues(this);
             //TODO: need to get the default dictionary
             foreach (var key in FiltersDictionary.Keys)
             {
                 FiltersDictionary[key].SetDefault();
             }
+            RefreshFilterPresenterValues(this);
             ClearFilterCommand.Execute(FiltersDictionary);
         }
 
         private void OnFilterButtonClick(object sender, RoutedEventArgs e)
         {
+            CommitFilterPresenterValues(this);
             ApplyFilterCommand.Execute(FiltersDictionary);
+        }
+
+        private static void CommitFilterPresenterValues(DependencyObject parent)
+        {
+            int childCount = VisualTreeHelper.GetChildrenCount(parent);
+            for (int index = 0; index < childCount; index++)
+            {
+                DependencyObject child = VisualTreeHelper.GetChild(parent, index);
+                switch (child)
+                {
+                    case DropdownFilterPresenter dropdownFilterPresenter:
+                        dropdownFilterPresenter.Commit();
+                        break;
+                    case TextFilterPresenter textFilterPresenter:
+                        textFilterPresenter.Commit();
+                        break;
+                    case DateFilterPresenter dateFilterPresenter:
+                        dateFilterPresenter.Commit();
+                        break;
+                }
+
+                CommitFilterPresenterValues(child);
+            }
+        }
+
+        private static void RefreshFilterPresenterValues(DependencyObject parent)
+        {
+            int childCount = VisualTreeHelper.GetChildrenCount(parent);
+            for (int index = 0; index < childCount; index++)
+            {
+                DependencyObject child = VisualTreeHelper.GetChild(parent, index);
+                switch (child)
+                {
+                    case DropdownFilterPresenter dropdownFilterPresenter:
+                        dropdownFilterPresenter.Refresh();
+                        break;
+                    case TextFilterPresenter textFilterPresenter:
+                        textFilterPresenter.Refresh();
+                        break;
+                    case DateFilterPresenter dateFilterPresenter:
+                        dateFilterPresenter.Refresh();
+                        break;
+                }
+
+                RefreshFilterPresenterValues(child);
+            }
         }
     }
 }

--- a/JitHub.WinUI/Views/Controls/Common/IssueSidePanel.xaml
+++ b/JitHub.WinUI/Views/Controls/Common/IssueSidePanel.xaml
@@ -2,23 +2,18 @@
     x:Class="JitHub.WinUI.Views.Controls.Common.IssueSidePanel"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:base="using:JitHub.Models.Base"
     xmlns:local="using:JitHub.WinUI.Views.Controls.Common"
+    xmlns:models="using:JitHub.Models"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
     xmlns:controls="using:CommunityToolkit.WinUI.UI.Controls"
-    xmlns:helpers="using:JitHub.WinUI.Helpers"
     mc:Ignorable="d"
     Background="Transparent"
     Loaded="IssueSidePanel_Loaded"
     d:DesignHeight="300"
     d:DesignWidth="400">
-    <UserControl.Resources>
-        <helpers:IssueSideItemTemplateSelector
-            x:Key="IssueSideItemTemplate"
-            UserTemplate="{StaticResource SelectableUserDateTemplate}"
-            LabelTemplate="{StaticResource SelectableLabelDataTemplate}"/>
-    </UserControl.Resources>
     <Grid
         MinWidth="280"
         Padding="4">
@@ -34,10 +29,10 @@
                 Visibility="{x:Bind ViewModel.Loading, Converter={StaticResource BoolToVisibilityReverseConverter}, Mode=OneWay}"
                 ItemsSource="{x:Bind ViewModel.Items, Mode=OneWay}">
                 <muxc:ItemsRepeater.ItemTemplate>
-                    <DataTemplate>
+                    <DataTemplate x:DataType="models:IssueSidePanelItem">
                         <Grid>
                             <muxc:Expander
-                                Header="{Binding Header, Mode=OneWay}"
+                                Header="{x:Bind Header, Mode=OneWay}"
                                 ExpandDirection="Down"
                                 VerticalAlignment="Top"
                                 HorizontalAlignment="Stretch"
@@ -47,12 +42,17 @@
                                         HorizontalAlignment="Center"
                                         VerticalAlignment="Center"
                                         Text="Nothing to show"
-                                        Visibility="{Binding Show, Converter={StaticResource BoolToVisibilityReverseConverter}, Mode=OneWay}"/>
+                                        Visibility="{x:Bind Show, Converter={StaticResource BoolToVisibilityReverseConverter}, Mode=OneWay}"/>
                                     <ScrollViewer
-                                        Visibility="{Binding Show, Converter={StaticResource BoolToVisibilityConverter}, Mode=OneWay}">
+                                        Visibility="{x:Bind Show, Converter={StaticResource BoolToVisibilityConverter}, Mode=OneWay}">
                                         <muxc:ItemsRepeater
-                                            ItemsSource="{Binding Items, Mode=OneWay}"
-                                            ItemTemplate="{StaticResource IssueSideItemTemplate}">
+                                            ItemsSource="{x:Bind Items, Mode=OneWay}">
+                                            <muxc:ItemsRepeater.ItemTemplate>
+                                                <DataTemplate x:DataType="base:SelectableItem">
+                                                    <local:IssueSidePanelSelectableItem
+                                                        Item="{x:Bind Mode=OneWay}"/>
+                                                </DataTemplate>
+                                            </muxc:ItemsRepeater.ItemTemplate>
                                             <muxc:ItemsRepeater.Layout>
                                                 <muxc:StackLayout
                                                     Orientation="Vertical"

--- a/JitHub.WinUI/Views/Controls/Common/IssueSidePanel.xaml.cs
+++ b/JitHub.WinUI/Views/Controls/Common/IssueSidePanel.xaml.cs
@@ -27,6 +27,8 @@ namespace JitHub.WinUI.Views.Controls.Common
                 {
                     self._loadedViewModel = null;
                 }
+
+                self.Bindings.Update();
             }
         }
 

--- a/JitHub.WinUI/Views/Controls/Common/IssueSidePanelSelectableItem.xaml
+++ b/JitHub.WinUI/Views/Controls/Common/IssueSidePanelSelectableItem.xaml
@@ -1,0 +1,11 @@
+<UserControl
+    x:Class="JitHub.WinUI.Views.Controls.Common.IssueSidePanelSelectableItem"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d"
+    d:DesignHeight="40"
+    d:DesignWidth="240">
+    <ContentPresenter x:Name="Presenter"/>
+</UserControl>

--- a/JitHub.WinUI/Views/Controls/Common/IssueSidePanelSelectableItem.xaml.cs
+++ b/JitHub.WinUI/Views/Controls/Common/IssueSidePanelSelectableItem.xaml.cs
@@ -1,0 +1,163 @@
+using System;
+using System.ComponentModel;
+using JitHub.Models;
+using JitHub.Models.Base;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+
+namespace JitHub.WinUI.Views.Controls.Common
+{
+    public sealed partial class IssueSidePanelSelectableItem : UserControl
+    {
+        public static readonly DependencyProperty ItemProperty = DependencyProperty.Register(
+            nameof(Item),
+            typeof(SelectableItem),
+            typeof(IssueSidePanelSelectableItem),
+            new PropertyMetadata(default(SelectableItem), OnItemChanged));
+
+        private CheckBox? _checkBox;
+        private SelectableItem? _subscribedItem;
+        private bool _syncingCheckState;
+
+        public SelectableItem? Item
+        {
+            get => (SelectableItem?)GetValue(ItemProperty);
+            set => SetValue(ItemProperty, value);
+        }
+
+        public IssueSidePanelSelectableItem()
+        {
+            InitializeComponent();
+            Unloaded += OnUnloaded;
+        }
+
+        private static void OnItemChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+        {
+            if (d is IssueSidePanelSelectableItem self)
+            {
+                self.SubscribeToItem(e.NewValue as SelectableItem);
+                self.RenderItem();
+            }
+        }
+
+        private void SubscribeToItem(SelectableItem? item)
+        {
+            if (_subscribedItem is not null)
+            {
+                _subscribedItem.PropertyChanged -= OnItemPropertyChanged;
+            }
+
+            _subscribedItem = item;
+
+            if (_subscribedItem is not null)
+            {
+                _subscribedItem.PropertyChanged += OnItemPropertyChanged;
+            }
+        }
+
+        private void OnItemPropertyChanged(object? sender, PropertyChangedEventArgs e)
+        {
+            if (e.PropertyName is nameof(SelectableItem.Selected))
+            {
+                SyncCheckState();
+            }
+            else if (e.PropertyName is nameof(SelectableItem.Selectable))
+            {
+                RenderItem();
+            }
+        }
+
+        private void RenderItem()
+        {
+            _checkBox = null;
+
+            if (Item is null)
+            {
+                Presenter.Content = null;
+                return;
+            }
+
+            var content = CreateContent(Item);
+            if (!Item.Selectable)
+            {
+                Presenter.Content = content;
+                return;
+            }
+
+            var checkBox = new CheckBox
+            {
+                Content = content,
+                MinHeight = 32,
+                VerticalAlignment = VerticalAlignment.Center
+            };
+
+            _checkBox = checkBox;
+            SyncCheckState();
+
+            checkBox.Checked += OnCheckedChanged;
+            checkBox.Unchecked += OnCheckedChanged;
+            Presenter.Content = checkBox;
+        }
+
+        private static FrameworkElement CreateContent(SelectableItem item)
+            => item switch
+            {
+                SelectableLabel selectableLabel => new RepoLabel
+                {
+                    Label = selectableLabel.Label,
+                    VerticalAlignment = VerticalAlignment.Center
+                },
+                SelectableUser selectableUser => new Avatar
+                {
+                    Login = selectableUser.Login,
+                    Url = selectableUser.AvatarUrl,
+                    ShowLogin = true,
+                    Size = UISize.MEDIUM,
+                    VerticalAlignment = VerticalAlignment.Center
+                },
+                _ => new TextBlock
+                {
+                    Text = item.Type,
+                    VerticalAlignment = VerticalAlignment.Center
+                }
+            };
+
+        private void SyncCheckState()
+        {
+            if (_checkBox is null || Item is null)
+            {
+                return;
+            }
+
+            _syncingCheckState = true;
+            _checkBox.IsChecked = Item.Selected;
+            _syncingCheckState = false;
+        }
+
+        private void OnCheckedChanged(object sender, RoutedEventArgs e)
+        {
+            if (_syncingCheckState || Item is null || sender is not CheckBox checkBox)
+            {
+                return;
+            }
+
+            Item.Selected = checkBox.IsChecked == true;
+            var command = Item.SelectionCommand;
+            if (command?.CanExecute(Item) == true)
+            {
+                command.Execute(Item);
+            }
+        }
+
+        private void OnUnloaded(object sender, RoutedEventArgs e)
+        {
+            SubscribeToItem(null);
+
+            if (_checkBox is not null)
+            {
+                _checkBox.Checked -= OnCheckedChanged;
+                _checkBox.Unchecked -= OnCheckedChanged;
+            }
+        }
+    }
+}

--- a/JitHub.WinUI/Views/Controls/Common/MarkdownForm.xaml.cs
+++ b/JitHub.WinUI/Views/Controls/Common/MarkdownForm.xaml.cs
@@ -9,6 +9,7 @@ using Microsoft.UI.Xaml.Controls;
 
 namespace JitHub.WinUI.Views.Controls.Common
 {
+    [WinRT.GeneratedBindableCustomProperty]
     public sealed partial class MarkdownForm : UserControl
     {
 
@@ -24,17 +25,17 @@ namespace JitHub.WinUI.Views.Controls.Common
             nameof(Text),
             typeof(string),
             typeof(MarkdownForm),
-            new PropertyMetadata(default(string), null));
+            new PropertyMetadata(default(string), OnBindablePropertyChanged));
         public static DependencyProperty FormPaddingProperty = DependencyProperty.Register(
             nameof(FormPadding),
             typeof(Thickness),
             typeof(MarkdownForm),
-            new PropertyMetadata(new Thickness(0), null));
+            new PropertyMetadata(new Thickness(0), OnBindablePropertyChanged));
         public static DependencyProperty EditorHeightProperty = DependencyProperty.Register(
             nameof(EditorHeight),
             typeof(double),
             typeof(MarkdownForm),
-            new PropertyMetadata(220d, null));
+            new PropertyMetadata(220d, OnBindablePropertyChanged));
 
         public string? Text
         {
@@ -70,9 +71,9 @@ namespace JitHub.WinUI.Views.Controls.Common
 
         public MarkdownForm()
         {
-            this.InitializeComponent();
             _gitHubService = Ioc.Default.GetService<IGitHubService>()
                 ?? throw new InvalidOperationException("IGitHubService is not registered.");
+            this.InitializeComponent();
         }
 
         private static void OnActionContentChanged(DependencyObject dependencyObject, DependencyPropertyChangedEventArgs args)
@@ -80,6 +81,14 @@ namespace JitHub.WinUI.Views.Controls.Common
             if (dependencyObject is MarkdownForm form)
             {
                 form.ActionContentPresenter.Content = args.NewValue;
+            }
+        }
+
+        private static void OnBindablePropertyChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+        {
+            if (d is MarkdownForm self)
+            {
+                self.Bindings.Update();
             }
         }
 

--- a/JitHub.WinUI/Views/Controls/Common/MarkdownViewer.xaml.cs
+++ b/JitHub.WinUI/Views/Controls/Common/MarkdownViewer.xaml.cs
@@ -10,7 +10,7 @@ namespace JitHub.WinUI.Views.Controls.Common
             nameof(Config),
             typeof(MarkdownConfig),
             typeof(MarkdownViewer),
-            null
+            new PropertyMetadata(null, OnConfigChanged)
         );
 
         public MarkdownConfig Config
@@ -22,6 +22,14 @@ namespace JitHub.WinUI.Views.Controls.Common
         public MarkdownViewer()
         {
             this.InitializeComponent();
+        }
+
+        private static void OnConfigChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+        {
+            if (d is MarkdownViewer self)
+            {
+                self.Bindings.Update();
+            }
         }
     }
 }

--- a/JitHub.WinUI/Views/Controls/Common/RepoLabel.xaml.cs
+++ b/JitHub.WinUI/Views/Controls/Common/RepoLabel.xaml.cs
@@ -21,7 +21,7 @@ namespace JitHub.WinUI.Views.Controls.Common
             nameof(Label),
             typeof(object),
             typeof(RepoLabel),
-            new PropertyMetadata(default(object), null));
+            new PropertyMetadata(default(object), OnLabelChanged));
         
         public object? Label
         {
@@ -32,6 +32,14 @@ namespace JitHub.WinUI.Views.Controls.Common
         public RepoLabel()
         {
             this.InitializeComponent();
+        }
+
+        private static void OnLabelChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+        {
+            if (d is RepoLabel self)
+            {
+                self.Bindings.Update();
+            }
         }
 
         public string GetName(object? label)

--- a/JitHub.WinUI/Views/Controls/Common/SidePanelDropDown.xaml.cs
+++ b/JitHub.WinUI/Views/Controls/Common/SidePanelDropDown.xaml.cs
@@ -14,14 +14,14 @@ namespace JitHub.WinUI.Views.Controls.Common
             nameof(TextContent),
             typeof(string),
             typeof(SidePanelDropDown),
-            new PropertyMetadata(default(string), null)
+            new PropertyMetadata(default(string), OnBindablePropertyChanged)
         );
 
         public static DependencyProperty FlyoutProperty = DependencyProperty.Register(
             nameof(Flyout),
             typeof(FrameworkElement),
             typeof(SidePanelDropDown),
-            new PropertyMetadata(default(FrameworkElement), null)
+            new PropertyMetadata(default(FrameworkElement), OnBindablePropertyChanged)
         );
 
         public string TextContent
@@ -39,6 +39,14 @@ namespace JitHub.WinUI.Views.Controls.Common
         public SidePanelDropDown()
         {
             this.InitializeComponent();
+        }
+
+        private static void OnBindablePropertyChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+        {
+            if (d is SidePanelDropDown self)
+            {
+                self.Bindings.Update();
+            }
         }
     }
 }

--- a/JitHub.WinUI/Views/Controls/Common/SidePanelItem.xaml.cs
+++ b/JitHub.WinUI/Views/Controls/Common/SidePanelItem.xaml.cs
@@ -11,14 +11,14 @@ namespace JitHub.WinUI.Views.Controls.Common
             nameof(Header),
             typeof(FrameworkElement),
             typeof(SidePanelItem),
-            new PropertyMetadata(default(FrameworkElement), null)
+            new PropertyMetadata(default(FrameworkElement), OnBindablePropertyChanged)
         );
 
         public static DependencyProperty BodyProperty = DependencyProperty.Register(
             nameof(Body),
             typeof(FrameworkElement),
             typeof(SidePanelItem),
-            new PropertyMetadata(default(FrameworkElement), null)
+            new PropertyMetadata(default(FrameworkElement), OnBindablePropertyChanged)
         );
 
         public FrameworkElement Header
@@ -36,6 +36,14 @@ namespace JitHub.WinUI.Views.Controls.Common
         public SidePanelItem()
         {
             this.InitializeComponent();
+        }
+
+        private static void OnBindablePropertyChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+        {
+            if (d is SidePanelItem self)
+            {
+                self.Bindings.Update();
+            }
         }
     }
 }

--- a/JitHub.WinUI/Views/Controls/Common/SvgIcon.xaml.cs
+++ b/JitHub.WinUI/Views/Controls/Common/SvgIcon.xaml.cs
@@ -30,14 +30,14 @@ namespace JitHub.WinUI.Views.Controls.Common
             nameof(IconHeight),
             typeof(double),
             typeof(SvgIcon),
-            new PropertyMetadata(default(double), null)
+            new PropertyMetadata(default(double), OnBindablePropertyChanged)
         );
 
         public static DependencyProperty IconWidthProperty = DependencyProperty.Register(
             nameof(IconWidth),
             typeof(double),
             typeof(SvgIcon),
-            new PropertyMetadata(default(double), null)
+            new PropertyMetadata(default(double), OnBindablePropertyChanged)
         );
 
         public static void OnDarkSourceChange(DependencyObject d, DependencyPropertyChangedEventArgs e)
@@ -49,6 +49,8 @@ namespace JitHub.WinUI.Views.Controls.Common
                 {
                     self.IconImage.Source = new SvgImageSource(new Uri(source));
                 }
+
+                self.Bindings.Update();
             }
         }
 
@@ -61,6 +63,8 @@ namespace JitHub.WinUI.Views.Controls.Common
                 {
                     self.IconImage.Source = new SvgImageSource(new Uri(source));
                 }
+
+                self.Bindings.Update();
             }
         }
 
@@ -76,8 +80,8 @@ namespace JitHub.WinUI.Views.Controls.Common
         }
         public double IconHeight
         {
-            get => (double)GetValue(HeightProperty);
-            set => SetValue(HeightProperty, value);
+            get => (double)GetValue(IconHeightProperty);
+            set => SetValue(IconHeightProperty, value);
         }
         public double IconWidth
         {
@@ -90,6 +94,15 @@ namespace JitHub.WinUI.Views.Controls.Common
             this.InitializeComponent();
             _themeListener.ThemeChanged += ListenerThemeChanged;
         }
+
+        private static void OnBindablePropertyChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+        {
+            if (d is SvgIcon self)
+            {
+                self.Bindings.Update();
+            }
+        }
+
         private void ListenerThemeChanged(ThemeListener sender)
         {
             IconImage.Source = _themeListener.CurrentTheme == ApplicationTheme.Dark ? new SvgImageSource(new Uri(DarkSource)) : new SvgImageSource(new Uri(LightSource));

--- a/JitHub.WinUI/Views/Controls/Common/ThemeImage.xaml.cs
+++ b/JitHub.WinUI/Views/Controls/Common/ThemeImage.xaml.cs
@@ -30,14 +30,14 @@ namespace JitHub.WinUI.Views.Controls.Common
             nameof(IconHeight),
             typeof(double),
             typeof(ThemeImage),
-            new PropertyMetadata(default(double), null)
+            new PropertyMetadata(default(double), OnBindablePropertyChanged)
         );
 
         public static DependencyProperty IconWidthProperty = DependencyProperty.Register(
             nameof(IconWidth),
             typeof(double),
             typeof(ThemeImage),
-            new PropertyMetadata(default(double), null)
+            new PropertyMetadata(default(double), OnBindablePropertyChanged)
         );
 
         public static void OnDarkSourceChange(DependencyObject d, DependencyPropertyChangedEventArgs e)
@@ -49,6 +49,8 @@ namespace JitHub.WinUI.Views.Controls.Common
                 {
                     self.IconImage.Source = new BitmapImage(new Uri(source));
                 }
+
+                self.Bindings.Update();
             }
         }
 
@@ -61,6 +63,8 @@ namespace JitHub.WinUI.Views.Controls.Common
                 {
                     self.IconImage.Source = new BitmapImage(new Uri(source));
                 }
+
+                self.Bindings.Update();
             }
         }
 
@@ -76,8 +80,8 @@ namespace JitHub.WinUI.Views.Controls.Common
         }
         public double IconHeight
         {
-            get => (double)GetValue(HeightProperty);
-            set => SetValue(HeightProperty, value);
+            get => (double)GetValue(IconHeightProperty);
+            set => SetValue(IconHeightProperty, value);
         }
         public double IconWidth
         {
@@ -90,6 +94,14 @@ namespace JitHub.WinUI.Views.Controls.Common
         {
             this.InitializeComponent();
             _themeListener.ThemeChanged += ListenerThemeChanged;
+        }
+
+        private static void OnBindablePropertyChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+        {
+            if (d is ThemeImage self)
+            {
+                self.Bindings.Update();
+            }
         }
 
         private void ListenerThemeChanged(ThemeListener sender)

--- a/JitHub.WinUI/Views/Controls/Filter/DateFilterPresenter.xaml
+++ b/JitHub.WinUI/Views/Controls/Filter/DateFilterPresenter.xaml
@@ -1,0 +1,26 @@
+<UserControl
+    x:Class="JitHub.WinUI.Views.Controls.Filter.DateFilterPresenter"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d"
+    d:DesignHeight="104"
+    d:DesignWidth="172">
+    <Grid>
+        <CalendarDatePicker
+            x:Name="FilterDatePicker"
+            Width="172"
+            MinWidth="172"
+            DateChanged="OnDateChanged"
+            Header="{x:Bind Title, Mode=OneWay}"
+            PlaceholderText="{x:Bind Placeholder, Mode=OneWay}"
+            Style="{StaticResource CalendarDatePicker}">
+            <CalendarDatePicker.HeaderTemplate>
+                <DataTemplate>
+                    <TextBlock Style="{StaticResource SectionSecondaryTextBlockStyle}" Text="{Binding Mode=OneWay}" />
+                </DataTemplate>
+            </CalendarDatePicker.HeaderTemplate>
+        </CalendarDatePicker>
+    </Grid>
+</UserControl>

--- a/JitHub.WinUI/Views/Controls/Filter/DateFilterPresenter.xaml.cs
+++ b/JitHub.WinUI/Views/Controls/Filter/DateFilterPresenter.xaml.cs
@@ -1,0 +1,89 @@
+using System;
+using JitHub.Models.Filter;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+
+namespace JitHub.WinUI.Views.Controls.Filter;
+
+public sealed partial class DateFilterPresenter : UserControl
+{
+    private bool _syncingFromModel;
+
+    public static readonly DependencyProperty FilterProperty = DependencyProperty.Register(
+        nameof(Filter),
+        typeof(object),
+        typeof(DateFilterPresenter),
+        new PropertyMetadata(default(object), OnFilterChanged));
+
+    public object? Filter
+    {
+        get => GetValue(FilterProperty);
+        set => SetValue(FilterProperty, value);
+    }
+
+    private DateFilter? TypedFilter => Filter as DateFilter;
+
+    public string Title => TypedFilter?.Title ?? string.Empty;
+
+    public DateTimeOffset? StartDate
+    {
+        get => TypedFilter?.StartDate;
+        set
+        {
+            if (TypedFilter is not null && value is DateTimeOffset date && TypedFilter.StartDate != date)
+            {
+                TypedFilter.StartDate = date;
+            }
+        }
+    }
+
+    public string Placeholder => TypedFilter?.Placeholder ?? string.Empty;
+
+    public DateFilterPresenter()
+    {
+        InitializeComponent();
+    }
+
+    private static void OnFilterChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+    {
+        if (d is DateFilterPresenter self)
+        {
+            self.Bindings.Update();
+            self.Refresh();
+        }
+    }
+
+    private void OnDateChanged(CalendarDatePicker sender, CalendarDatePickerDateChangedEventArgs args)
+    {
+        if (!_syncingFromModel)
+        {
+            Commit();
+        }
+    }
+
+    public void Commit()
+    {
+        if (TypedFilter is not null && FilterDatePicker.Date is DateTimeOffset date)
+        {
+            TypedFilter.StartDate = date;
+        }
+    }
+
+    public void Refresh()
+    {
+        if (TypedFilter is null)
+        {
+            return;
+        }
+
+        _syncingFromModel = true;
+        try
+        {
+            FilterDatePicker.Date = TypedFilter.StartDate;
+        }
+        finally
+        {
+            _syncingFromModel = false;
+        }
+    }
+}

--- a/JitHub.WinUI/Views/Controls/Filter/DropdownFilterPresenter.xaml
+++ b/JitHub.WinUI/Views/Controls/Filter/DropdownFilterPresenter.xaml
@@ -1,0 +1,29 @@
+<UserControl
+    x:Class="JitHub.WinUI.Views.Controls.Filter.DropdownFilterPresenter"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d"
+    d:DesignHeight="104"
+    d:DesignWidth="172">
+    <Grid>
+        <ComboBox
+            x:Name="FilterComboBox"
+            Width="172"
+            MinWidth="172"
+            HorizontalAlignment="Left"
+            DisplayMemberPath="DisplayMember"
+            Header="{x:Bind Title, Mode=OneWay}"
+            ItemsSource="{x:Bind Selections, Mode=OneWay}"
+            SelectedValuePath="SelectedValue"
+            SelectionChanged="OnSelectionChanged"
+            Style="{StaticResource ComboBox}">
+            <ComboBox.HeaderTemplate>
+                <DataTemplate>
+                    <TextBlock Style="{StaticResource SectionSecondaryTextBlockStyle}" Text="{Binding Mode=OneWay}" />
+                </DataTemplate>
+            </ComboBox.HeaderTemplate>
+        </ComboBox>
+    </Grid>
+</UserControl>

--- a/JitHub.WinUI/Views/Controls/Filter/DropdownFilterPresenter.xaml.cs
+++ b/JitHub.WinUI/Views/Controls/Filter/DropdownFilterPresenter.xaml.cs
@@ -1,0 +1,91 @@
+using System.Collections.ObjectModel;
+using JitHub.Models.Filter;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+
+namespace JitHub.WinUI.Views.Controls.Filter;
+
+public sealed partial class DropdownFilterPresenter : UserControl
+{
+    private bool _syncingFromModel;
+
+    public static readonly DependencyProperty FilterProperty = DependencyProperty.Register(
+        nameof(Filter),
+        typeof(object),
+        typeof(DropdownFilterPresenter),
+        new PropertyMetadata(default(object), OnFilterChanged));
+
+    public object? Filter
+    {
+        get => GetValue(FilterProperty);
+        set => SetValue(FilterProperty, value);
+    }
+
+    private DropdownFilter? TypedFilter => Filter as DropdownFilter;
+
+    public string Title => TypedFilter?.Title ?? string.Empty;
+
+    public ObservableCollection<Selection> Selections => TypedFilter?.Selections ?? [];
+
+    public Selection? Selected
+    {
+        get => TypedFilter?.Selected;
+        set
+        {
+            if (TypedFilter is not null && value is not null && !ReferenceEquals(TypedFilter.Selected, value))
+            {
+                TypedFilter.Selected = value;
+            }
+        }
+    }
+
+    public DropdownFilterPresenter()
+    {
+        InitializeComponent();
+    }
+
+    private static void OnFilterChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+    {
+        if (d is DropdownFilterPresenter self)
+        {
+            self.Bindings.Update();
+            self.Refresh();
+        }
+    }
+
+    private void OnSelectionChanged(object sender, SelectionChangedEventArgs e)
+    {
+        if (!_syncingFromModel)
+        {
+            Commit();
+        }
+    }
+
+    public void Commit()
+    {
+        if (TypedFilter is not null &&
+            FilterComboBox.SelectedItem is Selection selection &&
+            !ReferenceEquals(TypedFilter.Selected, selection))
+        {
+            TypedFilter.Selected = selection;
+        }
+    }
+
+    public void Refresh()
+    {
+        if (TypedFilter is null)
+        {
+            return;
+        }
+
+        _syncingFromModel = true;
+        try
+        {
+            FilterComboBox.SelectedItem = TypedFilter.Selected;
+        }
+        finally
+        {
+            _syncingFromModel = false;
+        }
+    }
+}

--- a/JitHub.WinUI/Views/Controls/Filter/TextFilterPresenter.xaml
+++ b/JitHub.WinUI/Views/Controls/Filter/TextFilterPresenter.xaml
@@ -1,0 +1,26 @@
+<UserControl
+    x:Class="JitHub.WinUI.Views.Controls.Filter.TextFilterPresenter"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d"
+    d:DesignHeight="104"
+    d:DesignWidth="172">
+    <Grid>
+        <TextBox
+            x:Name="FilterTextBox"
+            Width="172"
+            MinWidth="172"
+            Header="{x:Bind Title, Mode=OneWay}"
+            PlaceholderText="Type to filter"
+            Style="{StaticResource AppTextBoxStyle}"
+            TextChanged="OnTextChanged">
+            <TextBox.HeaderTemplate>
+                <DataTemplate>
+                    <TextBlock Style="{StaticResource SectionSecondaryTextBlockStyle}" Text="{Binding Mode=OneWay}" />
+                </DataTemplate>
+            </TextBox.HeaderTemplate>
+        </TextBox>
+    </Grid>
+</UserControl>

--- a/JitHub.WinUI/Views/Controls/Filter/TextFilterPresenter.xaml.cs
+++ b/JitHub.WinUI/Views/Controls/Filter/TextFilterPresenter.xaml.cs
@@ -1,0 +1,86 @@
+using JitHub.Models.Filter;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+
+namespace JitHub.WinUI.Views.Controls.Filter;
+
+public sealed partial class TextFilterPresenter : UserControl
+{
+    private bool _syncingFromModel;
+
+    public static readonly DependencyProperty FilterProperty = DependencyProperty.Register(
+        nameof(Filter),
+        typeof(object),
+        typeof(TextFilterPresenter),
+        new PropertyMetadata(default(object), OnFilterChanged));
+
+    public object? Filter
+    {
+        get => GetValue(FilterProperty);
+        set => SetValue(FilterProperty, value);
+    }
+
+    private TextFilter? TypedFilter => Filter as TextFilter;
+
+    public string Title => TypedFilter?.Title ?? string.Empty;
+
+    public string Text
+    {
+        get => TypedFilter?.Text ?? string.Empty;
+        set
+        {
+            if (TypedFilter is not null && TypedFilter.Text != value)
+            {
+                TypedFilter.Text = value;
+            }
+        }
+    }
+
+    public TextFilterPresenter()
+    {
+        InitializeComponent();
+    }
+
+    private static void OnFilterChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+    {
+        if (d is TextFilterPresenter self)
+        {
+            self.Bindings.Update();
+            self.Refresh();
+        }
+    }
+
+    private void OnTextChanged(object sender, TextChangedEventArgs e)
+    {
+        if (!_syncingFromModel)
+        {
+            Commit();
+        }
+    }
+
+    public void Commit()
+    {
+        if (TypedFilter is not null && TypedFilter.Text != FilterTextBox.Text)
+        {
+            TypedFilter.Text = FilterTextBox.Text;
+        }
+    }
+
+    public void Refresh()
+    {
+        if (TypedFilter is null)
+        {
+            return;
+        }
+
+        _syncingFromModel = true;
+        try
+        {
+            FilterTextBox.Text = TypedFilter.Text;
+        }
+        finally
+        {
+            _syncingFromModel = false;
+        }
+    }
+}

--- a/JitHub.WinUI/Views/Controls/Issue/IssueButton.xaml.cs
+++ b/JitHub.WinUI/Views/Controls/Issue/IssueButton.xaml.cs
@@ -22,7 +22,7 @@ namespace JitHub.WinUI.Views.Controls.Issue
             nameof(Issue),
             typeof(IssueModel),
             typeof(IssueButton),
-            new PropertyMetadata(default(IssueModel), null)
+            new PropertyMetadata(default(IssueModel), OnIssueChanged)
         );
 
         public static DependencyProperty RepoProperty = DependencyProperty.Register(
@@ -47,6 +47,14 @@ namespace JitHub.WinUI.Views.Controls.Issue
             this.InitializeComponent();
             _navigationService = Ioc.Default.GetService<NavigationService>()
                 ?? throw new InvalidOperationException("NavigationService is not registered.");
+        }
+
+        private static void OnIssueChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+        {
+            if (d is IssueButton self)
+            {
+                self.Bindings.Update();
+            }
         }
 
         private void OnClick(object sender, RoutedEventArgs args)

--- a/JitHub.WinUI/Views/Controls/Issue/IssueListItemPresenter.xaml
+++ b/JitHub.WinUI/Views/Controls/Issue/IssueListItemPresenter.xaml
@@ -1,0 +1,55 @@
+<UserControl
+    x:Class="JitHub.WinUI.Views.Controls.Issue.IssueListItemPresenter"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
+    mc:Ignorable="d"
+    d:DesignHeight="96"
+    d:DesignWidth="420">
+    <Grid Padding="4">
+        <StackPanel Margin="4,0,0,0" Spacing="4">
+            <Grid>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="auto" />
+                    <ColumnDefinition Width="*" />
+                </Grid.ColumnDefinitions>
+                <Rectangle
+                    Grid.Column="0"
+                    Width="10"
+                    Height="10"
+                    Margin="0,0,4,0"
+                    VerticalAlignment="Center"
+                    Fill="{x:Bind State, Converter={StaticResource OpenStatusToColorConverter}, Mode=OneWay}"
+                    RadiusX="6"
+                    RadiusY="6" />
+
+                <TextBlock
+                    Grid.Column="1"
+                    Padding="0,0,0,4"
+                    VerticalAlignment="Center"
+                    FontSize="16"
+                    FontWeight="SemiBold"
+                    Text="{x:Bind Title, Mode=OneWay}"
+                    TextWrapping="Wrap" />
+            </Grid>
+
+            <muxc:ItemsRepeater
+                ItemTemplate="{StaticResource IssueLabel}"
+                ItemsSource="{x:Bind Labels, Converter={StaticResource ListToShorterListConverter}, ConverterParameter='3', Mode=OneWay}">
+                <muxc:ItemsRepeater.Layout>
+                    <muxc:StackLayout Orientation="Horizontal" Spacing="4" />
+                </muxc:ItemsRepeater.Layout>
+            </muxc:ItemsRepeater>
+
+            <StackPanel Orientation="Horizontal" Spacing="5">
+                <TextBlock Foreground="{ThemeResource AppInkSubtleBrush}">
+                    <Run Text="{x:Bind NumberText, Mode=OneWay}" />
+                    <Run Text="{x:Bind CreatedAtText, Mode=OneWay}" />
+                    <Run Text="{x:Bind UserText, Mode=OneWay}" />
+                </TextBlock>
+            </StackPanel>
+        </StackPanel>
+    </Grid>
+</UserControl>

--- a/JitHub.WinUI/Views/Controls/Issue/IssueListItemPresenter.xaml.cs
+++ b/JitHub.WinUI/Views/Controls/Issue/IssueListItemPresenter.xaml.cs
@@ -1,0 +1,49 @@
+using System;
+using System.Collections.Generic;
+using JitHub.Models.Base;
+using JitHub.Models.LegacyGitHub;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using IssueModel = JitHub.Models.LegacyGitHub.Issue;
+
+namespace JitHub.WinUI.Views.Controls.Issue;
+
+public sealed partial class IssueListItemPresenter : UserControl
+{
+    public static readonly DependencyProperty ItemProperty = DependencyProperty.Register(
+        nameof(Item),
+        typeof(object),
+        typeof(IssueListItemPresenter),
+        new PropertyMetadata(default(object), OnItemChanged));
+
+    public object? Item
+    {
+        get => GetValue(ItemProperty);
+        set => SetValue(ItemProperty, value);
+    }
+
+    private RepoSelectableItemModel<IssueModel>? TypedItem => Item as RepoSelectableItemModel<IssueModel>;
+
+    public object? State => TypedItem?.Model.State;
+    public string Title => TypedItem?.Model.Title ?? string.Empty;
+    public List<Label> Labels => TypedItem?.Model.Labels ?? [];
+    public int Number => TypedItem?.Model.Number ?? 0;
+    public DateTimeOffset CreatedAt => TypedItem?.Model.CreatedAt ?? default;
+    public User? User => TypedItem?.Model.User;
+    public string NumberText => Number > 0 ? $"#{Number}" : "#0";
+    public string CreatedAtText => TypedItem is null ? string.Empty : $"opened on {CreatedAt:MMM dd, yyyy}";
+    public string UserText => string.IsNullOrWhiteSpace(User?.Login) ? string.Empty : $"by {User.Login}";
+
+    public IssueListItemPresenter()
+    {
+        InitializeComponent();
+    }
+
+    private static void OnItemChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+    {
+        if (d is IssueListItemPresenter self)
+        {
+            self.Bindings.Update();
+        }
+    }
+}

--- a/JitHub.WinUI/Views/Controls/Issue/UserIssueList.xaml
+++ b/JitHub.WinUI/Views/Controls/Issue/UserIssueList.xaml
@@ -5,6 +5,7 @@
     xmlns:local="using:JitHub.WinUI.Views.Controls.Issue"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:githubmodels="using:JitHub.Models.GitHub"
     xmlns:issueviewmodels="using:JitHub.WinUI.ViewModels.IssueViewModels"
     xmlns:controls="using:CommunityToolkit.WinUI.Controls"
     mc:Ignorable="d"
@@ -24,9 +25,9 @@
             <ListView
                 ItemsSource="{x:Bind ViewModel.CreatedIssues}">
                 <ListView.ItemTemplate>
-                    <DataTemplate>
+                    <DataTemplate x:DataType="githubmodels:GitHubIssue">
                         <Grid>
-                            <TextBlock Text="{Binding Title, Mode=OneWay}"/>
+                            <TextBlock Text="{x:Bind Title, Mode=OneWay}"/>
                         </Grid>
                     </DataTemplate>
                 </ListView.ItemTemplate>

--- a/JitHub.WinUI/Views/Controls/PullRequest/Conversation/PullRequestTimelineItem.xaml
+++ b/JitHub.WinUI/Views/Controls/PullRequest/Conversation/PullRequestTimelineItem.xaml
@@ -2,6 +2,7 @@
     x:Class="JitHub.WinUI.Views.Controls.PullRequest.Conversation.PullRequestTimelineItem"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:activities="using:JitHub.Models.Activities"
     xmlns:common="using:JitHub.WinUI.Views.Controls.Common"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
@@ -87,7 +88,7 @@
                             </ItemsPanelTemplate>
                         </ItemsControl.ItemsPanel>
                         <ItemsControl.ItemTemplate>
-                            <DataTemplate>
+                            <DataTemplate x:DataType="activities:ActivityCardDetailViewModel">
                                 <Grid ColumnSpacing="8">
                                     <Grid.ColumnDefinitions>
                                         <ColumnDefinition Width="Auto" />
@@ -99,11 +100,11 @@
                                         FontFamily="{StaticResource SegoeFluentIcons}"
                                         FontSize="11"
                                         Foreground="{ThemeResource AppInkMutedBrush}"
-                                        Glyph="{Binding Glyph}" />
+                                        Glyph="{x:Bind Glyph, Mode=OneWay}" />
                                     <TextBlock
                                         Grid.Column="1"
                                         Style="{StaticResource SectionSecondaryTextBlockStyle}"
-                                        Text="{Binding Text}"
+                                        Text="{x:Bind Text, Mode=OneWay}"
                                         TextTrimming="CharacterEllipsis"
                                         TextWrapping="NoWrap" />
                                 </Grid>

--- a/JitHub.WinUI/Views/Controls/PullRequest/Conversation/ReviewBlock.xaml
+++ b/JitHub.WinUI/Views/Controls/PullRequest/Conversation/ReviewBlock.xaml
@@ -6,6 +6,7 @@
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:muxc="using:Microsoft.UI.Xaml.Controls" xmlns:pullrequest="using:JitHub.WinUI.Views.Controls.PullRequest" xmlns:controls="using:JitHub.WinUI.Views.Controls" xmlns:common="using:JitHub.WinUI.Views.Controls.Common"
+    xmlns:viewmodels="using:JitHub.WinUI.ViewModels.PullRequestViewModels.ConversationViewModels"
     mc:Ignorable="d"
     d:DesignHeight="300"
     d:DesignWidth="400">
@@ -38,9 +39,9 @@
                 <muxc:ItemsRepeater
                     ItemsSource="{x:Bind ViewModel.Blocks, Mode=OneWay}">
                     <muxc:ItemsRepeater.ItemTemplate>
-                        <DataTemplate>
+                        <DataTemplate x:DataType="viewmodels:ReviewCommentViewModel">
                             <Grid>
-                                <local:ReviewCommentBlock ViewModel="{Binding Item, Mode=OneWay}"/>
+                                <local:ReviewCommentBlock ViewModel="{x:Bind Mode=OneWay}"/>
                             </Grid>
                         </DataTemplate>
                     </muxc:ItemsRepeater.ItemTemplate>

--- a/JitHub.WinUI/Views/Controls/PullRequest/Conversation/ReviewBlock.xaml.cs
+++ b/JitHub.WinUI/Views/Controls/PullRequest/Conversation/ReviewBlock.xaml.cs
@@ -19,6 +19,7 @@ namespace JitHub.WinUI.Views.Controls.PullRequest.Conversation
             if (d is ReviewBlock self && e.NewValue != null)
             {
                 self.DataContext = self.ViewModel;
+                self.Bindings.Update();
             }
         }
 

--- a/JitHub.WinUI/Views/Controls/PullRequest/Conversation/ReviewCommentBlock.xaml
+++ b/JitHub.WinUI/Views/Controls/PullRequest/Conversation/ReviewCommentBlock.xaml
@@ -9,6 +9,7 @@
     xmlns:pullrequest="using:JitHub.WinUI.Views.Controls.PullRequest"
     xmlns:controls="using:JitHub.WinUI.Views.Controls"
     xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
+    xmlns:userviewmodels="using:JitHub.WinUI.ViewModels.UserViewModel"
     mc:Ignorable="d"
     d:DesignHeight="300"
     d:DesignWidth="400">
@@ -32,11 +33,11 @@
             <muxc:ItemsRepeater
                 ItemsSource="{x:Bind ViewModel.Replies, Mode=OneWay}">
                 <muxc:ItemsRepeater.ItemTemplate>
-                    <DataTemplate>
+                    <DataTemplate x:DataType="userviewmodels:UserCommentBlockViewModel">
                         <Grid>
                             <controls:UserCommentBlock
                                 Size="MEDIUM"
-                                ViewModel="{Binding Item, Mode=OneWay}"/>
+                                ViewModel="{x:Bind Mode=OneWay}"/>
                         </Grid>
                     </DataTemplate>
                 </muxc:ItemsRepeater.ItemTemplate>

--- a/JitHub.WinUI/Views/Controls/PullRequest/Conversation/ReviewCommentBlock.xaml.cs
+++ b/JitHub.WinUI/Views/Controls/PullRequest/Conversation/ReviewCommentBlock.xaml.cs
@@ -31,9 +31,10 @@ namespace JitHub.WinUI.Views.Controls.PullRequest.Conversation
         {
             if (d is ReviewCommentBlock self && args.NewValue != null)
             {
-                self.ViewModel = (ReviewCommentViewModel)args.NewValue;
-                self.DataContext = self.ViewModel;
-                self.ViewModel.ReplyBox = self.ReplyBox;
+                var viewModel = (ReviewCommentViewModel)args.NewValue;
+                self.DataContext = viewModel;
+                viewModel.ReplyBox = self.ReplyBox;
+                self.Bindings.Update();
             }
         }
 

--- a/JitHub.WinUI/Views/Controls/PullRequest/PullRequestButton.xaml.cs
+++ b/JitHub.WinUI/Views/Controls/PullRequest/PullRequestButton.xaml.cs
@@ -22,7 +22,7 @@ namespace JitHub.WinUI.Views.Controls.PullRequest
             nameof(PullRequest),
             typeof(PullRequestModel),
             typeof(PullRequestButton),
-            new PropertyMetadata(default(PullRequestModel), null)
+            new PropertyMetadata(default(PullRequestModel), OnPullRequestChanged)
         );
 
         public static DependencyProperty RepoProperty = DependencyProperty.Register(
@@ -47,6 +47,14 @@ namespace JitHub.WinUI.Views.Controls.PullRequest
             this.InitializeComponent();
             _navigationService = Ioc.Default.GetService<NavigationService>()
                 ?? throw new InvalidOperationException("NavigationService is not registered.");
+        }
+
+        private static void OnPullRequestChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+        {
+            if (d is PullRequestButton self)
+            {
+                self.Bindings.Update();
+            }
         }
 
         private void OnClick(object sender, RoutedEventArgs args)

--- a/JitHub.WinUI/Views/Controls/PullRequest/PullRequestForm.xaml
+++ b/JitHub.WinUI/Views/Controls/PullRequest/PullRequestForm.xaml
@@ -3,6 +3,7 @@
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:local="using:JitHub.WinUI.Views.Controls.PullRequest"
+    xmlns:legacy="using:JitHub.Models.LegacyGitHub"
     xmlns:prviewmodels="using:JitHub.WinUI.ViewModels.PullRequestViewModels"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
@@ -192,15 +193,15 @@
                 <muxc:ItemsRepeater
                     ItemsSource="{x:Bind ViewModel.CompareResult.Files, Mode=OneWay}">
                     <muxc:ItemsRepeater.ItemTemplate>
-                        <DataTemplate>
+                        <DataTemplate x:DataType="legacy:GitHubCommitFile">
                             <Grid>
                                 <common:CommentBlock>
                                     <common:CommentBlock.HeaderContent>
-                                        <TextBlock Text="{Binding Filename, Mode=OneWay}"/>
+                                        <TextBlock Text="{x:Bind Filename, Mode=OneWay}"/>
                                     </common:CommentBlock.HeaderContent>
                                     <common:CommentBlock.BodyContent>
                                         <local:DiffTextBlock
-                                        Patch="{Binding Patch, Mode=OneWay}"/>
+                                        Patch="{x:Bind Patch, Mode=OneWay}"/>
                                     </common:CommentBlock.BodyContent>
                                 </common:CommentBlock>
                             </Grid>

--- a/JitHub.WinUI/Views/Controls/PullRequest/PullRequestListItemPresenter.xaml
+++ b/JitHub.WinUI/Views/Controls/PullRequest/PullRequestListItemPresenter.xaml
@@ -1,0 +1,36 @@
+<UserControl
+    x:Class="JitHub.WinUI.Views.Controls.PullRequest.PullRequestListItemPresenter"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
+    mc:Ignorable="d"
+    d:DesignHeight="96"
+    d:DesignWidth="420">
+    <Grid Padding="4,8">
+        <StackPanel Margin="4,0,0,0" Spacing="4">
+            <TextBlock
+                FontSize="16"
+                FontWeight="SemiBold"
+                Text="{x:Bind Title, Mode=OneWay}"
+                TextWrapping="Wrap" />
+
+            <muxc:ItemsRepeater
+                ItemTemplate="{StaticResource IssueLabel}"
+                ItemsSource="{x:Bind Labels, Converter={StaticResource ListToShorterListConverter}, ConverterParameter='3', Mode=OneWay}">
+                <muxc:ItemsRepeater.Layout>
+                    <muxc:StackLayout Orientation="Horizontal" Spacing="4" />
+                </muxc:ItemsRepeater.Layout>
+            </muxc:ItemsRepeater>
+
+            <StackPanel Orientation="Horizontal" Spacing="4">
+                <TextBlock Foreground="{ThemeResource AppInkSubtleBrush}">
+                    <Run Text="{x:Bind NumberText, Mode=OneWay}" />
+                    <Run Text="{x:Bind CreatedAtText, Mode=OneWay}" />
+                    <Run Text="{x:Bind UserText, Mode=OneWay}" />
+                </TextBlock>
+            </StackPanel>
+        </StackPanel>
+    </Grid>
+</UserControl>

--- a/JitHub.WinUI/Views/Controls/PullRequest/PullRequestListItemPresenter.xaml.cs
+++ b/JitHub.WinUI/Views/Controls/PullRequest/PullRequestListItemPresenter.xaml.cs
@@ -1,0 +1,48 @@
+using System;
+using System.Collections.Generic;
+using JitHub.Models.Base;
+using JitHub.Models.LegacyGitHub;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using PullRequestModel = JitHub.Models.LegacyGitHub.PullRequest;
+
+namespace JitHub.WinUI.Views.Controls.PullRequest;
+
+public sealed partial class PullRequestListItemPresenter : UserControl
+{
+    public static readonly DependencyProperty ItemProperty = DependencyProperty.Register(
+        nameof(Item),
+        typeof(object),
+        typeof(PullRequestListItemPresenter),
+        new PropertyMetadata(default(object), OnItemChanged));
+
+    public object? Item
+    {
+        get => GetValue(ItemProperty);
+        set => SetValue(ItemProperty, value);
+    }
+
+    private RepoSelectableItemModel<PullRequestModel>? TypedItem => Item as RepoSelectableItemModel<PullRequestModel>;
+
+    public string Title => TypedItem?.Model.Title ?? string.Empty;
+    public List<Label> Labels => TypedItem?.Model.Labels ?? [];
+    public int Number => TypedItem?.Model.Number ?? 0;
+    public DateTimeOffset CreatedAt => TypedItem?.Model.CreatedAt ?? default;
+    public User? User => TypedItem?.Model.User;
+    public string NumberText => Number > 0 ? $"#{Number}" : "#0";
+    public string CreatedAtText => TypedItem is null ? string.Empty : $"opened on {CreatedAt:MMM dd, yyyy}";
+    public string UserText => string.IsNullOrWhiteSpace(User?.Login) ? string.Empty : $"by {User.Login}";
+
+    public PullRequestListItemPresenter()
+    {
+        InitializeComponent();
+    }
+
+    private static void OnItemChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+    {
+        if (d is PullRequestListItemPresenter self)
+        {
+            self.Bindings.Update();
+        }
+    }
+}

--- a/JitHub.WinUI/Views/Controls/PullRequest/RepoPullRequestDetail.xaml.cs
+++ b/JitHub.WinUI/Views/Controls/PullRequest/RepoPullRequestDetail.xaml.cs
@@ -27,6 +27,7 @@ namespace JitHub.WinUI.Views.Controls.PullRequest
                 self.DataContext = self.ViewModel;
                 self.ViewModel.Frame = self.RepoPullRequestDetailFrame;
                 self.ViewModel.GoToConversationPage();
+                self.Bindings.Update();
                 //loading things
             }
         }

--- a/JitHub.WinUI/Views/Controls/Repo/RepoDeleteConfirmationDialog.xaml.cs
+++ b/JitHub.WinUI/Views/Controls/Repo/RepoDeleteConfirmationDialog.xaml.cs
@@ -28,10 +28,10 @@ namespace JitHub.WinUI.Views.Controls.Repo
         public ICommand CancelCommand { get; }
         public RepoDeleteConfirmationDialog(int number, ICommand confirmCommand, ICommand cancelCommand)
         {
-            this.InitializeComponent();
             Number = number;
             ConfirmCommand = confirmCommand;
             CancelCommand = cancelCommand;
+            this.InitializeComponent();
             _settings = Ioc.Default.GetService<ISettingService>()
                 ?? throw new InvalidOperationException("ISettingService is not registered.");
         }

--- a/JitHub.WinUI/Views/Controls/Repo/RepoDeletionFailDialog.xaml
+++ b/JitHub.WinUI/Views/Controls/Repo/RepoDeletionFailDialog.xaml
@@ -3,6 +3,7 @@
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:local="using:JitHub.WinUI.Views.Controls.Repo"
+    xmlns:models="using:JitHub.Models"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
@@ -36,14 +37,14 @@
                                 <muxc:StackLayout Spacing="4"/>
                             </muxc:ItemsRepeater.Layout>
                             <muxc:ItemsRepeater.ItemTemplate>
-                                <DataTemplate>
+                                <DataTemplate x:DataType="models:FailedRepo">
                                     <TextBlock
                                         TextWrapping="Wrap">
                                         <Run
-                                            Text="{Binding Repo.Repository.Name, Mode=OneWay}"/>
+                                            Text="{x:Bind Repo.Repository.Name, Mode=OneWay}"/>
                                         <LineBreak/>
                                         <Run
-                                            Text="{Binding Reason, Mode=OneWay}"/>
+                                            Text="{x:Bind Reason, Mode=OneWay}"/>
                                     </TextBlock>
                                 </DataTemplate>
                             </muxc:ItemsRepeater.ItemTemplate>

--- a/JitHub.WinUI/Views/Controls/Repo/RepoDeletionFailDialog.xaml.cs
+++ b/JitHub.WinUI/Views/Controls/Repo/RepoDeletionFailDialog.xaml.cs
@@ -1,5 +1,6 @@
 using JitHub.Models;
 using System.Collections.Generic;
+using System.Linq;
 using System.Windows.Input;
 using Microsoft.UI.Xaml.Controls;
 
@@ -9,13 +10,13 @@ namespace JitHub.WinUI.Views.Controls.Repo
 {
     public sealed partial class RepoDeletionFailDialog : UserControl
     {
-        public ICollection<FailedRepo> FailedRepos { get; }
+        public List<FailedRepo> FailedRepos { get; }
         public ICommand CancelCommand { get; }
-        public RepoDeletionFailDialog(ICollection<FailedRepo> repos, ICommand cancel)
+        public RepoDeletionFailDialog(IEnumerable<FailedRepo> repos, ICommand cancel)
         {
-            this.InitializeComponent();
-            FailedRepos = repos;
+            FailedRepos = repos.ToList();
             CancelCommand = cancel;
+            this.InitializeComponent();
         }
     }
 }

--- a/JitHub.WinUI/Views/Controls/Repo/RepoForm.xaml
+++ b/JitHub.WinUI/Views/Controls/Repo/RepoForm.xaml
@@ -3,6 +3,7 @@
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:local="using:JitHub.WinUI.Views.Controls.Repo"
+    xmlns:models="using:JitHub.Models"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:repositoryviewmodels="using:JitHub.WinUI.ViewModels.RepositoryViewModels"
@@ -41,8 +42,8 @@
                 ItemsSource="{x:Bind ViewModel.Licenses, Mode=OneWay}"
                 SelectedItem="{x:Bind ViewModel.SelectedLicense, Mode=TwoWay}">
                 <ComboBox.ItemTemplate>
-                    <DataTemplate>
-                        <TextBlock Text="{Binding DiaplayName, Mode=OneWay}"/>
+                    <DataTemplate x:DataType="models:License">
+                        <TextBlock Text="{x:Bind DiaplayName, Mode=OneWay}"/>
                     </DataTemplate>
                 </ComboBox.ItemTemplate>
             </ComboBox>

--- a/JitHub.WinUI/Views/Controls/RepoSideBar.xaml
+++ b/JitHub.WinUI/Views/Controls/RepoSideBar.xaml
@@ -8,6 +8,7 @@
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:enum="using:JitHub.Models.Base"
     xmlns:helpers="using:JitHub.WinUI.Helpers"
+    xmlns:models="using:JitHub.Models"
     xmlns:appcontrols="using:JitHub.WinUI.Views.Controls.App"
     xmlns:local="using:JitHub.WinUI.Views"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
@@ -23,11 +24,74 @@
         <repoviewmodels:RepoSideBarViewModel x:Name="ViewModel" />
     </UserControl.DataContext>
     <UserControl.Resources>
+        <DataTemplate
+            x:Key="SideBarPublicRepoTemplate"
+            x:DataType="models:RepoModel">
+            <Button
+                Margin="0,0,4,0"
+                HorizontalAlignment="Stretch"
+                HorizontalContentAlignment="Stretch"
+                Background="Transparent"
+                BorderThickness="0"
+                Command="{x:Bind DetailNavigationCommand, Mode=OneWay}"
+                Style="{StaticResource AppQuietButtonStyle}">
+                <StackPanel Orientation="Horizontal" Spacing="4">
+                    <appcontrols:AppIcon
+                        VerticalAlignment="Center"
+                        IconBrush="{ThemeResource AppInkMutedBrush}"
+                        IconKind="PublicRepository"
+                        IconSize="16" />
+                    <TextBlock VerticalAlignment="Center" Text="{x:Bind Name, Mode=OneWay}" />
+                </StackPanel>
+            </Button>
+        </DataTemplate>
+        <DataTemplate
+            x:Key="SideBarPrivateRepoTemplate"
+            x:DataType="models:RepoModel">
+            <Button
+                Margin="0,0,4,0"
+                HorizontalAlignment="Stretch"
+                HorizontalContentAlignment="Stretch"
+                Background="Transparent"
+                BorderThickness="0"
+                Command="{x:Bind DetailNavigationCommand, Mode=OneWay}"
+                Style="{StaticResource AppQuietButtonStyle}">
+                <StackPanel Orientation="Horizontal" Spacing="4">
+                    <appcontrols:AppIcon
+                        VerticalAlignment="Center"
+                        IconBrush="{ThemeResource PrivateRepoBrush}"
+                        IconKind="PrivateRepository"
+                        IconSize="16" />
+                    <TextBlock VerticalAlignment="Center" Text="{x:Bind Name, Mode=OneWay}" />
+                </StackPanel>
+            </Button>
+        </DataTemplate>
+        <DataTemplate
+            x:Key="SideBarForkRepoTemplate"
+            x:DataType="models:RepoModel">
+            <Button
+                Margin="0,0,4,0"
+                HorizontalAlignment="Stretch"
+                HorizontalContentAlignment="Stretch"
+                Background="Transparent"
+                BorderThickness="0"
+                Command="{x:Bind DetailNavigationCommand, Mode=OneWay}"
+                Style="{StaticResource AppQuietButtonStyle}">
+                <StackPanel Orientation="Horizontal" Spacing="4">
+                    <appcontrols:AppIcon
+                        VerticalAlignment="Center"
+                        IconBrush="{ThemeResource AppInkMutedBrush}"
+                        IconKind="Fork"
+                        IconSize="16" />
+                    <TextBlock VerticalAlignment="Center" Text="{x:Bind Name, Mode=OneWay}" />
+                </StackPanel>
+            </Button>
+        </DataTemplate>
         <helpers:RepoIconTemplateSelector
             x:Key="SimpleRepoTemplate"
-            ForkTemplate="{StaticResource ForkRepo}"
-            PrivateTemplate="{StaticResource PrivateRepo}"
-            PublicTemplate="{StaticResource PublicRepo}" />
+            ForkTemplate="{StaticResource SideBarForkRepoTemplate}"
+            PrivateTemplate="{StaticResource SideBarPrivateRepoTemplate}"
+            PublicTemplate="{StaticResource SideBarPublicRepoTemplate}" />
     </UserControl.Resources>
     <appcontrols:AppSidebarSection
         HorizontalAlignment="Stretch"

--- a/JitHub.WinUI/Views/Controls/UserCommentBlock.xaml
+++ b/JitHub.WinUI/Views/Controls/UserCommentBlock.xaml
@@ -8,6 +8,7 @@
     xmlns:markdowntextblock="using:CommunityToolkit.WinUI.Controls"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
+    xmlns:userviewmodels="using:JitHub.WinUI.ViewModels.UserViewModel"
     d:DesignHeight="300"
     d:DesignWidth="400"
     Loaded="UserCommentBlock_Loaded"
@@ -79,15 +80,15 @@
                             <common:EmojiPanelButton ViewModel="{x:Bind ViewModel.EmojiPanelViewModel, Mode=OneWay}" />
                             <muxc:ItemsRepeater ItemsSource="{x:Bind ViewModel.ReactionWithUsers, Mode=OneWay}">
                                 <muxc:ItemsRepeater.ItemTemplate>
-                                    <DataTemplate>
+                                    <DataTemplate x:DataType="userviewmodels:ReactionWithUsers">
                                         <Grid>
                                             <common:EmojiButton
-                                                Reaction="{Binding Type, Mode=OneWay}"
-                                                ReactionCommand="{Binding ReactionCommand, Mode=OneWay}"
-                                                ReactionCount="{Binding Users.Count, Mode=OneWay}"
+                                                Reaction="{x:Bind Type, Mode=OneWay}"
+                                                ReactionCommand="{x:Bind ReactionCommand, Mode=OneWay}"
+                                                ReactionCount="{x:Bind Users.Count, Mode=OneWay}"
                                                 ShowReactionCount="True"
-                                                Users="{Binding Users, Mode=OneWay}"
-                                                Voted="{Binding Voted, Mode=OneWay}" />
+                                                Users="{x:Bind Users, Mode=OneWay}"
+                                                Voted="{x:Bind Voted, Mode=OneWay}" />
                                         </Grid>
                                     </DataTemplate>
                                 </muxc:ItemsRepeater.ItemTemplate>

--- a/JitHub.WinUI/Views/Controls/UserCommentBlock.xaml.cs
+++ b/JitHub.WinUI/Views/Controls/UserCommentBlock.xaml.cs
@@ -13,7 +13,7 @@ namespace JitHub.WinUI.Views.Controls
             "Size",
             typeof(UISize),
             typeof(UserCommentBlock),
-            new PropertyMetadata(UISize.BIG, null));
+            new PropertyMetadata(UISize.BIG, OnSizeChanged));
 
         public static DependencyProperty ViewModelProperty = DependencyProperty.Register(
             nameof(ViewModel),
@@ -30,6 +30,16 @@ namespace JitHub.WinUI.Views.Controls
                 {
                     self._loadedViewModel = null;
                 }
+
+                self.Bindings.Update();
+            }
+        }
+
+        private static void OnSizeChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+        {
+            if (d is UserCommentBlock self)
+            {
+                self.Bindings.Update();
             }
         }
         

--- a/JitHub.WinUI/Views/DataTemplates/Filter/DateFilter.xaml
+++ b/JitHub.WinUI/Views/DataTemplates/Filter/DateFilter.xaml
@@ -1,23 +1,9 @@
 <ResourceDictionary
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    >
+    xmlns:filtercontrols="using:JitHub.WinUI.Views.Controls.Filter">
     <DataTemplate x:Key="DateFilter">
-        <Grid>
-            <CalendarDatePicker
-                x:Name="SinceDatePicker"
-                Style="{StaticResource CalendarDatePicker}"
-                MinWidth="150"
-                Header="{Binding Title, Mode=OneWay}"
-                Date="{Binding StartDate, Mode=TwoWay}"
-                PlaceholderText="{Binding Placeholder, Mode=OneWay}">
-                <CalendarDatePicker.HeaderTemplate>
-                    <DataTemplate>
-                        <TextBlock Style="{StaticResource SectionSecondaryTextBlockStyle}" Text="{Binding Mode=OneWay}" />
-                    </DataTemplate>
-                </CalendarDatePicker.HeaderTemplate>
-            </CalendarDatePicker>
-        </Grid>
+        <filtercontrols:DateFilterPresenter Filter="{Binding Mode=OneWay}" />
     </DataTemplate>
 </ResourceDictionary>
 

--- a/JitHub.WinUI/Views/DataTemplates/Filter/DropdownFilter.xaml
+++ b/JitHub.WinUI/Views/DataTemplates/Filter/DropdownFilter.xaml
@@ -1,26 +1,9 @@
 <ResourceDictionary
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    >
+    xmlns:filtercontrols="using:JitHub.WinUI.Views.Controls.Filter">
     <DataTemplate x:Key="DropdownFilter">
-        <Grid>
-            <ComboBox
-                Style="{StaticResource ComboBox}"
-                Width="172"
-                MinWidth="172"
-                HorizontalAlignment="Left"
-                Header="{Binding Title, Mode=OneWay}"
-                DisplayMemberPath="DisplayMember"
-                ItemsSource="{Binding Selections, Mode=OneWay}"
-                SelectedItem="{Binding Selected, Mode=TwoWay}"
-                SelectedValuePath="SelectedValue">
-                <ComboBox.HeaderTemplate>
-                    <DataTemplate>
-                        <TextBlock Style="{StaticResource SectionSecondaryTextBlockStyle}" Text="{Binding Mode=OneWay}" />
-                    </DataTemplate>
-                </ComboBox.HeaderTemplate>
-            </ComboBox>
-        </Grid>
+        <filtercontrols:DropdownFilterPresenter Filter="{Binding Mode=OneWay}" />
     </DataTemplate>
 </ResourceDictionary>
 

--- a/JitHub.WinUI/Views/DataTemplates/Filter/TextFilter.xaml
+++ b/JitHub.WinUI/Views/DataTemplates/Filter/TextFilter.xaml
@@ -1,24 +1,9 @@
 <ResourceDictionary
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    >
+    xmlns:filtercontrols="using:JitHub.WinUI.Views.Controls.Filter">
     <DataTemplate x:Key="TextFilter">
-        <Grid>
-            <StackPanel Spacing="4">
-                <TextBox
-                    Style="{StaticResource AppTextBoxStyle}"
-                    MinWidth="150"
-                    Header="{Binding Title, Mode=OneWay}"
-                    PlaceholderText="Type to filter"
-                    Text="{Binding Text, Mode=TwoWay}">
-                    <TextBox.HeaderTemplate>
-                        <DataTemplate>
-                            <TextBlock Style="{StaticResource SectionSecondaryTextBlockStyle}" Text="{Binding Mode=OneWay}" />
-                        </DataTemplate>
-                    </TextBox.HeaderTemplate>
-                </TextBox>
-            </StackPanel>
-        </Grid>
+        <filtercontrols:TextFilterPresenter Filter="{Binding Mode=OneWay}" />
     </DataTemplate>
 </ResourceDictionary>
 

--- a/JitHub.WinUI/Views/DataTemplates/IssueListItem.xaml
+++ b/JitHub.WinUI/Views/DataTemplates/IssueListItem.xaml
@@ -2,54 +2,11 @@
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:controls="using:CommunityToolkit.WinUI.UI.Controls"
+    xmlns:issuecontrols="using:JitHub.WinUI.Views.Controls.Issue"
     xmlns:local="using:JitHub.WinUI.Views.DataTemplates"
     xmlns:muxc="using:Microsoft.UI.Xaml.Controls">
     <DataTemplate x:Key="IssueListItem">
-
-        <Grid Padding="4">
-            <StackPanel Margin="4,0,0,0" Spacing="4">
-                <Grid>
-                    <Grid.ColumnDefinitions>
-                        <ColumnDefinition Width="auto" />
-                        <ColumnDefinition Width="*" />
-                    </Grid.ColumnDefinitions>
-                    <Rectangle
-                        Grid.Column="0"
-                        Width="10"
-                        Height="10"
-                        Margin="0,0,4,0"
-                        VerticalAlignment="Center"
-                        Fill="{Binding Model.State, Converter={StaticResource OpenStatusToColorConverter}, Mode=OneWay}"
-                        RadiusX="6"
-                        RadiusY="6" />
-
-                    <TextBlock
-                        Grid.Column="1"
-                        Padding="0,0,0,4"
-                        VerticalAlignment="Center"
-                        FontSize="16"
-                        FontWeight="SemiBold"
-                        Text="{Binding Model.Title, Mode=OneWay}"
-                        TextWrapping="Wrap" />
-
-                </Grid>
-
-                <muxc:ItemsRepeater ItemTemplate="{StaticResource IssueLabel}" ItemsSource="{Binding Model.Labels, Converter={StaticResource ListToShorterListConverter}, ConverterParameter='3', Mode=OneWay}">
-                    <muxc:ItemsRepeater.Layout>
-                        <muxc:StackLayout Orientation="Horizontal" Spacing="4" />
-                    </muxc:ItemsRepeater.Layout>
-                </muxc:ItemsRepeater>
-                <Grid Grid.Row="1">
-                    <StackPanel Orientation="Horizontal" Spacing="5">
-                        <TextBlock Foreground="{ThemeResource AppInkSubtleBrush}">
-                            <Run Text="{Binding Model.Number, Converter={StaticResource NumberToHashTaggedStringConverter}, Mode=OneWay}" />
-                            <Run Text="{Binding Model.CreatedAt, Converter={StaticResource OpenDateToStringConverter}, Mode=OneWay}" />
-                            <Run Text="{Binding Model.User, Converter={StaticResource UserToDiscriptionStringConverter}, Mode=OneWay}" />
-                        </TextBlock>
-                    </StackPanel>
-                </Grid>
-            </StackPanel>
-        </Grid>
+        <issuecontrols:IssueListItemPresenter Item="{Binding Mode=OneWay}" />
     </DataTemplate>
 </ResourceDictionary>
 

--- a/JitHub.WinUI/Views/DataTemplates/PullRequest/ConversationPlainComment.xaml
+++ b/JitHub.WinUI/Views/DataTemplates/PullRequest/ConversationPlainComment.xaml
@@ -6,7 +6,7 @@
     <DataTemplate x:Key="PRConversationPlainCommentDataTemplate">
         <!--  For issue style comments  -->
         <Grid>
-            <usercontrols:UserCommentBlock ViewModel="{Binding Item, Converter={StaticResource IssueCommentNodeToUserCommentBlockViewModelConverter}, Mode=OneWay}" />
+            <usercontrols:UserCommentBlock ViewModel="{Binding Converter={StaticResource IssueCommentNodeToUserCommentBlockViewModelConverter}, Mode=OneWay}" />
         </Grid>
     </DataTemplate>
 </ResourceDictionary>

--- a/JitHub.WinUI/Views/DataTemplates/PullRequest/ConversationReview.xaml
+++ b/JitHub.WinUI/Views/DataTemplates/PullRequest/ConversationReview.xaml
@@ -5,7 +5,7 @@
     <DataTemplate x:Key="PRConversationReviewDataTemplate" x:Name="PRConversationReviewDataTemplate">
         <!--  For multiple blocks of comments in a single review  -->
         <Grid>
-            <conversation:ReviewBlock ViewModel="{Binding Item, Converter={StaticResource ReviewNodeToViewModelConverter}, Mode=OneWay}" />
+            <conversation:ReviewBlock ViewModel="{Binding Converter={StaticResource ReviewNodeToViewModelConverter}, Mode=OneWay}" />
         </Grid>
     </DataTemplate>
 </ResourceDictionary>

--- a/JitHub.WinUI/Views/DataTemplates/PullRequestListItem.xaml
+++ b/JitHub.WinUI/Views/DataTemplates/PullRequestListItem.xaml
@@ -2,29 +2,10 @@
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:controls="using:CommunityToolkit.WinUI.UI.Controls"
-    xmlns:muxc="using:Microsoft.UI.Xaml.Controls">
+    xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
+    xmlns:prcontrols="using:JitHub.WinUI.Views.Controls.PullRequest">
     <DataTemplate x:Key="PullRequestListItem">
-        <Grid Padding="4,8">
-            <StackPanel Margin="4,0,0,0" Spacing="4">
-                <TextBlock
-                    FontSize="16"
-                    FontWeight="SemiBold"
-                    Text="{Binding Model.Title}"
-                    TextWrapping="Wrap" />
-                <muxc:ItemsRepeater ItemTemplate="{StaticResource IssueLabel}" ItemsSource="{Binding Model.Labels, Converter={StaticResource ListToShorterListConverter}, ConverterParameter='3', Mode=OneWay}">
-                    <muxc:ItemsRepeater.Layout>
-                        <muxc:StackLayout Orientation="Horizontal" Spacing="4" />
-                    </muxc:ItemsRepeater.Layout>
-                </muxc:ItemsRepeater>
-                <StackPanel Orientation="Horizontal" Spacing="4">
-                    <TextBlock Foreground="{ThemeResource AppInkSubtleBrush}">
-                        <Run Text="{Binding Model.Number, Converter={StaticResource NumberToHashTaggedStringConverter}, Mode=OneWay}" />
-                        <Run Text="{Binding Model.CreatedAt, Converter={StaticResource OpenDateToStringConverter}, Mode=OneWay}" />
-                        <Run Text="{Binding Model.User, Converter={StaticResource UserToDiscriptionStringConverter}, Mode=OneWay}" />
-                    </TextBlock>
-                </StackPanel>
-            </StackPanel>
-        </Grid>
+        <prcontrols:PullRequestListItemPresenter Item="{Binding Mode=OneWay}" />
     </DataTemplate>
 </ResourceDictionary>
 

--- a/JitHub.WinUI/Views/DataTemplates/RepoListItem.xaml
+++ b/JitHub.WinUI/Views/DataTemplates/RepoListItem.xaml
@@ -34,7 +34,7 @@
                     <TextBlock
                         Grid.Column="0"
                         Style="{StaticResource TitleStyle}"
-                        Text="{Binding Repository.Name}" />
+                        Text="{Binding Name}" />
                     <Grid
                         Grid.Column="1"
                         Padding="5,2"
@@ -55,14 +55,14 @@
                         <TextBlock
                             Grid.Column="1"
                             FontSize="14"
-                            Text="{Binding Repository.StargazersCount}" />
+                            Text="{Binding StargazersCount}" />
                     </Grid>
 
                 </Grid>
                 <TextBlock
                     Grid.Row="1"
                     Foreground="{ThemeResource AppInkSubtleBrush}"
-                    Text="{Binding Repository.Description}" />
+                    Text="{Binding Description}" />
                 <StackPanel
                     Grid.Row="2"
                     HorizontalAlignment="Stretch"
@@ -70,9 +70,9 @@
                     Orientation="Horizontal">
                     <TextBlock
                         Margin="0,0,15,0"
-                        Text="{Binding Repository.Language}"
-                        Visibility="{Binding Repository.Language, Converter={StaticResource LanguageToVisibilityConverter}, Mode=OneWay}" />
-                    <TextBlock Text="{Binding Repository.UpdatedAt, Converter={StaticResource TimeAgoConverter}, Mode=OneWay}" />
+                        Text="{Binding Language}"
+                        Visibility="{Binding Language, Converter={StaticResource LanguageToVisibilityConverter}, Mode=OneWay}" />
+                    <TextBlock Text="{Binding UpdatedAt, Converter={StaticResource TimeAgoConverter}, Mode=OneWay}" />
                 </StackPanel>
             </Grid>
         </Button>

--- a/JitHub.WinUI/Views/DataTemplates/Repository/ForkRepo.xaml
+++ b/JitHub.WinUI/Views/DataTemplates/Repository/ForkRepo.xaml
@@ -20,7 +20,7 @@
                         IconBrush="{ThemeResource AppInkMutedBrush}"
                         IconKind="Fork"
                         IconSize="16" />
-                    <TextBlock VerticalAlignment="Center" Text="{Binding Repository.Name}" />
+                    <TextBlock VerticalAlignment="Center" Text="{Binding Name}" />
                 </StackPanel>
             </Grid>
         </Button>
@@ -44,14 +44,14 @@
                     IconKind="Fork"
                     IconSize="16" />
                 <StackPanel Grid.Column="1">
-                    <TextBlock Text="{Binding Repository.FullName, Mode=OneWay}" />
-                    <TextBlock Text="{Binding Repository.Description, Mode=OneWay}" TextWrapping="Wrap" />
+                    <TextBlock Text="{Binding FullName, Mode=OneWay}" />
+                    <TextBlock Text="{Binding Description, Mode=OneWay}" TextWrapping="Wrap" />
                     <StackPanel Orientation="Horizontal">
                         <appcontrols:AppIcon
                             IconBrush="{ThemeResource AppWarmAccentBrush}"
                             IconKind="Star"
                             IconSize="14" />
-                        <TextBlock Text="{Binding Repository.StargazersCount, Converter={StaticResource NumberToKizedStringConverter}, Mode=OneWay}" />
+                        <TextBlock Text="{Binding StargazersCount, Converter={StaticResource NumberToKizedStringConverter}, Mode=OneWay}" />
                     </StackPanel>
                 </StackPanel>
             </Grid>
@@ -73,14 +73,14 @@
                         IconKind="Fork"
                         IconSize="16" />
                     <StackPanel Grid.Column="1">
-                        <TextBlock Text="{Binding Repo.Repository.FullName, Mode=OneWay}" />
-                        <TextBlock Text="{Binding Repo.Repository.Description, Mode=OneWay}" TextWrapping="Wrap" />
+                        <TextBlock Text="{Binding FullName, Mode=OneWay}" />
+                        <TextBlock Text="{Binding Description, Mode=OneWay}" TextWrapping="Wrap" />
                         <StackPanel Orientation="Horizontal" Spacing="4">
                             <appcontrols:AppIcon
                                 IconBrush="{ThemeResource AppWarmAccentBrush}"
                                 IconKind="Star"
                                 IconSize="14" />
-                            <TextBlock VerticalAlignment="Center" Text="{Binding Repo.Repository.StargazersCount, Converter={StaticResource NumberToKizedStringConverter}, Mode=OneWay}" />
+                            <TextBlock VerticalAlignment="Center" Text="{Binding StargazersCount, Converter={StaticResource NumberToKizedStringConverter}, Mode=OneWay}" />
                         </StackPanel>
                     </StackPanel>
                 </Grid>

--- a/JitHub.WinUI/Views/DataTemplates/Repository/PrivateRepo.xaml
+++ b/JitHub.WinUI/Views/DataTemplates/Repository/PrivateRepo.xaml
@@ -20,7 +20,7 @@
                         IconBrush="{ThemeResource PrivateRepoBrush}"
                         IconKind="PrivateRepository"
                         IconSize="16" />
-                    <TextBlock VerticalAlignment="Center" Text="{Binding Repository.Name}" />
+                    <TextBlock VerticalAlignment="Center" Text="{Binding Name}" />
                 </StackPanel>
             </Grid>
         </Button>
@@ -44,14 +44,14 @@
                     IconKind="PrivateRepository"
                     IconSize="16" />
                 <StackPanel Grid.Column="1">
-                    <TextBlock Text="{Binding Repository.FullName, Mode=OneWay}" />
-                    <TextBlock Text="{Binding Repository.Description, Mode=OneWay}" TextWrapping="Wrap" />
+                    <TextBlock Text="{Binding FullName, Mode=OneWay}" />
+                    <TextBlock Text="{Binding Description, Mode=OneWay}" TextWrapping="Wrap" />
                     <StackPanel Orientation="Horizontal">
                         <appcontrols:AppIcon
                             IconBrush="{ThemeResource AppWarmAccentBrush}"
                             IconKind="Star"
                             IconSize="14" />
-                        <TextBlock Text="{Binding Repository.StargazersCount, Converter={StaticResource NumberToKizedStringConverter}, Mode=OneWay}" />
+                        <TextBlock Text="{Binding StargazersCount, Converter={StaticResource NumberToKizedStringConverter}, Mode=OneWay}" />
                     </StackPanel>
                 </StackPanel>
             </Grid>
@@ -73,14 +73,14 @@
                         IconKind="PrivateRepository"
                         IconSize="16" />
                     <StackPanel Grid.Column="1">
-                        <TextBlock Text="{Binding Repo.Repository.FullName, Mode=OneWay}" />
-                        <TextBlock Text="{Binding Repo.Repository.Description, Mode=OneWay}" TextWrapping="Wrap" />
+                        <TextBlock Text="{Binding FullName, Mode=OneWay}" />
+                        <TextBlock Text="{Binding Description, Mode=OneWay}" TextWrapping="Wrap" />
                         <StackPanel Orientation="Horizontal" Spacing="4">
                             <appcontrols:AppIcon
                                 IconBrush="{ThemeResource AppWarmAccentBrush}"
                                 IconKind="Star"
                                 IconSize="14" />
-                            <TextBlock Text="{Binding Repo.Repository.StargazersCount, Converter={StaticResource NumberToKizedStringConverter}, Mode=OneWay}" />
+                            <TextBlock Text="{Binding StargazersCount, Converter={StaticResource NumberToKizedStringConverter}, Mode=OneWay}" />
                         </StackPanel>
                     </StackPanel>
                 </Grid>

--- a/JitHub.WinUI/Views/DataTemplates/Repository/PublicRepo.xaml
+++ b/JitHub.WinUI/Views/DataTemplates/Repository/PublicRepo.xaml
@@ -20,7 +20,7 @@
                         IconBrush="{ThemeResource AppInkMutedBrush}"
                         IconKind="PublicRepository"
                         IconSize="16" />
-                    <TextBlock VerticalAlignment="Center" Text="{Binding Repository.Name}" />
+                    <TextBlock VerticalAlignment="Center" Text="{Binding Name}" />
                 </StackPanel>
             </Grid>
         </Button>
@@ -47,15 +47,15 @@
                     <TextBlock
                         FontSize="16"
                         FontWeight="SemiBold"
-                        Text="{Binding Repository.FullName, Mode=OneWay}" />
-                    <TextBlock Text="{Binding Repository.Description, Mode=OneWay}" TextWrapping="Wrap" />
+                        Text="{Binding FullName, Mode=OneWay}" />
+                    <TextBlock Text="{Binding Description, Mode=OneWay}" TextWrapping="Wrap" />
                     <StackPanel Orientation="Horizontal" Spacing="5">
                         <appcontrols:AppIcon
                             VerticalAlignment="Center"
                             IconBrush="{ThemeResource AppWarmAccentBrush}"
                             IconKind="Star"
                             IconSize="13" />
-                        <TextBlock VerticalAlignment="Bottom" Text="{Binding Repository.StargazersCount, Converter={StaticResource NumberToKizedStringConverter}, Mode=OneWay}" />
+                        <TextBlock VerticalAlignment="Bottom" Text="{Binding StargazersCount, Converter={StaticResource NumberToKizedStringConverter}, Mode=OneWay}" />
                     </StackPanel>
                 </StackPanel>
             </Grid>
@@ -77,14 +77,14 @@
                         IconKind="PublicRepository"
                         IconSize="16" />
                     <StackPanel Grid.Column="1">
-                        <TextBlock Text="{Binding Repo.Repository.FullName, Mode=OneWay}" />
-                        <TextBlock Text="{Binding Repo.Repository.Description, Mode=OneWay}" TextWrapping="Wrap" />
+                        <TextBlock Text="{Binding FullName, Mode=OneWay}" />
+                        <TextBlock Text="{Binding Description, Mode=OneWay}" TextWrapping="Wrap" />
                         <StackPanel Orientation="Horizontal" Spacing="4">
                             <appcontrols:AppIcon
                                 IconBrush="{ThemeResource AppWarmAccentBrush}"
                                 IconKind="Star"
                                 IconSize="14" />
-                            <TextBlock Text="{Binding Repo.Repository.StargazersCount, Converter={StaticResource NumberToKizedStringConverter}, Mode=OneWay}" />
+                            <TextBlock Text="{Binding StargazersCount, Converter={StaticResource NumberToKizedStringConverter}, Mode=OneWay}" />
                         </StackPanel>
                     </StackPanel>
                 </Grid>

--- a/JitHub.WinUI/Views/Pages/Design/DesignLabPage.xaml.cs
+++ b/JitHub.WinUI/Views/Pages/Design/DesignLabPage.xaml.cs
@@ -18,8 +18,8 @@ public sealed partial class DesignLabPage : Page
     public Label BugLabel { get; } = new(1, string.Empty, "bug", string.Empty, "F2C94C", "Something is not behaving correctly.", false);
     public Label AccessibilityLabel { get; } = new(2, string.Empty, "accessibility", string.Empty, "7BB99C", "Accessibility and keyboard polish.", false);
     public Label NeedsTriageLabel { get; } = new(3, string.Empty, "needs triage", string.Empty, "D7C39B", "Needs owner review.", false);
-    public IReadOnlyList<ActivityCardViewModel> ActivityCards { get; } = ActivityMockData.CreateCards();
-    public IReadOnlyList<ConversationNode> PullRequestTimelineItems { get; } = CreatePullRequestTimelineItems();
+    public List<ActivityCardViewModel> ActivityCards { get; } = ActivityMockData.CreateCards();
+    public List<ConversationNode> PullRequestTimelineItems { get; } = CreatePullRequestTimelineItems();
     public EmojiPanelViewModel DemoEmojiPanelViewModel { get; } = new()
     {
         VotesMap = new Dictionary<ReactionType, Reaction>
@@ -83,7 +83,7 @@ public sealed partial class DesignLabPage : Page
         }
     }
 
-    private static IReadOnlyList<ConversationNode> CreatePullRequestTimelineItems()
+    private static List<ConversationNode> CreatePullRequestTimelineItems()
     {
         Repository repo = CreateRepo();
         User actor = CreateUser("cdacamar", "https://avatars.githubusercontent.com/u/1755071?v=4");

--- a/JitHub.WinUI/Views/Pages/IssuePage/IssueDetailPage.xaml
+++ b/JitHub.WinUI/Views/Pages/IssuePage/IssueDetailPage.xaml
@@ -153,7 +153,7 @@
                             <DataTemplate>
                                 <Grid>
                                     <controls:UserCommentBlock
-                                        ViewModel="{Binding Item, Mode=OneWay}"/>
+                                        ViewModel="{Binding Mode=OneWay}"/>
                                 </Grid>
                             </DataTemplate>
                         </muxc:ItemsRepeater.ItemTemplate>

--- a/JitHub.WinUI/Views/Pages/IssuePage/IssueDetailPage.xaml.cs
+++ b/JitHub.WinUI/Views/Pages/IssuePage/IssueDetailPage.xaml.cs
@@ -31,6 +31,7 @@ namespace JitHub.WinUI.Views.Pages.IssuePage
             {
                 ViewModel = viewModel;
                 DataContext = viewModel;
+                Bindings.Update();
                 if (viewModel.LoadCommand.CanExecute(null))
                 {
                     viewModel.LoadCommand.Execute(null);

--- a/JitHub.WinUI/Views/Pages/PullRequestCommitsPage.xaml
+++ b/JitHub.WinUI/Views/Pages/PullRequestCommitsPage.xaml
@@ -26,11 +26,9 @@
             SelectionChanged="{x:Bind ViewModel.SelectionChanged, Mode=OneWay}">
             <controls:ListDetailsView.ItemTemplate>
                 <DataTemplate>
-                    <Grid>
-                        <commit:CommitItem
-                            ViewModel="{Binding Item, Mode=OneWay}"
-                            ShowHoverMenu="True"/>
-                    </Grid>
+                    <commit:CommitListDetailsItemPresenter
+                        Item="{Binding Mode=OneWay}"
+                        ShowHoverMenu="True"/>
                 </DataTemplate>
             </controls:ListDetailsView.ItemTemplate>
             <controls:ListDetailsView.NoSelectionContentTemplate>
@@ -40,11 +38,7 @@
             </controls:ListDetailsView.NoSelectionContentTemplate>
             <controls:ListDetailsView.DetailsTemplate>
                 <DataTemplate>
-                    <Grid
-                        Padding="5">
-                        <commit:CommitDetail
-                            Commit="{Binding Item, Mode=OneWay}"/>
-                    </Grid>
+                    <commit:CommitListDetailsDetailPresenter Item="{Binding Mode=OneWay}"/>
                 </DataTemplate>
             </controls:ListDetailsView.DetailsTemplate>
         </controls:ListDetailsView>

--- a/JitHub.WinUI/Views/Pages/PullRequestConversationPage.xaml.cs
+++ b/JitHub.WinUI/Views/Pages/PullRequestConversationPage.xaml.cs
@@ -30,7 +30,9 @@ namespace JitHub.WinUI.Views.Pages
                 {
                     ViewModel = new PullRequestConversationViewModel(arg.Repository, arg.PullRequest, arg.RefreshCommand, ScrollToBottom, new RelayCommand<UIElement?>(ScrollToElement));
                     DataContext = ViewModel;
+                    Bindings.Update();
                     await ViewModel.OnNavigatedTo();
+                    Bindings.Update();
                 }
             }
             catch (System.Exception ex)

--- a/JitHub.WinUI/Views/Pages/RepoCommitDetailPage.xaml
+++ b/JitHub.WinUI/Views/Pages/RepoCommitDetailPage.xaml
@@ -105,7 +105,7 @@
                 <muxc:ItemsRepeater.ItemTemplate>
                     <DataTemplate>
                         <Grid>
-                            <commit:FileDiff ViewModel="{Binding Item, Mode=OneWay}"/>
+                            <commit:FileDiff ViewModel="{Binding Mode=OneWay}"/>
                         </Grid>
                     </DataTemplate>
                 </muxc:ItemsRepeater.ItemTemplate>

--- a/JitHub.WinUI/Views/Pages/RepoCommitDetailPage.xaml.cs
+++ b/JitHub.WinUI/Views/Pages/RepoCommitDetailPage.xaml.cs
@@ -8,11 +8,11 @@ namespace JitHub.WinUI.Views.Pages;
 
 public sealed partial class RepoCommitDetailPage : Page
 {
-    public CommitDetailViewModel ViewModel { get; private set; }
+    public CommitDetailViewModel ViewModel { get; } = new();
+
     public RepoCommitDetailPage()
     {
         this.InitializeComponent();
-        ViewModel = new CommitDetailViewModel();
         DataContext = ViewModel;
     }
 

--- a/JitHub.WinUI/Views/Pages/RepoCommitsPage.xaml
+++ b/JitHub.WinUI/Views/Pages/RepoCommitsPage.xaml
@@ -45,10 +45,7 @@
             SelectionChanged="{x:Bind ViewModel.SelectionChanged, Mode=OneWay}">
             <controls:ListDetailsView.ItemTemplate>
                 <DataTemplate>
-                    <Grid>
-                        <commit:CommitItem
-                            ViewModel="{Binding Item, Mode=OneWay}"/>
-                    </Grid>
+                    <commit:CommitListDetailsItemPresenter Item="{Binding Mode=OneWay}"/>
                 </DataTemplate>
             </controls:ListDetailsView.ItemTemplate>
             <controls:ListDetailsView.NoSelectionContentTemplate>
@@ -73,11 +70,7 @@
             </controls:ListDetailsView.NoSelectionContentTemplate>
             <controls:ListDetailsView.DetailsTemplate>
                 <DataTemplate>
-                    <Grid
-                        Padding="4">
-                        <commit:CommitDetail
-                            Commit="{Binding Item, Mode=OneWay}"/>
-                    </Grid>
+                    <commit:CommitListDetailsDetailPresenter Item="{Binding Mode=OneWay}"/>
                 </DataTemplate>
             </controls:ListDetailsView.DetailsTemplate>
         </controls:ListDetailsView>

--- a/JitHub.WinUI/Views/Pages/RepoIssuePage.xaml
+++ b/JitHub.WinUI/Views/Pages/RepoIssuePage.xaml
@@ -72,7 +72,7 @@
             <controls:ListDetailsView.DetailsTemplate>
                 <DataTemplate>
                     <issue:RepoIssueDetail
-                        Issue="{Binding Item, Mode=OneWay}"/>
+                        Issue="{Binding Mode=OneWay}"/>
                 </DataTemplate>
             </controls:ListDetailsView.DetailsTemplate>
             <controls:ListDetailsView.NoSelectionContentTemplate>

--- a/JitHub.WinUI/Views/Pages/ShellPage.xaml.cs
+++ b/JitHub.WinUI/Views/Pages/ShellPage.xaml.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.ComponentModel;
 using System.Threading;
 using System.Threading.Tasks;
@@ -546,8 +547,9 @@ public sealed partial class ShellPage : Page
         return false;
     }
 
-    private static GitHubRepository[] CreateAutomationSearchResults() =>
-    [
+    private static List<GitHubRepository> CreateAutomationSearchResults() =>
+    new()
+    {
         CreateAutomationRepository(1, "flutter", "flutter", "Flutter makes it easy and fast to build beautiful apps."),
         CreateAutomationRepository(2, "flutter", "plugins", "Plugins for Flutter maintained by the Flutter team."),
         CreateAutomationRepository(3, "iampawan", "FlutterExampleApps", "Example Flutter apps for UI and architecture testing."),
@@ -556,7 +558,7 @@ public sealed partial class ShellPage : Page
         CreateAutomationRepository(6, "kaina404", "FlutterDouBan", "DouBan client written in Flutter."),
         CreateAutomationRepository(7, "toly1994328", "FlutterUnit", "Flutter samples and widgets."),
         CreateAutomationRepository(8, "flutter", "engine", "The Flutter engine.")
-    ];
+    };
 
     private static GitHubRepository CreateAutomationRepository(long id, string owner, string name, string description) =>
         new()

--- a/JitHub.slnx
+++ b/JitHub.slnx
@@ -9,16 +9,15 @@
   <Project Path="JitHub.Web/JitHub.Web.csproj" />
   <Project Path="JitHub.WinUI.Automation/JitHub.WinUI.Automation.csproj" />
   <Project Path="JitHub.WinUI/JitHub.WinUI.csproj">
+    <Platform Solution="*|Any CPU" Project="x64" />
     <Platform Solution="*|ARM" Project="x86" />
     <Platform Solution="*|ARM64" Project="ARM64" />
     <Platform Solution="*|x64" Project="x64" />
     <Platform Solution="*|x86" Project="x86" />
-    <Platform Solution="Debug|Any CPU" Project="x64" />
-    <Platform Solution="Release|Any CPU" Project="x86" />
+    <Deploy Solution="*|Any CPU" />
     <Deploy Solution="*|ARM64" />
     <Deploy Solution="*|x64" />
     <Deploy Solution="*|x86" />
-    <Deploy Solution="Debug|Any CPU" />
   </Project>
   <Project Path="JitHub.WinUI.Tests/JitHub.WinUI.Tests.csproj">
     <Platform Solution="*|ARM" Project="x86" />

--- a/JitHub.slnx
+++ b/JitHub.slnx
@@ -9,15 +9,16 @@
   <Project Path="JitHub.Web/JitHub.Web.csproj" />
   <Project Path="JitHub.WinUI.Automation/JitHub.WinUI.Automation.csproj" />
   <Project Path="JitHub.WinUI/JitHub.WinUI.csproj">
-    <Platform Solution="*|Any CPU" Project="x64" />
     <Platform Solution="*|ARM" Project="x86" />
     <Platform Solution="*|ARM64" Project="ARM64" />
     <Platform Solution="*|x64" Project="x64" />
     <Platform Solution="*|x86" Project="x86" />
-    <Deploy Solution="*|Any CPU" />
+    <Platform Solution="Debug|Any CPU" Project="x64" />
+    <Platform Solution="Release|Any CPU" Project="x86" />
     <Deploy Solution="*|ARM64" />
     <Deploy Solution="*|x64" />
     <Deploy Solution="*|x86" />
+    <Deploy Solution="Debug|Any CPU" />
   </Project>
   <Project Path="JitHub.WinUI.Tests/JitHub.WinUI.Tests.csproj">
     <Platform Solution="*|ARM" Project="x86" />


### PR DESCRIPTION
## Summary

- Replaced trim-fragile loose-template/property-path bindings with code-backed presenters across release-broken UI surfaces.
- Restored issue and pull request filtering by moving filter templates behind presenters, explicitly committing Apply/Clear values, resetting stale request state, and wiring issue label filters.
- Added public-preview issue/PR filter handling so packaged release smoke tests can exercise filter behavior without depending on GitHub API state.
- Added a XAML binding pattern regression test to catch the release-mode binding shape that caused these failures.

## Root Cause

Release trimming was breaking untyped XAML binding paths in loose templates and related UI surfaces. Debug mode kept enough reflection metadata around for those bindings to appear healthy, but packaged Release lost binding data, leaving controls blank or non-functional. Some filters also held stale request objects between Apply/Clear, so even working controls could leave old filter parameters behind.

## Validation

- `dotnet test JitHub.WinUI.Tests\JitHub.WinUI.Tests.csproj -c Release -p:Platform=x64` passed, 92/92.
- `dotnet build JitHub.WinUI\JitHub.WinUI.csproj -c Release -p:Platform=x64` succeeded with the existing `SvgPreview` trim warning.
- Packaged Release smoke: PR State, PR Head, Issue State, and Issue Labels filters applied and Clear restored lists without crashing.
- Windows Application event log showed 0 JitHub crashes since the final packaged launch.