### PR TITLE
[codex] Improve markdown accessibility and selection

### DIFF
--- a/MarkdownRenderer/MarkdownRenderer.Gfm/Renderers/TaskListItemRenderer.cs
+++ b/MarkdownRenderer/MarkdownRenderer.Gfm/Renderers/TaskListItemRenderer.cs
@@ -2,6 +2,7 @@ using Markdig.Extensions.TaskLists;
 using Markdig.Syntax;
 using Markdig.Syntax.Inlines;
 using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Automation;
 using Microsoft.UI.Xaml.Controls;
 using MarkdownRenderer.Layout;
 using MarkdownRenderer.Layout.Boxes;
@@ -42,23 +43,16 @@ public sealed class TaskListItemRenderer : MarkdownNodeRenderer<ListItemBlock>
 
         var marker = new InlineContainerBox(context, MarkdownElementKeys.ListMarker);
         marker.BlockIndex = context.NextBlockIndex();
-        marker.Add(new InlineEmbedRun(20f, 20f, () => new CheckBox
-        {
-            IsChecked = isChecked,
-            IsEnabled = false,
-            MinWidth = 20,
-            MinHeight = 20,
-            Padding = new Thickness(0),
-            Margin = new Thickness(0),
-            HorizontalContentAlignment = HorizontalAlignment.Left,
-            VerticalContentAlignment = VerticalAlignment.Center,
-        })
+        marker.Add(new InlineEmbedRun(20f, 20f, () => CreateTaskCheckBox(isChecked))
         {
             ElementKey = MarkdownElementKeys.ListMarker,
             SourceSpan = new MarkdownRenderer.SourceSpan(listItem.Span.Start, 0)
         });
 
-        var content = new StackBox();
+        var content = new StackBox
+        {
+            FlowDirection = context.FlowDirection,
+        };
         content.BlockIndex = context.NextBlockIndex();
 
         foreach (var child in listItem)
@@ -69,7 +63,7 @@ public sealed class TaskListItemRenderer : MarkdownNodeRenderer<ListItemBlock>
                 contentBox.BlockIndex = context.NextBlockIndex();
                 // Skip the TaskList inline — it's the marker, not body content.
                 GfmChildBuilder.AddInlines(contentBox, p.Inline, skipFirstIf: i => i is TaskList);
-            content.Add(contentBox);
+                content.Add(contentBox);
             }
             else
             {
@@ -78,6 +72,38 @@ public sealed class TaskListItemRenderer : MarkdownNodeRenderer<ListItemBlock>
             }
         }
 
-        return new ListItemBox(marker, content, markerWidth: 28f);
+        return new ListItemBox(marker, content, markerWidth: 28f)
+        {
+            FlowDirection = context.FlowDirection,
+        };
+    }
+
+    private static CheckBox CreateTaskCheckBox(bool isChecked)
+    {
+        var checkBox = new CheckBox
+        {
+            IsChecked = isChecked,
+            IsEnabled = true,
+            IsTabStop = true,
+            MinWidth = 20,
+            MinHeight = 20,
+            Padding = new Thickness(0),
+            Margin = new Thickness(0),
+            HorizontalContentAlignment = HorizontalAlignment.Left,
+            VerticalContentAlignment = VerticalAlignment.Center,
+        };
+
+        AutomationProperties.SetName(checkBox, isChecked ? "Completed task" : "Incomplete task");
+        AutomationProperties.SetHelpText(checkBox, "Read-only task checkbox");
+
+        void RestoreCheckedState(object sender, RoutedEventArgs e)
+        {
+            if (checkBox.IsChecked != isChecked)
+                checkBox.IsChecked = isChecked;
+        }
+
+        checkBox.Checked += RestoreCheckedState;
+        checkBox.Unchecked += RestoreCheckedState;
+        return checkBox;
     }
 }

--- a/MarkdownRenderer/MarkdownRenderer.Sample.Automation/Program.cs
+++ b/MarkdownRenderer/MarkdownRenderer.Sample.Automation/Program.cs
@@ -11,6 +11,8 @@ namespace MarkdownRenderer.Sample.Automation;
 
 internal static class Program
 {
+    private const string DiagnosticsEnvironmentVariable = "MARKDOWN_RENDERER_DIAGNOSTICS";
+
     private static readonly List<string> Failures = new();
     private static readonly List<string> Passes = new();
 
@@ -21,21 +23,35 @@ internal static class Program
             ?? throw new InvalidOperationException(
                 "Cannot locate MarkdownRenderer.Sample.exe. Pass --app-path <exe>.");
 
+        if (args.Contains("--narrator-smoke", StringComparer.OrdinalIgnoreCase))
+            return RunNarratorSmoke(appPath);
+
         Console.WriteLine($"[automation] launching {appPath}");
         KillExistingApplicationInstances(appPath);
-        using var app = Application.Launch(new ProcessStartInfo(appPath) { UseShellExecute = false });
+        using var app = LaunchSample(appPath, enableDiagnostics: true);
         using var automation = new UIA3Automation();
         try
         {
-            var window = Retry.WhileNull(() => app.GetMainWindow(automation),
+            var window = Retry.WhileNull(() =>
+                {
+                    try { return app.GetMainWindow(automation); }
+                    catch { return null; }
+                },
                 timeout: TimeSpan.FromSeconds(30), interval: TimeSpan.FromMilliseconds(250)).Result
                 ?? throw new InvalidOperationException("Main window did not appear.");
-            window.Focus();
+            WaitForSampleContent(window, app);
+            TryFocus(window, "main window");
             Thread.Sleep(750);
 
             RunProbe("automation-tree-shape", () => ProbeAutomationTreeShape(window));
             RunProbe("rtl-toggle-flips-flow",  () => ProbeRtlToggle(window));
             RunProbe("sample-buttons-discoverable", () => ProbeSampleButtons(window));
+            RunProbe("accessibility-lab-text-pattern", () => ProbeAccessibilityLabTextPattern(window));
+            RunProbe("accessibility-lab-semantic-roles", () => ProbeAccessibilityLabSemanticRoles(window));
+            RunProbe("accessibility-lab-text-attributes", () => ProbeAccessibilityLabTextAttributes(window));
+            RunProbe("accessibility-lab-forced-high-contrast", () => ProbeAccessibilityLabForcedHighContrast(window));
+            RunProbe("accessibility-lab-keyboard-order", () => ProbeAccessibilityLabKeyboardOrder(window));
+            RunProbe("accessibility-lab-pointer-resume", () => ProbeAccessibilityLabPointerResume(window));
             RunProbe("virtualization-bounded-realization", () => ProbeVirtualization(window));
             RunProbe("images-sample-loads", () => ProbeImagesSample(window));
             RunProbe("lazy-images-sample-loads", () => ProbeLazyImagesSample(window));
@@ -43,6 +59,11 @@ internal static class Program
             RunProbe("footnotes-sample-loads", () => ProbeFootnotesSample(window));
             RunProbe("keyboard-nav-tab-traversal", () => ProbeKeyboardNav(window));
             RunProbe("click-dismisses-focus-ring", () => ProbeClickDismissesFocus(window));
+            RunProbe("selection-dismisses-on-external-pointer", () => ProbeSelectionDismissesOnExternalPointer(window));
+            RunProbe("selection-dismisses-on-hosted-control-pointer", () => ProbeSelectionDismissesOnHostedControlPointer(window));
+            RunProbe("selection-persists-after-pointer-release", () => ProbeSelectionPersistsAfterPointerRelease(window));
+            RunProbe("ctrl-c-copies-pointer-selection", () => ProbeCtrlCCopiesPointerSelection(window));
+            RunProbe("table-selection-row-border-is-stable", () => ProbeTableSelectionRowBorderIsStable(window));
             RunProbe("double-click-selects-word",  () => ProbeDoubleClickSelectsWord(window));
             RunProbe("triple-click-selects-line",  () => ProbeTripleClickSelectsLine(window));
             RunProbe("context-menu-appears",       () => ProbeContextMenu(window));
@@ -67,11 +88,167 @@ internal static class Program
         return Failures.Count == 0 ? 0 : 1;
     }
 
+    private static int RunNarratorSmoke(string appPath)
+    {
+        Console.WriteLine($"[narrator-smoke] launching {appPath}");
+        KillExistingApplicationInstances(appPath);
+        bool narratorWasRunning = Process.GetProcessesByName("Narrator").Any();
+        using var app = LaunchSample(appPath, enableDiagnostics: false);
+        using var automation = new UIA3Automation();
+        Process? narrator = null;
+
+        try
+        {
+            var window = Retry.WhileNull(() =>
+                {
+                    try { return app.GetMainWindow(automation); }
+                    catch { return null; }
+                },
+                timeout: TimeSpan.FromSeconds(30), interval: TimeSpan.FromMilliseconds(250)).Result
+                ?? throw new InvalidOperationException("Main window did not appear.");
+            WaitForSampleContent(window, app);
+
+            ClickSample(window, "Accessibility_Lab");
+            Thread.Sleep(1500);
+
+            var renderer = FindRenderer(window);
+            renderer.Focus();
+            Thread.Sleep(500);
+
+            var textPattern = renderer.Patterns.Text.PatternOrDefault
+                              ?? throw new InvalidOperationException("Renderer does not expose TextPattern");
+            var quick = textPattern.DocumentRange.FindText("quick", backward: false, ignoreCase: true)
+                        ?? throw new InvalidOperationException("Could not find 'quick' via TextPattern");
+            quick.ExpandToEnclosingUnit(TextUnit.Word);
+            var quickRects = quick.GetBoundingRectangles();
+            Console.WriteLine($"[narrator-smoke] renderer name: {renderer.Name}");
+            Console.WriteLine($"[narrator-smoke] quick rects: {string.Join("; ", quickRects.Select(FormatRect))}");
+            Console.WriteLine($"[narrator-smoke] renderer bounds: {FormatRect(renderer.BoundingRectangle)}");
+
+            if (!narratorWasRunning)
+            {
+                var narratorPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.Windows), "System32", "Narrator.exe");
+                narrator = Process.Start(new ProcessStartInfo(narratorPath) { UseShellExecute = true });
+                Thread.Sleep(3500);
+            }
+            MinimizeNarratorHome(automation);
+
+            string artifactDir = Path.Combine(Path.GetFullPath("."), "MarkdownRenderer", "artifacts");
+            Directory.CreateDirectory(artifactDir);
+
+            renderer.Focus();
+            Thread.Sleep(700);
+
+            string beforePath = Path.Combine(artifactDir, "narrator-before-read.png");
+            using (var image = FlaUI.Core.Capturing.Capture.ScreensWithElement(renderer, new FlaUI.Core.Capturing.CaptureSettings()))
+                image.ToFile(beforePath);
+            Console.WriteLine($"[narrator-smoke] before screenshot: {beforePath}");
+
+            Keyboard.TypeSimultaneously(VirtualKeyShort.INSERT, VirtualKeyShort.DOWN);
+            Thread.Sleep(1700);
+
+            string afterPath = Path.Combine(artifactDir, "narrator-after-read.png");
+            using (var image = FlaUI.Core.Capturing.Capture.ScreensWithElement(renderer, new FlaUI.Core.Capturing.CaptureSettings()))
+                image.ToFile(afterPath);
+            Console.WriteLine($"[narrator-smoke] after screenshot: {afterPath}");
+
+            Thread.Sleep(1200);
+            string laterPath = Path.Combine(artifactDir, "narrator-later-read.png");
+            using (var image = FlaUI.Core.Capturing.Capture.ScreensWithElement(renderer, new FlaUI.Core.Capturing.CaptureSettings()))
+                image.ToFile(laterPath);
+            Console.WriteLine($"[narrator-smoke] later screenshot: {laterPath}");
+
+            var tabFocus = TabIntoRendererFromSampleList(window, renderer);
+            Console.WriteLine($"[narrator-smoke] tab-entry focus event: {DescribeFocus(tabFocus)}");
+            Thread.Sleep(1200);
+            string tabEntryPath = Path.Combine(artifactDir, "narrator-tab-entry.png");
+            using (var image = FlaUI.Core.Capturing.Capture.ScreensWithElement(renderer, new FlaUI.Core.Capturing.CaptureSettings()))
+                image.ToFile(tabEntryPath);
+            Console.WriteLine($"[narrator-smoke] tab-entry screenshot: {tabEntryPath}");
+
+            try { window.Close(); } catch { }
+            return 0;
+        }
+        finally
+        {
+            if (!narratorWasRunning)
+            {
+                foreach (var process in Process.GetProcessesByName("Narrator"))
+                {
+                    try { process.Kill(); } catch { }
+                }
+            }
+
+            try { if (!app.HasExited) app.Kill(); } catch { }
+        }
+    }
+
+    private static void MinimizeNarratorHome(UIA3Automation automation)
+    {
+        for (int attempt = 0; attempt < 12; attempt++)
+        {
+            try
+            {
+                var desktop = automation.GetDesktop();
+                var narratorWindow = desktop.FindAllChildren(cf => cf.ByControlType(ControlType.Window))
+                    .FirstOrDefault(w => (w.Name ?? string.Empty).Contains("Narrator", StringComparison.OrdinalIgnoreCase));
+                if (narratorWindow is null)
+                {
+                    Thread.Sleep(250);
+                    continue;
+                }
+
+                var minimizeButton = narratorWindow.FindAllDescendants(cf => cf.ByControlType(ControlType.Button))
+                    .FirstOrDefault(b =>
+                    {
+                        var name = b.Name ?? string.Empty;
+                        return name.Equals("Minimise", StringComparison.OrdinalIgnoreCase) ||
+                               name.Equals("Minimize", StringComparison.OrdinalIgnoreCase);
+                    });
+                if (minimizeButton is not null)
+                {
+                    minimizeButton.AsButton().Invoke();
+                    Thread.Sleep(600);
+                    return;
+                }
+
+                var windowPattern = narratorWindow.Patterns.Window.PatternOrDefault;
+                if (windowPattern is not null)
+                {
+                    windowPattern.SetWindowVisualState(WindowVisualState.Minimized);
+                    Thread.Sleep(600);
+                    return;
+                }
+            }
+            catch
+            {
+            }
+
+            Thread.Sleep(250);
+        }
+    }
+
     private static void ProbeAutomationTreeShape(Window window)
     {
         var renderer = FindRenderer(window);
         var name = renderer.Name ?? string.Empty;
-        Assert(name.Length > 0, "renderer.Name must aggregate document text but was empty");
+        Assert(!string.IsNullOrWhiteSpace(name), "renderer.Name must expose a short document label");
+        Assert(name.Length <= 120, $"renderer.Name must stay short so Narrator reads content through TextPattern, got length {name.Length}");
+        try
+        {
+            var landmarkType = renderer.Properties.LandmarkType.ValueOrDefault;
+            Assert(!string.Equals(landmarkType.ToString(), "Custom", StringComparison.OrdinalIgnoreCase),
+                $"renderer must not expose itself as a custom landmark, got LandmarkType={landmarkType}");
+        }
+        catch (NotSupportedException)
+        {
+            // UIA providers may omit LandmarkType entirely; that is acceptable
+            // and preferable to exposing this document as a custom landmark.
+        }
+        Assert(renderer.Properties.IsControlElement.ValueOrDefault,
+            "renderer must be present in the UIA control view");
+        Assert(renderer.Properties.IsContentElement.ValueOrDefault,
+            "renderer must be present in the UIA content view");
         var descendants = renderer.FindAllDescendants();
         Assert(descendants.Length > 0, "renderer must expose block peers as descendants");
     }
@@ -111,6 +288,7 @@ internal static class Program
             "Typography", "Lists", "Tables", "Code", "GFM_Alerts",
             "Images", "Embeds", "RTL", "Virtualization", "Selection",
             "Lazy_Images", "Scroll_Anchor", "Footnotes", "Keyboard_Nav",
+            "Accessibility_Lab",
             "Full_Demo",
         };
         foreach (var label in expected)
@@ -118,6 +296,465 @@ internal static class Program
             var btn = window.FindFirstDescendant(cf => cf.ByAutomationId("SampleButton_" + label));
             Assert(btn is not null, $"SampleButton_{label} not found in automation tree");
         }
+    }
+
+    private static void ProbeAccessibilityLabTextPattern(Window window)
+    {
+        ClickSample(window, "Accessibility_Lab");
+        Thread.Sleep(1200);
+
+        var renderer = FindRenderer(window);
+        var textPattern = renderer.Patterns.Text.PatternOrDefault
+                          ?? throw new InvalidOperationException("MarkdownRenderer must expose UIA TextPattern");
+        string text = textPattern.DocumentRange.GetText(-1);
+        Assert(text.Contains("Accessibility Lab", StringComparison.Ordinal),
+            "TextPattern document text must include the lab heading");
+        Assert(text.Contains("quick brown fox", StringComparison.OrdinalIgnoreCase),
+            "TextPattern document text must include paragraph content");
+        Assert(text.Contains("Console.WriteLine", StringComparison.Ordinal),
+            "TextPattern document text must include fenced code content");
+
+        var word = textPattern.DocumentRange.FindText("quick", backward: false, ignoreCase: true)
+                   ?? throw new InvalidOperationException("TextPattern FindText('quick') returned null");
+        word.ExpandToEnclosingUnit(TextUnit.Word);
+        var rects = word.GetBoundingRectangles();
+        Assert(rects.Length > 0, "TextPattern word range must expose at least one bounding rectangle");
+        Assert(rects.All(r => r.Width < renderer.BoundingRectangle.Width / 3 &&
+                              r.Height < renderer.BoundingRectangle.Height / 3),
+            "TextPattern word bounding rectangles must be glyph/line-sized, not renderer-sized");
+
+        var endpointRange = textPattern.DocumentRange.Clone();
+        endpointRange.MoveEndpointByRange(TextPatternRangeEndpoint.Start, word, TextPatternRangeEndpoint.Start);
+        endpointRange.MoveEndpointByRange(TextPatternRangeEndpoint.End, word, TextPatternRangeEndpoint.Start);
+        int endpointMoved = endpointRange.MoveEndpointByUnit(TextPatternRangeEndpoint.Start, TextUnit.Word, 1);
+        Assert(endpointMoved == 1, $"MoveEndpointByUnit(Start, Word, 1) from a collapsed range should move one word, moved={endpointMoved}");
+        Assert(endpointRange.CompareEndpoints(TextPatternRangeEndpoint.Start, endpointRange, TextPatternRangeEndpoint.End) == 0,
+            "MoveEndpointByUnit must keep the range valid by collapsing the opposite endpoint when Start crosses End");
+
+        var blockTextPeer = renderer.FindAllDescendants(cf => cf.ByControlType(ControlType.Text))
+            .FirstOrDefault(e => (e.Name ?? string.Empty).Contains("quick brown fox", StringComparison.OrdinalIgnoreCase))
+            ?? throw new InvalidOperationException("Accessibility lab paragraph text peer not found");
+        var blockTextPattern = blockTextPeer.Patterns.Text.PatternOrDefault
+                               ?? throw new InvalidOperationException("Paragraph text peer must expose TextPattern for Narrator word highlighting");
+        var blockWord = blockTextPattern.DocumentRange.FindText("quick", backward: false, ignoreCase: true)
+                        ?? throw new InvalidOperationException("Paragraph TextPattern FindText('quick') returned null");
+        blockWord.ExpandToEnclosingUnit(TextUnit.Word);
+        var blockWordRects = blockWord.GetBoundingRectangles();
+        Assert(blockWordRects.Length > 0, "Paragraph TextPattern word range must expose bounding rectangles");
+        Assert(blockWordRects.All(r => r.Width < blockTextPeer.BoundingRectangle.Width / 2 &&
+                                       r.Height < blockTextPeer.BoundingRectangle.Height),
+            "Paragraph TextPattern word rectangles must be smaller than the paragraph peer rectangle");
+
+        var movedWord = textPattern.DocumentRange.Clone();
+        int moved = movedWord.Move(TextUnit.Word, 1);
+        Assert(moved == 1, $"TextPattern Move(Word, 1) should move by one word, moved={moved}");
+        string movedWordText = movedWord.GetText(-1).Trim();
+        Assert(!string.IsNullOrWhiteSpace(movedWordText) &&
+               movedWordText.Length <= 32 &&
+               !movedWordText.Contains('\n'),
+            $"TextPattern Move(Word, 1) must produce a word-sized range, got '{movedWordText}'");
+        var movedWordRects = movedWord.GetBoundingRectangles();
+        Assert(movedWordRects.Length > 0, "Moved word range must expose bounding rectangles");
+        Assert(movedWordRects.Sum(r => r.Width) < renderer.BoundingRectangle.Width / 2,
+            "Moved word range bounding rectangles must be word-sized, not whole-document-sized");
+
+        var visible = textPattern.GetVisibleRanges();
+        Assert(visible.Length > 0, "TextPattern must expose visible ranges");
+        Assert(visible[0].GetText(200).Length > 0, "Visible TextPattern range must contain text");
+
+        var offscreen = textPattern.DocumentRange.FindText("Paragraph 5", backward: false, ignoreCase: false)
+                        ?? throw new InvalidOperationException("offscreen paragraph range not found");
+        offscreen.ScrollIntoView(alignToTop: false);
+        Thread.Sleep(500);
+        var offscreenRects = offscreen.GetBoundingRectangles();
+        Assert(offscreenRects.Any(r => r.Width > 0 && r.Height > 0 && renderer.BoundingRectangle.IntersectsWith(r)),
+            "TextPattern.ScrollIntoView must bring the requested offscreen range into the renderer viewport");
+
+        var descendants = renderer.FindAllDescendants();
+        Assert(descendants.Any(e => e.ControlType == ControlType.Hyperlink),
+            "Accessibility lab must expose hyperlink descendants for TextPattern clients");
+    }
+
+    private static void ProbeAccessibilityLabSemanticRoles(Window window)
+    {
+        ClickSample(window, "Accessibility_Lab");
+        Thread.Sleep(1200);
+
+        var renderer = FindRenderer(window);
+        var descendants = renderer.FindAllDescendants();
+        Assert(descendants.Any(e => e.ControlType == ControlType.Header), "Accessibility lab must expose heading/header peers");
+        Assert(descendants.Any(e => e.ControlType == ControlType.Hyperlink), "Accessibility lab must expose hyperlink peers");
+        Assert(descendants.Any(e => e.ControlType == ControlType.List), "Accessibility lab must expose list peer");
+        Assert(descendants.Any(e => e.ControlType == ControlType.ListItem), "Accessibility lab must expose list item peers");
+        Assert(descendants.Any(e => e.ControlType == ControlType.Table), "Accessibility lab must expose table peer");
+        Assert(descendants.Any(e => e.ControlType == ControlType.DataItem), "Accessibility lab must expose table cell peers");
+        Assert(descendants.Count(e => e.ControlType == ControlType.Image) >= 2,
+            "Accessibility lab must expose both block and inline image peers");
+        Assert(descendants.Any(e => e.ControlType == ControlType.Image &&
+                                    (e.Name ?? string.Empty).Contains("Inline accessibility icon", StringComparison.Ordinal)),
+            "Inline markdown image must expose an image peer instead of flattening to plain paragraph text");
+        Assert(descendants.Any(e => e.ControlType == ControlType.Button && (e.Name ?? string.Empty).Contains("Native action", StringComparison.Ordinal)),
+            "Accessibility lab must expose hosted native button");
+        Assert(descendants.Any(e => e.ControlType == ControlType.CheckBox), "Accessibility lab must expose hosted task checkbox");
+
+        var table = descendants.First(e => e.ControlType == ControlType.Table);
+        var grid = table.Patterns.Grid.PatternOrDefault
+                   ?? throw new InvalidOperationException("Table peer must expose GridPattern");
+        Assert(grid.RowCount.Value >= 4, "GridPattern RowCount must include header and body rows");
+        Assert(grid.ColumnCount.Value == 3, "GridPattern ColumnCount must be 3 for the lab table");
+        Assert(grid.GetItem(0, 0) is not null, "GridPattern.GetItem(0, 0) must return a cell");
+    }
+
+    private static void ProbeAccessibilityLabTextAttributes(Window window)
+    {
+        ClickSample(window, "Accessibility_Lab");
+        Thread.Sleep(1200);
+
+        var renderer = FindRenderer(window);
+        var textPattern = renderer.Patterns.Text.PatternOrDefault
+                          ?? throw new InvalidOperationException("MarkdownRenderer must expose UIA TextPattern");
+        var attributes = renderer.Automation.TextAttributeLibrary;
+        var descendants = renderer.FindAllDescendants();
+
+        var hyperlink = descendants.First(e => e.ControlType == ControlType.Hyperlink);
+        var hyperlinkRange = textPattern.RangeFromChild(hyperlink);
+        Assert(hyperlinkRange.GetText(-1).Contains(hyperlink.Name ?? string.Empty, StringComparison.Ordinal),
+            "TextPattern.RangeFromChild(hyperlink) must return the hyperlink text range");
+
+        var image = descendants.First(e => e.ControlType == ControlType.Image &&
+                                           (e.Name ?? string.Empty).Contains("Accessibility lab blue square", StringComparison.Ordinal));
+        var imageRange = textPattern.RangeFromChild(image);
+        Assert(imageRange.GetText(-1).Contains("Accessibility lab blue square", StringComparison.Ordinal),
+            "TextPattern.RangeFromChild(image) must return image alt text");
+
+        var hostedButton = descendants.First(e => e.ControlType == ControlType.Button &&
+            (e.Name ?? string.Empty).Contains("Native action", StringComparison.Ordinal));
+        var hostedButtonRange = textPattern.RangeFromChild(hostedButton);
+        Assert(hostedButtonRange.GetText(-1).Length > 0,
+            "TextPattern.RangeFromChild(hosted native button) must return its embedded-object placeholder range");
+
+        var paintedLinkRange = textPattern.DocumentRange.FindText("painted link", backward: false, ignoreCase: false)
+                               ?? throw new InvalidOperationException("painted link range not found");
+        var underline = paintedLinkRange.GetAttributeValue(attributes.UnderlineStyle);
+        Assert(IsNonNoneTextDecoration(underline),
+            $"painted link must expose a non-None UnderlineStyle text attribute, got {DescribeAttributeValue(underline)}");
+        Assert((paintedLinkRange.GetAttributeValue(attributes.StyleName)?.ToString() ?? string.Empty)
+               .Contains("Link", StringComparison.Ordinal),
+            "painted link must expose StyleName=Link");
+
+        var codeRange = textPattern.DocumentRange.FindText("Console.WriteLine", backward: false, ignoreCase: false)
+                        ?? throw new InvalidOperationException("code range not found");
+        string fontName = codeRange.GetAttributeValue(attributes.FontName)?.ToString() ?? string.Empty;
+        Assert(fontName.Contains("Consolas", StringComparison.OrdinalIgnoreCase),
+            $"code range must expose monospace FontName, got {fontName}");
+
+        var quickRange = textPattern.DocumentRange.FindText("quick", backward: false, ignoreCase: true)
+                         ?? throw new InvalidOperationException("quick range not found");
+        Assert(IsTrueAttribute(quickRange.GetAttributeValue(attributes.IsReadOnly)),
+            "TextPattern ranges must expose IsReadOnly=true");
+
+        var findUnderline = textPattern.DocumentRange.FindAttribute(attributes.UnderlineStyle, underline, backward: false)
+                            ?? throw new InvalidOperationException("FindAttribute(UnderlineStyle) returned null");
+        Assert(findUnderline.GetText(-1).Contains("painted link", StringComparison.Ordinal) ||
+               findUnderline.GetText(-1).Contains("second painted link", StringComparison.Ordinal),
+            "FindAttribute(UnderlineStyle) must return an underlined markdown link range");
+    }
+
+    private static void ProbeAccessibilityLabForcedHighContrast(Window window)
+    {
+        var toggle = window.FindFirstDescendant(cf => cf.ByAutomationId("ForcedHighContrastToggle"))?.AsToggleButton()
+                     ?? throw new InvalidOperationException("ForcedHighContrastToggle not found");
+
+        try
+        {
+            if (toggle.ToggleState != ToggleState.On)
+            {
+                toggle.Toggle();
+                Thread.Sleep(1200);
+            }
+
+            ClickSample(window, "Accessibility_Lab");
+            Thread.Sleep(1200);
+
+            var status = window.FindFirstDescendant(cf => cf.ByAutomationId("HighContrastStatus"));
+            var statusText = status?.Name ?? status?.Properties.Name.ValueOrDefault ?? string.Empty;
+            Assert(statusText.Contains("hc:on", StringComparison.Ordinal),
+                $"forced high contrast status must be on, got '{statusText}'");
+
+            var renderer = FindRenderer(window);
+            var textPattern = renderer.Patterns.Text.PatternOrDefault
+                              ?? throw new InvalidOperationException("MarkdownRenderer must expose UIA TextPattern");
+            var attributes = renderer.Automation.TextAttributeLibrary;
+
+            var bodyRange = textPattern.DocumentRange.FindText("quick", backward: false, ignoreCase: true)
+                            ?? throw new InvalidOperationException("quick range not found");
+            Assert(ToColorRefValue(bodyRange.GetAttributeValue(attributes.ForegroundColor)) == ColorRef(0xFF, 0xFF, 0xFF),
+                "forced high contrast body foreground must resolve to WindowText");
+            Assert(ToColorRefValue(bodyRange.GetAttributeValue(attributes.BackgroundColor)) == ColorRef(0x00, 0x00, 0x00),
+                "forced high contrast body background must resolve to Window");
+
+            var linkRange = textPattern.DocumentRange.FindText("painted link", backward: false, ignoreCase: false)
+                            ?? throw new InvalidOperationException("painted link range not found");
+            Assert(ToColorRefValue(linkRange.GetAttributeValue(attributes.ForegroundColor)) == ColorRef(0x00, 0xFF, 0xFF),
+                "forced high contrast link foreground must resolve to Hotlight");
+
+            var inlineCodeRange = textPattern.DocumentRange.FindText("inline-code-token", backward: false, ignoreCase: false)
+                                  ?? throw new InvalidOperationException("inline code range not found");
+            Assert(ToColorRefValue(inlineCodeRange.GetAttributeValue(attributes.ForegroundColor)) == ColorRef(0xFF, 0xFF, 0xFF),
+                "forced high contrast inline code foreground must resolve to WindowText");
+            Assert(ToColorRefValue(inlineCodeRange.GetAttributeValue(attributes.BackgroundColor)) == ColorRef(0x00, 0x00, 0x00),
+                "forced high contrast inline code background must resolve to Window");
+
+            var tableHeaderRange = textPattern.DocumentRange.FindText("Feature", backward: false, ignoreCase: false)
+                                   ?? throw new InvalidOperationException("table header range not found");
+            Assert(ToColorRefValue(tableHeaderRange.GetAttributeValue(attributes.ForegroundColor)) == ColorRef(0x00, 0x00, 0x00),
+                "forced high contrast table header foreground must resolve to HighlightText");
+            Assert(ToColorRefValue(tableHeaderRange.GetAttributeValue(attributes.BackgroundColor)) == ColorRef(0xFF, 0xFF, 0x00),
+                "forced high contrast table header background must resolve to Highlight");
+        }
+        finally
+        {
+            if (toggle.ToggleState == ToggleState.On)
+            {
+                toggle.Toggle();
+                Thread.Sleep(800);
+            }
+        }
+    }
+
+    private static void ProbeAccessibilityLabKeyboardOrder(Window window)
+    {
+        ClickSample(window, "Accessibility_Lab");
+        Thread.Sleep(1200);
+
+        var renderer = FindRenderer(window);
+
+        var focusedPaintedLink = TabIntoRendererFromSampleList(window, renderer);
+        Assert(IsPaintedLinkFocus(focusedPaintedLink),
+            $"Tab entry should promote renderer root focus to the first painted hyperlink, focused={DescribeFocus(focusedPaintedLink)}");
+
+        Keyboard.Press(VirtualKeyShort.TAB); // hosted button
+        Thread.Sleep(250);
+        var focusedButton = renderer.Automation.FocusedElement();
+        Assert(IsNativeActionButton(focusedButton),
+            $"Second Tab should land on hosted native button, focused={DescribeFocus(focusedButton)}");
+
+        Keyboard.Press(VirtualKeyShort.TAB); // first focusable descendant in composite embed
+        Thread.Sleep(250);
+        var focusedCompositeTextBox = renderer.Automation.FocusedElement();
+        Assert(IsCompositeValueTextBox(focusedCompositeTextBox),
+            $"Third Tab should land inside the composite hosted embed text box, focused={DescribeFocus(focusedCompositeTextBox)}");
+
+        Keyboard.Press(VirtualKeyShort.TAB); // second focusable descendant in composite embed
+        Thread.Sleep(250);
+        var focusedCompositeButton = renderer.Automation.FocusedElement();
+        Assert(IsCompositeActionButton(focusedCompositeButton),
+            $"Fourth Tab should stay inside the composite hosted embed and land on its button, focused={DescribeFocus(focusedCompositeButton)}");
+
+        Keyboard.Press(VirtualKeyShort.TAB); // hosted checkbox
+        Thread.Sleep(250);
+        var focusedCheckbox = renderer.Automation.FocusedElement();
+        Assert(focusedCheckbox.ControlType == ControlType.CheckBox,
+            $"Fifth Tab should land on hosted task checkbox, focused={DescribeFocus(focusedCheckbox)}");
+
+        var focusedSecondPaintedLink = PressTabExpectPaintedLink(renderer, "Sixth Tab");
+        Assert(IsPaintedLinkFocus(focusedSecondPaintedLink),
+            $"Sixth Tab should land on second painted hyperlink, focused={DescribeFocus(focusedSecondPaintedLink)}");
+
+        Keyboard.Press(VirtualKeyShort.TAB); // leave markdown
+        Thread.Sleep(300);
+        var focusedAfterExit = renderer.Automation.FocusedElement();
+        Assert(!IsAccessibilityLabInternalFocus(focusedAfterExit),
+            $"Tab at the last markdown item must leave the renderer instead of looping into embeds, focused={DescribeFocus(focusedAfterExit)}");
+        TryFocus(window, "main window after markdown keyboard boundary probe");
+        Thread.Sleep(250);
+    }
+
+    private static AutomationElement TabIntoRendererFromSampleList(Window window, AutomationElement renderer)
+    {
+        AutomationElement? observedPaintedLink = null;
+        var observed = new List<string>();
+        using var paintedLinkFocused = new ManualResetEventSlim(false);
+        var focusHandler = renderer.Automation.RegisterFocusChangedEvent(element =>
+        {
+            string description;
+            try { description = DescribeFocus(element); }
+            catch (Exception ex) { description = $"<unreadable focus event: {ex.Message}>"; }
+
+            lock (observed) observed.Add(description);
+            if (IsPaintedLinkFocus(element))
+            {
+                observedPaintedLink = element;
+                paintedLinkFocused.Set();
+            }
+        });
+
+        var source = window.FindFirstDescendant(cf => cf.ByAutomationId("SampleButton_Accessibility_Lab"))?.AsButton()
+                     ?? throw new InvalidOperationException("Accessibility Lab sample button not found");
+        try
+        {
+            source.Focus();
+            Thread.Sleep(250);
+
+            for (int i = 0; i < 80; i++)
+            {
+                Keyboard.Press(VirtualKeyShort.TAB);
+                if (paintedLinkFocused.Wait(TimeSpan.FromMilliseconds(500)) && observedPaintedLink is not null)
+                    return observedPaintedLink;
+
+                var focused = renderer.Automation.FocusedElement();
+                if (IsAccessibilityLabInternalFocus(focused))
+                {
+                    if (paintedLinkFocused.Wait(TimeSpan.FromMilliseconds(750)) && observedPaintedLink is not null)
+                        return observedPaintedLink;
+
+                    lock (observed)
+                    {
+                        throw new InvalidOperationException(
+                            $"Tab reached markdown without a virtual hyperlink focus event. Current focus={DescribeFocus(focused)}; events={string.Join(" | ", observed)}");
+                    }
+                }
+            }
+
+            lock (observed)
+            {
+                throw new InvalidOperationException(
+                    $"Tab did not reach the Accessibility Lab renderer within 80 stops; events={string.Join(" | ", observed)}");
+            }
+        }
+        finally
+        {
+            renderer.Automation.UnregisterFocusChangedEvent(focusHandler);
+        }
+    }
+
+    private static AutomationElement PressTabExpectPaintedLink(AutomationElement renderer, string stepName)
+    {
+        AutomationElement? observedPaintedLink = null;
+        var observed = new List<string>();
+        using var paintedLinkFocused = new ManualResetEventSlim(false);
+        var focusHandler = renderer.Automation.RegisterFocusChangedEvent(element =>
+        {
+            string description;
+            try { description = DescribeFocus(element); }
+            catch (Exception ex) { description = $"<unreadable focus event: {ex.Message}>"; }
+
+            lock (observed) observed.Add(description);
+            if (IsPaintedLinkFocus(element))
+            {
+                observedPaintedLink = element;
+                paintedLinkFocused.Set();
+            }
+        });
+
+        try
+        {
+            Keyboard.Press(VirtualKeyShort.TAB);
+            if (paintedLinkFocused.Wait(TimeSpan.FromMilliseconds(1000)) && observedPaintedLink is not null)
+                return observedPaintedLink;
+
+            var focused = renderer.Automation.FocusedElement();
+            lock (observed)
+            {
+                throw new InvalidOperationException(
+                    $"{stepName} did not raise virtual hyperlink focus. Current focus={DescribeFocus(focused)}; events={string.Join(" | ", observed)}");
+            }
+        }
+        finally
+        {
+            renderer.Automation.UnregisterFocusChangedEvent(focusHandler);
+        }
+    }
+
+    private static bool IsPaintedLinkFocus(AutomationElement focused)
+    {
+        return focused.ControlType == ControlType.Hyperlink &&
+               !string.IsNullOrWhiteSpace(NameOrEmpty(focused));
+    }
+
+    private static bool IsRendererOrDocumentFocus(AutomationElement focused)
+    {
+        return AutomationIdOrEmpty(focused) == "MarkdownRenderer" ||
+               focused.ControlType == ControlType.Document;
+    }
+
+    private static bool IsNativeActionButton(AutomationElement focused)
+    {
+        return focused.ControlType == ControlType.Button &&
+               NameOrEmpty(focused).Contains("Native action", StringComparison.Ordinal);
+    }
+
+    private static bool IsCompositeValueTextBox(AutomationElement focused)
+    {
+        return focused.ControlType == ControlType.Edit &&
+               (AutomationIdOrEmpty(focused) == "CompositeValueTextBox" ||
+                NameOrEmpty(focused).Contains("Composite value", StringComparison.Ordinal));
+    }
+
+    private static bool IsCompositeActionButton(AutomationElement focused)
+    {
+        return focused.ControlType == ControlType.Button &&
+               (AutomationIdOrEmpty(focused) == "CompositeActionButton" ||
+                NameOrEmpty(focused).Contains("Composite action", StringComparison.Ordinal));
+    }
+
+    private static bool IsAccessibilityLabInternalFocus(AutomationElement focused)
+    {
+        return IsPaintedLinkFocus(focused) ||
+               IsRendererOrDocumentFocus(focused) ||
+               IsNativeActionButton(focused) ||
+               IsCompositeValueTextBox(focused) ||
+               IsCompositeActionButton(focused) ||
+               focused.ControlType == ControlType.CheckBox;
+    }
+
+    private static string DescribeFocus(AutomationElement focused)
+        => $"{focused.ControlType}/{NameOrEmpty(focused)}/AutomationId={AutomationIdOrEmpty(focused)}";
+
+    private static string NameOrEmpty(AutomationElement element)
+    {
+        try { return element.Name ?? string.Empty; }
+        catch { return element.Properties.Name.ValueOrDefault ?? string.Empty; }
+    }
+
+    private static string AutomationIdOrEmpty(AutomationElement element)
+    {
+        try { return element.AutomationId ?? string.Empty; }
+        catch { return element.Properties.AutomationId.ValueOrDefault ?? string.Empty; }
+    }
+
+    private static void ProbeAccessibilityLabPointerResume(Window window)
+    {
+        ClickSample(window, "Accessibility_Lab");
+        Thread.Sleep(1200);
+
+        var renderer = FindRenderer(window);
+        var button = renderer.FindAllDescendants(cf => cf.ByControlType(ControlType.Button))
+            .FirstOrDefault(e => (e.Name ?? string.Empty).Contains("Native action", StringComparison.Ordinal))
+            ?? throw new InvalidOperationException("Hosted Native action button not found");
+
+        var buttonBounds = button.BoundingRectangle;
+        var rendererBounds = renderer.BoundingRectangle;
+        var nearbyDocumentPoint = new System.Drawing.Point(
+            buttonBounds.Left + buttonBounds.Width / 2,
+            Math.Max(rendererBounds.Top + 4, buttonBounds.Top - 12));
+        Mouse.Click(nearbyDocumentPoint, FlaUI.Core.Input.MouseButton.Left);
+        Thread.Sleep(300);
+
+        Keyboard.Press(VirtualKeyShort.TAB);
+        Thread.Sleep(300);
+
+        var focused = renderer.Automation.FocusedElement();
+        if (focused.ControlType == ControlType.Button &&
+            (focused.Name ?? string.Empty).Contains("Native action", StringComparison.Ordinal))
+        {
+            Keyboard.Press(VirtualKeyShort.TAB);
+            Thread.Sleep(300);
+            focused = renderer.Automation.FocusedElement();
+        }
+
+        Assert(IsCompositeValueTextBox(focused) || IsCompositeActionButton(focused) || focused.ControlType == ControlType.CheckBox,
+            $"Tab after pointer dismissal near hosted controls should resume within markdown focus order, focused={DescribeFocus(focused)}");
     }
 
     private static void ProbeVirtualization(Window window)
@@ -150,8 +787,8 @@ internal static class Program
         btn.Invoke();
         Thread.Sleep(1500);
         var renderer = FindRenderer(window);
-        var name = renderer.Name ?? string.Empty;
-        Assert(name.Length > 0, "Images sample renderer name must not be empty");
+        var text = GetRendererDocumentText(renderer);
+        Assert(text.Length > 0, "Images sample renderer document text must not be empty");
     }
 
     private static void ProbeLazyImagesSample(Window window)
@@ -161,8 +798,8 @@ internal static class Program
         btn.Invoke();
         Thread.Sleep(1500);
         var renderer = FindRenderer(window);
-        var name = renderer.Name ?? string.Empty;
-        Assert(name.Length > 0, "Lazy Images sample renderer name must not be empty");
+        var text = GetRendererDocumentText(renderer);
+        Assert(text.Length > 0, "Lazy Images sample renderer document text must not be empty");
         // Verify renderer has children (block peers in UIA tree)
         var descendants = renderer.FindAllDescendants();
         Assert(descendants.Length > 0, "Lazy Images renderer must expose block peers as descendants");
@@ -175,16 +812,16 @@ internal static class Program
         btn.Invoke();
         Thread.Sleep(1000);
         var renderer = FindRenderer(window);
-        var name = renderer.Name ?? string.Empty;
-        Assert(name.Length > 0, "Scroll Anchor sample renderer name must not be empty");
+        var text = GetRendererDocumentText(renderer);
+        Assert(text.Length > 0, "Scroll Anchor sample renderer document text must not be empty");
         // Scroll down and verify content is still available
         renderer.Focus();
         Keyboard.Press(VirtualKeyShort.NEXT); // Page Down
         Thread.Sleep(300);
         Keyboard.Press(VirtualKeyShort.PRIOR); // Page Up
         Thread.Sleep(300);
-        var nameAfterScroll = renderer.Name ?? string.Empty;
-        Assert(nameAfterScroll.Length > 0, "Scroll Anchor renderer name must remain non-empty after scroll");
+        var textAfterScroll = GetRendererDocumentText(renderer);
+        Assert(textAfterScroll.Length > 0, "Scroll Anchor renderer document text must remain non-empty after scroll");
     }
 
     private static void ProbeFootnotesSample(Window window)
@@ -194,14 +831,14 @@ internal static class Program
         btn.Invoke();
         Thread.Sleep(1200);
         var renderer = FindRenderer(window);
-        var name = renderer.Name ?? string.Empty;
-        Assert(name.Length > 0, "Footnotes sample renderer name must not be empty");
+        var text = GetRendererDocumentText(renderer);
+        Assert(text.Length > 0, "Footnotes sample renderer document text must not be empty");
         // Verify the rendered text contains footnote markers (superscripts / back-arrows)
-        // The renderer aggregates all text into its Name for UIA, so we verify the
-        // footnote-bearing text is included.
-        bool hasFootnoteContent = name.Contains("sentence with a footnote", StringComparison.OrdinalIgnoreCase)
-                                  || name.Contains("footnote", StringComparison.OrdinalIgnoreCase);
-        Assert(hasFootnoteContent, $"Footnotes renderer content must mention 'footnote', got: {name[..Math.Min(120, name.Length)]}");
+        // The renderer exposes document text through TextPattern so Narrator can
+        // use text ranges instead of reading the root element Name.
+        bool hasFootnoteContent = text.Contains("sentence with a footnote", StringComparison.OrdinalIgnoreCase)
+                                  || text.Contains("footnote", StringComparison.OrdinalIgnoreCase);
+        Assert(hasFootnoteContent, $"Footnotes renderer content must mention 'footnote', got: {text[..Math.Min(120, text.Length)]}");
     }
 
     private static void ProbeKeyboardNav(Window window)
@@ -235,8 +872,8 @@ internal static class Program
         Thread.Sleep(200);
 
         // Verify renderer is still responsive
-        var nameAfter = renderer.Name ?? string.Empty;
-        Assert(nameAfter.Length > 0, "Keyboard Nav renderer must remain responsive after Tab/Escape traversal");
+        var textAfter = GetRendererDocumentText(renderer);
+        Assert(textAfter.Length > 0, "Keyboard Nav renderer must remain responsive after Tab/Escape traversal");
     }
 
     private static void ProbeClickDismissesFocus(Window window)
@@ -263,8 +900,150 @@ internal static class Program
         Thread.Sleep(300);
 
         // The renderer must still be responsive after the click.
-        var nameAfter = renderer.Name ?? string.Empty;
-        Assert(nameAfter.Length > 0, "Renderer must remain responsive after click-dismisses-focus");
+        var textAfter = GetRendererDocumentText(renderer);
+        Assert(textAfter.Length > 0, "Renderer must remain responsive after click-dismisses-focus");
+    }
+
+    private static void ProbeSelectionDismissesOnExternalPointer(Window window)
+    {
+        ClickSample(window, "Selection");
+        Thread.Sleep(1200);
+
+        var renderer = FindRenderer(window);
+        var textPattern = renderer.Patterns.Text.PatternOrDefault
+                          ?? throw new InvalidOperationException("MarkdownRenderer must expose UIA TextPattern");
+        var selectionRange = textPattern.DocumentRange.FindText("Click", backward: false, ignoreCase: true)
+                             ?? throw new InvalidOperationException("Selection external-dismiss probe could not find text");
+        selectionRange.ExpandToEnclosingUnit(TextUnit.Word);
+        selectionRange.Select();
+        Thread.Sleep(500);
+        Assert(!string.IsNullOrWhiteSpace(GetRendererSelectionText(renderer)),
+            "TextPattern.Select must create a UIA-visible selection before dismissal");
+
+        var editor = window.FindFirstDescendant(cf => cf.ByAutomationId("MarkdownEditor"))
+                     ?? throw new InvalidOperationException("Markdown source editor not found");
+        var bounds = editor.BoundingRectangle;
+        Mouse.Click(new System.Drawing.Point(bounds.Left + 20, bounds.Top + 20), FlaUI.Core.Input.MouseButton.Left);
+        Thread.Sleep(500);
+
+        Assert(string.IsNullOrEmpty(GetRendererSelectionText(renderer)),
+            "clicking another app control must dismiss the markdown selection");
+    }
+
+    private static void ProbeSelectionDismissesOnHostedControlPointer(Window window)
+    {
+        ClickSample(window, "Accessibility_Lab");
+        Thread.Sleep(1200);
+
+        var renderer = FindRenderer(window);
+        var point = FindTextPatternPoint(renderer, "quick", "selection hosted-control-dismiss probe");
+        Mouse.DoubleClick(point, FlaUI.Core.Input.MouseButton.Left);
+        Thread.Sleep(500);
+        Assert(!string.IsNullOrWhiteSpace(GetRendererSelectionText(renderer)),
+            "double-clicking renderer text must create a UIA-visible selection before hosted-control dismissal");
+
+        var hostedTextBox = window.FindFirstDescendant(cf => cf.ByAutomationId("CompositeValueTextBox"))
+                            ?? throw new InvalidOperationException("Composite hosted TextBox not found");
+        var bounds = hostedTextBox.BoundingRectangle;
+        Mouse.Click(new System.Drawing.Point(bounds.Left + bounds.Width / 2, bounds.Top + bounds.Height / 2), FlaUI.Core.Input.MouseButton.Left);
+        Thread.Sleep(500);
+
+        Assert(string.IsNullOrEmpty(GetRendererSelectionText(renderer)),
+            "clicking a hosted WinUI control inside the markdown renderer must dismiss the markdown selection");
+    }
+
+    private static void ProbeSelectionPersistsAfterPointerRelease(Window window)
+    {
+        var cases = new[]
+        {
+            (Sample: "Typography", Start: "Heading 6", End: "Regular paragraph text", Expected: "quick brown fox"),
+            (Sample: "Selection", Start: "Click and drag", End: "The selection spans", Expected: "select"),
+            (Sample: "Code", Start: "C# example", End: "public sealed class", Expected: "public"),
+        };
+
+        foreach (var c in cases)
+        {
+            ClickSample(window, c.Sample);
+            Thread.Sleep(1200);
+
+            var renderer = FindRenderer(window);
+            var start = FindTextPatternPoint(renderer, c.Start, $"{c.Sample} selection persist start");
+            var end = FindTextPatternPoint(renderer, c.End, $"{c.Sample} selection persist end");
+            Assert(Math.Abs(end.X - start.X) + Math.Abs(end.Y - start.Y) >= 24,
+                $"{c.Sample} selection persist probe did not find a meaningful drag range: start={start}, end={end}");
+
+            DragMouseThrough(start, end);
+            Thread.Sleep(700);
+
+            string selected = GetRendererSelectionText(renderer);
+            Assert(!string.IsNullOrWhiteSpace(selected),
+                $"{c.Sample} selection must remain active after mouse release");
+            Assert(selected.Contains(c.Expected, StringComparison.OrdinalIgnoreCase),
+                $"{c.Sample} selection after release should include dragged text, got: {Truncate(selected, 160)}");
+        }
+    }
+
+    private static void ProbeCtrlCCopiesPointerSelection(Window window)
+    {
+        ClickSample(window, "Selection");
+        Thread.Sleep(1200);
+
+        var renderer = FindRenderer(window);
+        var start = FindTextPatternPoint(renderer, "Click and drag", "ctrl-c copy drag start");
+        var end = FindTextPatternPoint(renderer, "The selection spans", "ctrl-c copy drag end");
+        DragMouseThrough(start, end);
+        Thread.Sleep(500);
+
+        string selected = GetRendererSelectionText(renderer);
+        Assert(!string.IsNullOrWhiteSpace(selected),
+            "ctrl-c copy probe must have an active pointer selection before copying");
+
+        const string sentinel = "markdown-renderer-clipboard-sentinel";
+        SetClipboardText(sentinel);
+        Keyboard.TypeSimultaneously(VirtualKeyShort.CONTROL, VirtualKeyShort.KEY_C);
+        Thread.Sleep(700);
+
+        string copied = GetClipboardText();
+        Assert(!string.Equals(copied, sentinel, StringComparison.Ordinal),
+            "Ctrl+C left the clipboard unchanged; renderer likely did not handle the key event");
+        Assert(copied.Contains("select any text", StringComparison.OrdinalIgnoreCase) ||
+               copied.Contains("selection spans", StringComparison.OrdinalIgnoreCase),
+            $"Ctrl+C should copy selected markdown source, got: {Truncate(copied, 240)}");
+    }
+
+    private static void ProbeTableSelectionRowBorderIsStable(Window window)
+    {
+        ClickSample(window, "Tables");
+        Thread.Sleep(1200);
+
+        var renderer = FindRenderer(window);
+        var anchorRect = FindTextPatternRect(renderer, "Selection + Copy", "table row-border drag anchor");
+        var previousRowRect = FindTextPatternRect(renderer, "Links", "table row-border drag previous row");
+        var start = new System.Drawing.Point(anchorRect.Left + anchorRect.Width / 2, anchorRect.Top + anchorRect.Height / 2);
+        var border = new System.Drawing.Point(
+            anchorRect.Left + anchorRect.Width / 2,
+            previousRowRect.Bottom + Math.Max(1, (anchorRect.Top - previousRowRect.Bottom) / 2));
+
+        SendMouseMove(start);
+        Thread.Sleep(100);
+        SendMouseButton(MouseEventFlags.LeftDown);
+        try
+        {
+            Thread.Sleep(120);
+            SendMouseMove(border);
+            Thread.Sleep(500);
+
+            string selected = GetRendererSelectionText(renderer);
+            Assert(!string.IsNullOrWhiteSpace(selected),
+                $"table row-border drag should keep a non-empty selection at border point {border}");
+            Assert(!selected.Contains("AOT compatibility", StringComparison.OrdinalIgnoreCase) &&
+                   !selected.Contains("Live theme switch", StringComparison.OrdinalIgnoreCase),
+                $"table row-border drag must not jump to rows after the anchor, got: {Truncate(selected, 240)}");
+        }
+        finally
+        {
+            SendMouseButton(MouseEventFlags.LeftUp);
+        }
     }
 
     private static void ProbeDoubleClickSelectsWord(Window window)
@@ -278,7 +1057,7 @@ internal static class Program
         var renderer = FindRenderer(window);
         string logPath = FindShakeLog()
             ?? throw new InvalidOperationException("text_shaking2.log not found — sample may not have ShakeLogger enabled");
-        var point = FindSelectablePointInRenderer(logPath, renderer.BoundingRectangle, "double-click word probe");
+        var point = FindSelectableTextPatternPoint(logPath, renderer, "Lorem", "double-click word probe");
         Thread.Sleep(900);
         long baseline = new FileInfo(logPath).Length;
 
@@ -305,7 +1084,7 @@ internal static class Program
         var renderer = FindRenderer(window);
         string logPath = FindShakeLog()
             ?? throw new InvalidOperationException("text_shaking2.log not found — sample may not have ShakeLogger enabled");
-        var point = FindSelectablePointInRenderer(logPath, renderer.BoundingRectangle, "triple-click line probe");
+        var point = FindSelectableTextPatternPoint(logPath, renderer, "Click and drag", "triple-click line probe");
         Thread.Sleep(900);
         long baseline = new FileInfo(logPath).Length;
 
@@ -361,12 +1140,12 @@ internal static class Program
             Console.Error.WriteLine("[automation] warn: context-menu probe: no MenuItem elements found in UIA tree — flyout may not be UIA-exposed on this system");
 
         // Dismiss the menu BEFORE querying renderer properties so an open flyout
-        // cannot intercept the UIA focus and cause the Name query to stale/block.
+        // cannot intercept the UIA focus and cause the TextPattern query to stale/block.
         Keyboard.Press(VirtualKeyShort.ESCAPE);
         Thread.Sleep(200);
 
-        var nameAfter = renderer.Name ?? string.Empty;
-        Assert(nameAfter.Length > 0, "Renderer must remain responsive after right-click context menu");
+        var textAfter = GetRendererDocumentText(renderer);
+        Assert(textAfter.Length > 0, "Renderer must remain responsive after right-click context menu");
     }
 
     /// <summary>
@@ -438,9 +1217,10 @@ internal static class Program
     /// <summary>
     /// Regression probe for the embeds-page shake reported from manual testing:
     /// a text-selection drag on the hosted-embeds sample must not repaint the
-    /// DirectWrite canvas. Selection rectangles live on the XAML overlay; any
-    /// appended canvas region/inline-paint event after the drag starts means
-    /// mouse-down or drag still dirtied text and can visibly jitter at 150% DPI.
+    /// DirectWrite canvas. Selection pixels live on a single Win2D adorner;
+    /// any appended canvas region/inline-paint event after the drag starts means
+    /// mouse-down or drag still dirtied document text and can visibly jitter at
+    /// 150% DPI.
     /// </summary>
     private static void ProbeEmbedsSelectionDoesNotShake(Window window)
     {
@@ -458,12 +1238,8 @@ internal static class Program
         string logPath = FindShakeLog()
             ?? throw new InvalidOperationException("text_shaking2.log not found — sample may not have ShakeLogger enabled");
 
-        var start = FindSelectablePointInRenderer(logPath, bounds, "embeds drag start");
-        var end = FindSelectablePointInRenderer(
-            logPath,
-            bounds,
-            "embeds drag end",
-            p => Math.Abs(p.X - start.X) + Math.Abs(p.Y - start.Y) >= 160);
+        var start = FindSelectableTextPatternPoint(logPath, renderer, "The renderer hosts", "embeds drag start");
+        var end = FindSelectableTextPatternPoint(logPath, renderer, "Anything else", "embeds drag end");
         Assert(Math.Abs(end.X - start.X) + Math.Abs(end.Y - start.Y) >= 80,
             $"embeds selection probe did not find a meaningful in-text drag range: start={start}, end={end}");
         Thread.Sleep(900);
@@ -478,6 +1254,7 @@ internal static class Program
         int dragEvents = CountOccurrences(appended, "ptr-move-drag");
         int extendEvents = CountOccurrences(appended, "sel-extend");
         int selectionRectEvents = CountOccurrences(appended, "sel-rect-phys");
+        int adornerDrawEvents = CountOccurrences(appended, "sel-adorner-draw");
         int paintEvents = CountOccurrences(appended, "inline-paint");
         int regionEvents = CountOccurrences(appended, " region ");
 
@@ -493,6 +1270,9 @@ internal static class Program
         Assert(selectionRectEvents > 0,
             $"embed selection-shake probe did not render selection overlay rectangles. " +
             $"Recent log excerpt: {Truncate(appended, 600)}");
+        Assert(adornerDrawEvents > 0,
+            $"embed selection-shake probe did not draw the selection adorner. " +
+            $"Recent log excerpt: {Truncate(appended, 600)}");
         Assert(paintEvents == 0,
             $"embed selection-shake regression: {paintEvents} inline-paint event(s) fired during embeds-page drag. " +
             $"Recent log excerpt: {Truncate(appended, 600)}");
@@ -501,60 +1281,123 @@ internal static class Program
             $"Recent log excerpt: {Truncate(appended, 600)}");
     }
 
-    private static System.Drawing.Point FindSelectablePointInRenderer(
-        string logPath,
-        System.Drawing.Rectangle bounds,
-        string description,
-        Func<System.Drawing.Point, bool>? predicate = null)
+    private static System.Drawing.Point FindTextPatternPoint(AutomationElement renderer, string text, string description)
     {
-        var candidates = EnumerateRendererCandidatePoints(bounds)
-            .Where(p => predicate?.Invoke(p) ?? true)
-            .Distinct()
-            .ToArray();
+        var rect = FindTextPatternRect(renderer, text, description);
+        var center = new System.Drawing.Point(rect.Left + rect.Width / 2, rect.Top + rect.Height / 2);
+        Console.WriteLine($"[automation] {description}: using TextPattern point {center} from '{text}' in rect {FormatRect(rect)}");
+        return center;
+    }
 
-        foreach (var point in candidates)
+    private static System.Drawing.Rectangle FindTextPatternRect(AutomationElement renderer, string text, string description)
+    {
+        var textPattern = renderer.Patterns.Text.PatternOrDefault
+                          ?? throw new InvalidOperationException($"{description}: renderer does not expose TextPattern");
+        var range = textPattern.DocumentRange.FindText(text, backward: false, ignoreCase: true)
+                    ?? throw new InvalidOperationException($"{description}: TextPattern could not find '{text}'");
+
+        var rendererBounds = renderer.BoundingRectangle;
+        foreach (var rect in range.GetBoundingRectangles())
         {
-            long baseline = new FileInfo(logPath).Length;
-            Mouse.Click(point, FlaUI.Core.Input.MouseButton.Left);
-            Thread.Sleep(250);
-            string appended = ReadShakeLogFrom(logPath, baseline);
-            if (CountOccurrences(appended, "sel-anchor") > 0)
+            if (rect.Width <= 1 || rect.Height <= 1) continue;
+            var center = new System.Drawing.Point(rect.Left + rect.Width / 2, rect.Top + rect.Height / 2);
+            if (rendererBounds.Contains(center))
             {
-                Console.WriteLine($"[automation] {description}: validated selectable point {point} inside renderer bounds {FormatRect(bounds)}");
-                return point;
+                return rect;
             }
-            Thread.Sleep(650);
         }
 
         throw new InvalidOperationException(
-            $"Could not find a real selectable text point for {description} inside renderer bounds {FormatRect(bounds)}. " +
-            "Every candidate failed to produce a sel-anchor log entry.");
+            $"{description}: TextPattern found '{text}' but returned no usable bounding rectangle inside renderer bounds {FormatRect(rendererBounds)}");
     }
 
-    private static IEnumerable<System.Drawing.Point> EnumerateRendererCandidatePoints(System.Drawing.Rectangle bounds)
+    private static System.Drawing.Point FindSelectableTextPatternPoint(
+        string logPath,
+        AutomationElement renderer,
+        string text,
+        string description)
     {
-        int[] xOffsets = { 42, 90, 150, 240, 340, 460, 600 };
-        int[] yOffsets = { 42, 70, 100, 140, 180, 240, 320, 420, 560, 720 };
-        foreach (int y in yOffsets)
-        foreach (int x in xOffsets)
-        {
-            if (x >= bounds.Width - 8 || y >= bounds.Height - 8) continue;
-            yield return new System.Drawing.Point(bounds.X + x, bounds.Y + y);
-        }
+        var point = FindTextPatternPoint(renderer, text, description);
+        long baseline = new FileInfo(logPath).Length;
+        Mouse.MoveTo(point);
+        Thread.Sleep(100);
+        Mouse.Click(point, FlaUI.Core.Input.MouseButton.Left);
+        Thread.Sleep(350);
 
-        double[] xFractions = { 0.2, 0.35, 0.5, 0.65, 0.8 };
-        double[] yFractions = { 0.18, 0.28, 0.38, 0.5, 0.62, 0.75 };
-        foreach (double y in yFractions)
-        foreach (double x in xFractions)
-        {
-            yield return new System.Drawing.Point(
-                (int)Math.Round(bounds.X + bounds.Width * x),
-                (int)Math.Round(bounds.Y + bounds.Height * y));
-        }
+        string appended = ReadShakeLogFrom(logPath, baseline);
+        Assert(CountOccurrences(appended, "sel-anchor") > 0,
+            $"{description}: TextPattern point {point} from '{text}' was not selectable. Recent log excerpt: {Truncate(appended, 600)}");
+
+        Thread.Sleep(750);
+        return point;
     }
 
     private static string FormatRect(System.Drawing.Rectangle rect)
         => $"x={rect.X},y={rect.Y},w={rect.Width},h={rect.Height}";
+
+    private static bool IsNonNoneTextDecoration(object? value)
+    {
+        if (value is null) return false;
+        string s = value.ToString() ?? string.Empty;
+        if (string.Equals(s, "None", StringComparison.OrdinalIgnoreCase)) return false;
+        return !TryAttributeNumber(value, out var number) || Math.Abs(number) > 0.001;
+    }
+
+    private static bool IsTrueAttribute(object? value) =>
+        value is bool b
+            ? b
+            : bool.TryParse(value?.ToString(), out var parsed) && parsed;
+
+    private static int ToColorRefValue(object? value)
+    {
+        if (value is null)
+            throw new InvalidOperationException("Color attribute returned null");
+
+        if (value is int i) return i;
+        if (value is uint u) return unchecked((int)u);
+        if (TryAttributeNumber(value, out var number)) return (int)Math.Round(number);
+
+        throw new InvalidOperationException($"Cannot interpret color attribute value {DescribeAttributeValue(value)}");
+    }
+
+    private static int ColorRef(byte r, byte g, byte b) => r | (g << 8) | (b << 16);
+
+    private static bool TryAttributeNumber(object value, out double number)
+    {
+        try
+        {
+            var type = Nullable.GetUnderlyingType(value.GetType()) ?? value.GetType();
+            if (type.IsEnum)
+            {
+                number = Convert.ToDouble(value, System.Globalization.CultureInfo.InvariantCulture);
+                return true;
+            }
+
+            switch (Type.GetTypeCode(type))
+            {
+                case TypeCode.Byte:
+                case TypeCode.SByte:
+                case TypeCode.Int16:
+                case TypeCode.UInt16:
+                case TypeCode.Int32:
+                case TypeCode.UInt32:
+                case TypeCode.Int64:
+                case TypeCode.UInt64:
+                case TypeCode.Single:
+                case TypeCode.Double:
+                case TypeCode.Decimal:
+                    number = Convert.ToDouble(value, System.Globalization.CultureInfo.InvariantCulture);
+                    return true;
+            }
+        }
+        catch { }
+
+        number = 0;
+        return false;
+    }
+
+    private static string DescribeAttributeValue(object? value) =>
+        value is null ? "<null>" : $"{value} ({value.GetType().FullName})";
 
     private static void DragMouseThrough(System.Drawing.Point start, System.Drawing.Point end)
     {
@@ -619,7 +1462,97 @@ internal static class Program
         }
     }
 
+    private static void SetClipboardText(string text)
+    {
+        WithOpenClipboard(() =>
+        {
+            if (!EmptyClipboard())
+                throw new System.ComponentModel.Win32Exception(System.Runtime.InteropServices.Marshal.GetLastWin32Error());
+
+            int byteCount = checked((text.Length + 1) * 2);
+            IntPtr handle = GlobalAlloc(GlobalMemoryMoveable | GlobalMemoryZeroInit, (UIntPtr)byteCount);
+            if (handle == IntPtr.Zero)
+                throw new System.ComponentModel.Win32Exception(System.Runtime.InteropServices.Marshal.GetLastWin32Error());
+
+            bool transferred = false;
+            try
+            {
+                IntPtr locked = GlobalLock(handle);
+                if (locked == IntPtr.Zero)
+                    throw new System.ComponentModel.Win32Exception(System.Runtime.InteropServices.Marshal.GetLastWin32Error());
+                try
+                {
+                    if (text.Length > 0)
+                        System.Runtime.InteropServices.Marshal.Copy(text.ToCharArray(), 0, locked, text.Length);
+                    System.Runtime.InteropServices.Marshal.WriteInt16(locked, text.Length * 2, 0);
+                }
+                finally
+                {
+                    GlobalUnlock(handle);
+                }
+
+                if (SetClipboardData(ClipboardFormatUnicodeText, handle) == IntPtr.Zero)
+                    throw new System.ComponentModel.Win32Exception(System.Runtime.InteropServices.Marshal.GetLastWin32Error());
+                transferred = true;
+            }
+            finally
+            {
+                if (!transferred)
+                    GlobalFree(handle);
+            }
+        });
+    }
+
+    private static string GetClipboardText()
+    {
+        return WithOpenClipboard(() =>
+        {
+            IntPtr handle = GetClipboardData(ClipboardFormatUnicodeText);
+            if (handle == IntPtr.Zero)
+                return string.Empty;
+
+            IntPtr locked = GlobalLock(handle);
+            if (locked == IntPtr.Zero)
+                return string.Empty;
+            try
+            {
+                return System.Runtime.InteropServices.Marshal.PtrToStringUni(locked) ?? string.Empty;
+            }
+            finally
+            {
+                GlobalUnlock(handle);
+            }
+        });
+    }
+
+    private static void WithOpenClipboard(Action action) => WithOpenClipboard<object?>(() =>
+    {
+        action();
+        return null;
+    });
+
+    private static T WithOpenClipboard<T>(Func<T> action)
+    {
+        Exception? last = null;
+        for (int attempt = 0; attempt < 20; attempt++)
+        {
+            if (OpenClipboard(IntPtr.Zero))
+            {
+                try { return action(); }
+                finally { CloseClipboard(); }
+            }
+
+            last = new System.ComponentModel.Win32Exception(System.Runtime.InteropServices.Marshal.GetLastWin32Error());
+            Thread.Sleep(50);
+        }
+
+        throw new InvalidOperationException("Could not open clipboard for automation probe", last);
+    }
+
     private const uint InputMouse = 0;
+    private const uint ClipboardFormatUnicodeText = 13;
+    private const uint GlobalMemoryMoveable = 0x0002;
+    private const uint GlobalMemoryZeroInit = 0x0040;
     private const int SystemMetricVirtualScreenX = 76;
     private const int SystemMetricVirtualScreenY = 77;
     private const int SystemMetricVirtualScreenWidth = 78;
@@ -662,6 +1595,33 @@ internal static class Program
     [System.Runtime.InteropServices.DllImport("user32.dll")]
     private static extern int GetSystemMetrics(int index);
 
+    [System.Runtime.InteropServices.DllImport("user32.dll", SetLastError = true)]
+    private static extern bool OpenClipboard(IntPtr newOwner);
+
+    [System.Runtime.InteropServices.DllImport("user32.dll", SetLastError = true)]
+    private static extern bool CloseClipboard();
+
+    [System.Runtime.InteropServices.DllImport("user32.dll", SetLastError = true)]
+    private static extern bool EmptyClipboard();
+
+    [System.Runtime.InteropServices.DllImport("user32.dll", SetLastError = true)]
+    private static extern IntPtr GetClipboardData(uint format);
+
+    [System.Runtime.InteropServices.DllImport("user32.dll", SetLastError = true)]
+    private static extern IntPtr SetClipboardData(uint format, IntPtr handle);
+
+    [System.Runtime.InteropServices.DllImport("kernel32.dll", SetLastError = true)]
+    private static extern IntPtr GlobalAlloc(uint flags, UIntPtr bytes);
+
+    [System.Runtime.InteropServices.DllImport("kernel32.dll", SetLastError = true)]
+    private static extern IntPtr GlobalLock(IntPtr handle);
+
+    [System.Runtime.InteropServices.DllImport("kernel32.dll", SetLastError = true)]
+    private static extern bool GlobalUnlock(IntPtr handle);
+
+    [System.Runtime.InteropServices.DllImport("kernel32.dll", SetLastError = true)]
+    private static extern IntPtr GlobalFree(IntPtr handle);
+
     private static string? FindShakeLog()
     {
         // Walk up from the running automation exe to find text_shaking2.log
@@ -702,6 +1662,27 @@ internal static class Program
     private static AutomationElement FindRenderer(Window window)
         => window.FindFirstDescendant(cf => cf.ByAutomationId("MarkdownRenderer"))
            ?? throw new InvalidOperationException("MarkdownRenderer not found in automation tree");
+
+    private static string GetRendererDocumentText(AutomationElement renderer)
+    {
+        var textPattern = renderer.Patterns.Text.PatternOrDefault
+                          ?? throw new InvalidOperationException("MarkdownRenderer must expose UIA TextPattern");
+        return textPattern.DocumentRange.GetText(-1);
+    }
+
+    private static string GetRendererSelectionText(AutomationElement renderer)
+    {
+        var textPattern = renderer.Patterns.Text.PatternOrDefault
+                          ?? throw new InvalidOperationException("MarkdownRenderer must expose UIA TextPattern");
+        return string.Concat(textPattern.GetSelection().Select(range => range.GetText(-1)));
+    }
+
+    private static void ClickSample(Window window, string automationIdSuffix)
+    {
+        var btn = window.FindFirstDescendant(cf => cf.ByAutomationId("SampleButton_" + automationIdSuffix))?.AsButton()
+                  ?? throw new InvalidOperationException($"{automationIdSuffix} sample button not found");
+        btn.Invoke();
+    }
 
     private static int CountEmbedButtons(AutomationElement renderer)
         => renderer.FindAllDescendants(cf => cf.ByControlType(ControlType.Button)).Length;
@@ -756,11 +1737,55 @@ internal static class Program
         if (!condition) throw new InvalidOperationException(message);
     }
 
+    private static void TryFocus(AutomationElement element, string description)
+    {
+        try { element.Focus(); }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine($"[automation] warn: could not focus {description}: {ex.Message}");
+        }
+    }
+
+    private static void WaitForSampleContent(Window window, Application app)
+    {
+        var ready = Retry.WhileFalse(() =>
+            {
+                if (app.HasExited) return true;
+                try
+                {
+                    return window.FindFirstDescendant(cf => cf.ByAutomationId("MarkdownRenderer")) is not null ||
+                           window.FindFirstDescendant(cf => cf.ByAutomationId("SampleButton_Typography")) is not null;
+                }
+                catch { return false; }
+            },
+            timeout: TimeSpan.FromSeconds(20),
+            interval: TimeSpan.FromMilliseconds(250)).Result;
+
+        if (app.HasExited)
+            throw new InvalidOperationException("Sample app exited before UIA content became available.");
+        if (!ready)
+            throw new InvalidOperationException("Sample app did not expose MarkdownRenderer or sample buttons within 20 seconds.");
+    }
+
     private static string? ParseAppPath(string[] args)
     {
         for (int i = 0; i < args.Length - 1; i++)
             if (args[i] == "--app-path") return args[i + 1];
         return null;
+    }
+
+    private static Application LaunchSample(string appPath, bool enableDiagnostics)
+    {
+        var startInfo = new ProcessStartInfo(appPath)
+        {
+            UseShellExecute = false,
+            WorkingDirectory = Path.GetDirectoryName(appPath) ?? Environment.CurrentDirectory,
+        };
+
+        if (enableDiagnostics)
+            startInfo.Environment[DiagnosticsEnvironmentVariable] = "1";
+
+        return Application.Launch(startInfo);
     }
 
     private static string? FindDefaultAppPath()

--- a/MarkdownRenderer/MarkdownRenderer.Sample/App.xaml.cs
+++ b/MarkdownRenderer/MarkdownRenderer.Sample/App.xaml.cs
@@ -1,3 +1,4 @@
+using System;
 using Microsoft.UI.Xaml;
 
 namespace MarkdownRenderer.Sample;
@@ -13,11 +14,9 @@ public partial class App : Application
 
     protected override void OnLaunched(LaunchActivatedEventArgs args)
     {
-        // Enable diagnostic logger by default in the sample app so any
-        // reproduction of the selection-shake bug captures per-frame paint
-        // coordinates to text_shaking2.log next to the repo root.
-        // Flip to false to silence.
-        MarkdownRenderer.Diagnostics.ShakeLogger.Enabled = true;
+        if (args.Arguments.Contains("--markdown-renderer-diagnostics", StringComparison.OrdinalIgnoreCase))
+            MarkdownRenderer.Diagnostics.ShakeLogger.Enabled = true;
+
         _window = new MainWindow();
         _window.Activate();
     }

--- a/MarkdownRenderer/MarkdownRenderer.Sample/MainWindow.xaml.cs
+++ b/MarkdownRenderer/MarkdownRenderer.Sample/MainWindow.xaml.cs
@@ -18,6 +18,7 @@ public sealed partial class MainWindow : Window
     private readonly TextBox _editor;
     private TextBlock? _realizedCountStatus;
     private TextBlock? _flowDirectionStatus;
+    private TextBlock? _highContrastStatus;
 
     // Mapping from tab label → sample markdown for each feature
     private static readonly Dictionary<string, string> Samples = new()
@@ -36,6 +37,7 @@ public sealed partial class MainWindow : Window
         ["Scroll Anchor"] = ScrollAnchorSample,
         ["Footnotes"]     = FootnotesSample,
         ["Keyboard Nav"]  = KeyboardNavSample,
+        ["Accessibility Lab"] = AccessibilityLabSample,
         ["Full Demo"]  = FullDemoSample,
     };
 
@@ -44,6 +46,7 @@ public sealed partial class MainWindow : Window
         Title = "MarkdownRenderer — Feature Showcase";
 
         var rootGrid = new Grid();
+        MarkdownSystemIntegration.SetUseSystemFlowDirection(rootGrid, true);
         rootGrid.RowDefinitions.Add(new RowDefinition { Height = GridLength.Auto });  // toolbar
         rootGrid.RowDefinitions.Add(new RowDefinition { Height = new GridLength(1, GridUnitType.Star) }); // content
 
@@ -94,6 +97,41 @@ public sealed partial class MainWindow : Window
         rtlToggle.Unchecked += (_, _) => { if (_renderer is not null) { _renderer.FlowDirection = FlowDirection.LeftToRight; UpdateFlowDirectionStatus(); } };
         toolbar.Children.Add(rtlToggle);
 
+        var forcedHighContrastToggle = new ToggleButton
+        {
+            Content = "Forced HC",
+            Margin = new Thickness(8, 0, 0, 0),
+            Padding = new Thickness(10, 4, 10, 4),
+            Name = "ForcedHighContrastToggle",
+        };
+        AutomationProperties.SetAutomationId(forcedHighContrastToggle, "ForcedHighContrastToggle");
+        AutomationProperties.SetName(forcedHighContrastToggle, "Forced high contrast");
+        forcedHighContrastToggle.Checked += (_, _) =>
+        {
+            ThemeResolver.SystemThemeProviderOverride = new ForcedMarkdownSystemThemeProvider
+            {
+                IsHighContrast = true,
+                WindowTextColor = Windows.UI.Color.FromArgb(0xFF, 0xFF, 0xFF, 0xFF),
+                WindowColor = Windows.UI.Color.FromArgb(0xFF, 0x00, 0x00, 0x00),
+                HotlightColor = Windows.UI.Color.FromArgb(0xFF, 0x00, 0xFF, 0xFF),
+                HighlightColor = Windows.UI.Color.FromArgb(0xFF, 0xFF, 0xFF, 0x00),
+                HighlightTextColor = Windows.UI.Color.FromArgb(0xFF, 0x00, 0x00, 0x00),
+            };
+            if (_renderer?.Theme is { } theme)
+                theme.AccentColor = Windows.UI.Color.FromArgb(0xFF, 0x80, 0x00, 0x80);
+            UpdateHighContrastStatus(true);
+            _renderer?.RequestRebuild();
+        };
+        forcedHighContrastToggle.Unchecked += (_, _) =>
+        {
+            ThemeResolver.SystemThemeProviderOverride = null;
+            if (_renderer?.Theme is { } theme)
+                theme.AccentColor = null;
+            UpdateHighContrastStatus(false);
+            _renderer?.RequestRebuild();
+        };
+        toolbar.Children.Add(forcedHighContrastToggle);
+
         Grid.SetRow(toolbar, 0);
         rootGrid.Children.Add(toolbar);
 
@@ -112,6 +150,8 @@ public sealed partial class MainWindow : Window
             Padding = new Thickness(8),
             Text = FullDemoSample,
         };
+        AutomationProperties.SetAutomationId(_editor, "MarkdownEditor");
+        AutomationProperties.SetName(_editor, "Markdown source editor");
         ScrollViewer.SetHorizontalScrollBarVisibility(_editor, ScrollBarVisibility.Auto);
         ScrollViewer.SetVerticalScrollBarVisibility(_editor, ScrollBarVisibility.Auto);
         _editor.TextChanged += (_, _) =>
@@ -135,7 +175,6 @@ public sealed partial class MainWindow : Window
             Margin = new Thickness(0),
         };
         AutomationProperties.SetAutomationId(_renderer, "MarkdownRenderer");
-        AutomationProperties.SetName(_renderer, "Markdown Renderer");
         _renderer.LinkClick += (_, e) =>
         {
             try { _ = Windows.System.Launcher.LaunchUriAsync(new Uri(e.Url)); } catch { }
@@ -173,6 +212,17 @@ public sealed partial class MainWindow : Window
         AutomationProperties.SetAutomationId(_flowDirectionStatus, "FlowDirectionStatus");
         AutomationProperties.SetName(_flowDirectionStatus, "flow:ltr");
 
+        _highContrastStatus = new TextBlock
+        {
+            Text = "hc:off",
+            Opacity = 0,
+            IsHitTestVisible = false,
+            Width = 1,
+            Height = 1,
+        };
+        AutomationProperties.SetAutomationId(_highContrastStatus, "HighContrastStatus");
+        AutomationProperties.SetName(_highContrastStatus, "hc:off");
+
         Grid.SetColumn(_editor, 0);
         Grid.SetColumn(splitter, 1);
         Grid.SetColumn(_renderer, 2);
@@ -185,8 +235,19 @@ public sealed partial class MainWindow : Window
         rootGrid.Children.Add(contentGrid);
         rootGrid.Children.Add(_realizedCountStatus);
         rootGrid.Children.Add(_flowDirectionStatus);
+        rootGrid.Children.Add(_highContrastStatus);
 
         Content = rootGrid;
+    }
+
+    private void UpdateHighContrastStatus(bool enabled)
+    {
+        if (_highContrastStatus is null) return;
+        string s = enabled
+            ? "hc:on;fg:#FFFFFF;bg:#000000;hotlight:#00FFFF;highlight:#FFFF00;highlightText:#000000"
+            : "hc:off";
+        _highContrastStatus.Text = s;
+        AutomationProperties.SetName(_highContrastStatus, s);
     }
 
     private void UpdateFlowDirectionStatus()
@@ -276,7 +337,7 @@ public sealed partial class MainWindow : Window
         - [x] Design the layout engine
         - [x] Implement Win2D painter
         - [x] Threading safety with ThemeSnapshot
-        - [ ] Full ITextProvider accessibility
+        - [x] Full ITextProvider accessibility
         - [ ] Performance profiling on real documents
 
         ## Mixed content in list items
@@ -503,7 +564,7 @@ public sealed partial class MainWindow : Window
         - [x] AOT-safe renderer dispatch
         - [x] GFM: tables, task lists, alerts, footnotes
         - [x] ListItemBox — bullet and text side by side
-        - [ ] Full ITextProvider accessibility peer
+        - [x] Full ITextProvider accessibility peer
         - [ ] Per-language syntax highlighting
 
         ## Table
@@ -649,13 +710,12 @@ public sealed partial class MainWindow : Window
 
         - [x] Markdig integration
         - [x] Flow layout
-        - [ ] You can't toggle these because they're disabled — but they're
-              still real WinUI CheckBoxes hosted on the overlay
+        - [ ] These are focusable read-only WinUI CheckBoxes hosted on the overlay
         """;
 
     // ── New feature sample pages ───────────────────────────────────────────────
 
-    private static readonly string LazyImagesSample = """
+    private const string LazyImagesSample = """
         # Lazy Image Loading
 
         Images are only fetched when they are within **800 px** of the current
@@ -838,31 +898,102 @@ public sealed partial class MainWindow : Window
         [^kn1]: First keyboard-nav footnote.
         [^kn2]: Second keyboard-nav footnote. Press Enter on ↩ to return.
         """;
+
+    private const string AccessibilityLabSample = """
+        # Accessibility Lab
+
+        This stable page is intentionally dense: it contains the roles,
+        text ranges, hosted controls, and bidi cases that UI automation probes
+        use for accessibility verification.
+
+        ## Text Pattern
+
+        The quick brown fox jumps over the lazy dog. Narrator should read this
+        paragraph as document text, and UIA TextPattern ranges should return
+        word bounding rectangles for each word.
+
+        Inline `inline-code-token` text must remain visible in high contrast.
+
+        Inline image ![Inline accessibility icon](data:image/svg+xml;utf8,%3Csvg%20xmlns%3D%27http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%27%20width%3D%2716%27%20height%3D%2716%27%20viewBox%3D%270%200%2016%2016%27%3E%3Ctitle%3EInline%20icon%3C%2Ftitle%3E%3Ccircle%20cx%3D%278%27%20cy%3D%278%27%20r%3D%276%27%20fill%3D%27%230078D4%27%2F%3E%3C%2Fsvg%3E) should expose image semantics inside paragraph text.
+
+        A [painted link](https://example.com/accessibility) appears before a
+        hosted WinUI button.
+
+        ```button:Native action
+        ```
+
+        ```panel:Composite action
+        ```
+
+        - [ ] Hosted task checkbox after the button
+        - A regular list item with a [second painted link](https://example.com/second)
+        - Mixed bidi text: English אבגדה Arabic مرحبا 12345
+
+        ## Semantic Table
+
+        | Feature | Expected UIA Role | Detail |
+        |---------|-------------------|--------|
+        | Table | Table/Grid | Exposes row and column counts |
+        | Header cells | DataItem with headers | Header row is discoverable |
+        | Body cells | DataItem | Cell coordinates are stable |
+
+        ## Image
+
+        ![Accessibility lab blue square](data:image/svg+xml;utf8,%3Csvg%20xmlns%3D%27http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%27%20width%3D%2748%27%20height%3D%2748%27%20viewBox%3D%270%200%2048%2048%27%3E%3Ctitle%3EBlue%20square%3C%2Ftitle%3E%3Cdesc%3EUsed%20for%20accessibility%20automation%3C%2Fdesc%3E%3Crect%20width%3D%2748%27%20height%3D%2748%27%20fill%3D%27%230078D4%27%2F%3E%3C%2Fsvg%3E)
+
+        ## Code
+
+        ```csharp
+        Console.WriteLine("code language is exposed as help text");
+        ```
+
+        ## Offscreen Content
+
+        ScrollIntoView should bring this later content into view through UIA.
+
+        Paragraph 1. More stable text for range movement.
+
+        Paragraph 2. More stable text for range movement.
+
+        Paragraph 3. More stable text for range movement.
+
+        Paragraph 4. More stable text for range movement.
+
+        Paragraph 5. More stable text for range movement.
+        """;
 }
 
 /// <summary>
 /// Demonstrates <see cref="IMarkdownEmbedFactory"/> by intercepting fenced
-/// code blocks whose info-string starts with <c>button:</c> and rendering them
-/// as native WinUI <see cref="Button"/>s.
+/// code blocks whose info-string starts with <c>button:</c> or <c>panel:</c>
+/// and rendering them as native WinUI controls.
 /// </summary>
 internal sealed class SampleEmbedFactory : MarkdownRenderer.Hosting.IMarkdownEmbedFactory
 {
     public bool CanCreate(Markdig.Syntax.Block block)
     {
         return block is Markdig.Syntax.FencedCodeBlock fc
-            && (fc.Info?.StartsWith("button:", StringComparison.Ordinal) ?? false);
+            && ((fc.Info?.StartsWith("button:", StringComparison.Ordinal) ?? false) ||
+                (fc.Info?.StartsWith("panel:", StringComparison.Ordinal) ?? false));
     }
 
     public float MeasureHeight(Markdig.Syntax.Block block, float availableWidth)
     {
-        // Simple Button at default WinUI metrics is ~32px tall.
-        return 36f;
+        var fc = (Markdig.Syntax.FencedCodeBlock)block;
+        return fc.Info?.StartsWith("panel:", StringComparison.Ordinal) == true
+            ? 84f
+            : 36f;
     }
 
     public Microsoft.UI.Xaml.FrameworkElement CreateBlock(Markdig.Syntax.Block block)
     {
         var fc = (Markdig.Syntax.FencedCodeBlock)block;
+        if (fc.Info?.StartsWith("panel:", StringComparison.Ordinal) == true)
+            return CreateCompositePanel(fc);
+
         string label = fc.Info!.Substring("button:".Length);
+        if (!string.IsNullOrWhiteSpace(fc.Arguments))
+            label = $"{label} {fc.Arguments}";
         var btn = new Button
         {
             Content = label,
@@ -880,6 +1011,44 @@ internal sealed class SampleEmbedFactory : MarkdownRenderer.Hosting.IMarkdownEmb
             _ = dlg.ShowAsync();
         };
         return btn;
+    }
+
+    private static Microsoft.UI.Xaml.FrameworkElement CreateCompositePanel(Markdig.Syntax.FencedCodeBlock fc)
+    {
+        string label = fc.Info!.Substring("panel:".Length);
+        if (!string.IsNullOrWhiteSpace(fc.Arguments))
+            label = $"{label} {fc.Arguments}";
+
+        var panel = new StackPanel
+        {
+            Orientation = Orientation.Horizontal,
+            Spacing = 8,
+            VerticalAlignment = VerticalAlignment.Center,
+        };
+        AutomationProperties.SetName(panel, label);
+
+        var textBox = new TextBox
+        {
+            Text = "Composite value",
+            Width = 180,
+            MinWidth = 120,
+            VerticalAlignment = VerticalAlignment.Center,
+        };
+        AutomationProperties.SetName(textBox, "Composite value");
+        AutomationProperties.SetAutomationId(textBox, "CompositeValueTextBox");
+
+        var button = new Button
+        {
+            Content = "Composite action",
+            Padding = new Thickness(12, 4, 12, 4),
+            VerticalAlignment = VerticalAlignment.Center,
+        };
+        AutomationProperties.SetName(button, "Composite action");
+        AutomationProperties.SetAutomationId(button, "CompositeActionButton");
+
+        panel.Children.Add(textBox);
+        panel.Children.Add(button);
+        return panel;
     }
 }
 

--- a/MarkdownRenderer/MarkdownRenderer.Tests/FocusableItemTests.cs
+++ b/MarkdownRenderer/MarkdownRenderer.Tests/FocusableItemTests.cs
@@ -1,0 +1,33 @@
+using MarkdownRenderer.Layout;
+using Xunit;
+
+namespace MarkdownRenderer.Tests;
+
+public sealed class FocusableItemTests
+{
+    [Fact]
+    public void LegacyBooleanConstructorPreservesLinkAndInlineEmbedKinds()
+    {
+        var link = new FocusableItem(3, 4, isLink: true);
+        var inlineEmbed = new FocusableItem(5, 6, isLink: false);
+
+        Assert.Equal(FocusableItemKind.Link, link.Kind);
+        Assert.True(link.IsLink);
+        Assert.False(link.IsInlineEmbed);
+
+        Assert.Equal(FocusableItemKind.InlineEmbed, inlineEmbed.Kind);
+        Assert.False(inlineEmbed.IsLink);
+        Assert.True(inlineEmbed.IsInlineEmbed);
+    }
+
+    [Fact]
+    public void ExplicitKindConstructorSupportsBlockEmbeds()
+    {
+        var item = new FocusableItem(7, 0, FocusableItemKind.BlockEmbed);
+
+        Assert.Equal(7, item.BlockIndex);
+        Assert.Equal(0, item.InlineIndex);
+        Assert.True(item.IsBlockEmbed);
+        Assert.False(item.IsLink);
+    }
+}

--- a/MarkdownRenderer/MarkdownRenderer.Tests/HighContrastDefaultsTests.cs
+++ b/MarkdownRenderer/MarkdownRenderer.Tests/HighContrastDefaultsTests.cs
@@ -1,0 +1,51 @@
+using MarkdownRenderer.Theming;
+using Xunit;
+
+namespace MarkdownRenderer.Tests;
+
+public sealed class HighContrastDefaultsTests
+{
+    [Fact]
+    public void LinkUsesSystemHotlightAndUnderline()
+    {
+        var roles = MarkdownHighContrastDefaults.Resolve("Link");
+
+        Assert.Equal(MarkdownHighContrastColorRole.Hotlight, roles.Foreground);
+        Assert.True(roles.Underline);
+        Assert.Null(roles.Background);
+    }
+
+    [Fact]
+    public void BodyAndCodeUseWindowForegroundAndBackground()
+    {
+        var body = MarkdownHighContrastDefaults.Resolve("Body");
+        var code = MarkdownHighContrastDefaults.Resolve("CodeBlock");
+        var inlineCode = MarkdownHighContrastDefaults.Resolve("CodeInline");
+
+        Assert.Equal(MarkdownHighContrastColorRole.WindowText, body.Foreground);
+        Assert.Equal(MarkdownHighContrastColorRole.Window, body.Background);
+        Assert.Equal(MarkdownHighContrastColorRole.WindowText, code.Foreground);
+        Assert.Equal(MarkdownHighContrastColorRole.Window, code.Background);
+        Assert.Equal(MarkdownHighContrastColorRole.WindowText, code.AccentBar);
+        Assert.Equal(MarkdownHighContrastColorRole.WindowText, inlineCode.Foreground);
+        Assert.Equal(MarkdownHighContrastColorRole.Window, inlineCode.Background);
+    }
+
+    [Fact]
+    public void TableHeaderUsesHighlightPair()
+    {
+        var roles = MarkdownHighContrastDefaults.Resolve("TableHeader");
+
+        Assert.Equal(MarkdownHighContrastColorRole.HighlightText, roles.Foreground);
+        Assert.Equal(MarkdownHighContrastColorRole.Highlight, roles.Background);
+    }
+
+    [Fact]
+    public void AlertsUseHotlightAccentBar()
+    {
+        var roles = MarkdownHighContrastDefaults.Resolve("AlertWarning");
+
+        Assert.Equal(MarkdownHighContrastColorRole.WindowText, roles.Foreground);
+        Assert.Equal(MarkdownHighContrastColorRole.Hotlight, roles.AccentBar);
+    }
+}

--- a/MarkdownRenderer/MarkdownRenderer.Tests/KeyboardNavTests.cs
+++ b/MarkdownRenderer/MarkdownRenderer.Tests/KeyboardNavTests.cs
@@ -1,4 +1,5 @@
 using MarkdownRenderer.Layout;
+using Windows.Foundation;
 using Xunit;
 
 namespace MarkdownRenderer.Tests;
@@ -58,5 +59,59 @@ public class KeyboardNavTests
         Assert.Equal(int.MaxValue, item.BlockIndex);
         Assert.Equal(int.MaxValue, item.InlineIndex);
         Assert.False(item.IsLink);
+    }
+
+    [Theory]
+    [InlineData(false, 0)]
+    [InlineData(true, 3)]
+    public void MoveTab_EntersAtBoundary_WhenNoResume(bool reverse, int expected)
+    {
+        Assert.Equal(expected, FocusNavigationHelper.MoveTab(4, currentIndex: -1, resumeIndex: -1, reverse));
+    }
+
+    [Fact]
+    public void MoveTab_UsesPointerResumeIndex()
+    {
+        Assert.Equal(2, FocusNavigationHelper.MoveTab(4, currentIndex: -1, resumeIndex: 2, reverse: false));
+        Assert.Equal(1, FocusNavigationHelper.MoveTab(4, currentIndex: -1, resumeIndex: 2, reverse: true));
+    }
+
+    [Fact]
+    public void MoveTab_ReturnsMinusOne_WhenTraversalShouldExitControl()
+    {
+        Assert.Equal(-1, FocusNavigationHelper.MoveTab(3, currentIndex: 2, resumeIndex: -1, reverse: false));
+        Assert.Equal(-1, FocusNavigationHelper.MoveTab(3, currentIndex: 0, resumeIndex: -1, reverse: true));
+    }
+
+    [Fact]
+    public void FindNearestIndex_ChoosesContainingOrClosestRect()
+    {
+        var rects = new[]
+        {
+            new Rect(10, 10, 20, 20),
+            new Rect(90, 10, 20, 20),
+            new Rect(10, 90, 20, 20),
+        };
+
+        Assert.Equal(0, FocusNavigationHelper.FindNearestIndex(rects, new Point(15, 15)));
+        Assert.Equal(1, FocusNavigationHelper.FindNearestIndex(rects, new Point(75, 20)));
+        Assert.Equal(2, FocusNavigationHelper.FindNearestIndex(rects, new Point(20, 75)));
+    }
+
+    [Fact]
+    public void MoveSpatial_UsesVisualDirection()
+    {
+        var rects = new[]
+        {
+            new Rect(50, 50, 20, 20),
+            new Rect(100, 52, 20, 20),
+            new Rect(52, 110, 20, 20),
+            new Rect(100, 110, 20, 20),
+        };
+
+        Assert.Equal(1, FocusNavigationHelper.MoveSpatial(rects, 0, FocusNavigationDirection.Right));
+        Assert.Equal(2, FocusNavigationHelper.MoveSpatial(rects, 0, FocusNavigationDirection.Down));
+        Assert.Equal(-1, FocusNavigationHelper.MoveSpatial(rects, 0, FocusNavigationDirection.Left));
+        Assert.Equal(3, FocusNavigationHelper.MoveSpatial(rects, 1, FocusNavigationDirection.Down));
     }
 }

--- a/MarkdownRenderer/MarkdownRenderer.Tests/MarkdownRenderer.Tests.csproj
+++ b/MarkdownRenderer/MarkdownRenderer.Tests/MarkdownRenderer.Tests.csproj
@@ -27,6 +27,8 @@
     <Compile Include="..\MarkdownRenderer\Document\MarkdownSourceMap.cs" Link="Core\MarkdownSourceMap.cs" />
     <Compile Include="..\MarkdownRenderer\Parsing\MarkdigParser.cs" Link="Core\MarkdigParser.cs" />
     <Compile Include="..\MarkdownRenderer\Parsing\ForgivingDataUriFixer.cs" Link="Core\ForgivingDataUriFixer.cs" />
+    <Compile Include="..\MarkdownRenderer\Diagnostics\ShakeLogger.cs" Link="Core\ShakeLogger.cs" />
+    <Compile Include="..\MarkdownRenderer\Diagnostics\MarkdownDiagnostics.cs" Link="Core\MarkdownDiagnostics.cs" />
     <Compile Include="..\MarkdownRenderer\Layout\Boxes\SvgIntrinsics.cs" Link="Core\SvgIntrinsics.cs" />
     <Compile Include="..\MarkdownRenderer\Layout\Boxes\SvgThemeInjector.cs" Link="Core\SvgThemeInjector.cs" />
     <Compile Include="..\MarkdownRenderer\Layout\Boxes\SvgTitleExtractor.cs" Link="Core\SvgTitleExtractor.cs" />
@@ -36,6 +38,8 @@
     <Compile Include="..\MarkdownRenderer\Controls\EmbedVisibility.cs" Link="Core\EmbedVisibility.cs" />
     <Compile Include="..\MarkdownRenderer\Layout\TextBoundaryHelper.cs" Link="Core\TextBoundaryHelper.cs" />
     <Compile Include="..\MarkdownRenderer\Layout\FocusableItem.cs" Link="Core\FocusableItem.cs" />
+    <Compile Include="..\MarkdownRenderer\Layout\FocusNavigationHelper.cs" Link="Core\FocusNavigationHelper.cs" />
+    <Compile Include="..\MarkdownRenderer\Theming\MarkdownHighContrastDefaults.cs" Link="Core\MarkdownHighContrastDefaults.cs" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="..\MarkdownRenderer\native\win-x64\thorvg.dll">

--- a/MarkdownRenderer/MarkdownRenderer.Tests/ShakeLoggerTests.cs
+++ b/MarkdownRenderer/MarkdownRenderer.Tests/ShakeLoggerTests.cs
@@ -1,0 +1,49 @@
+using MarkdownRenderer.Diagnostics;
+using Xunit;
+
+namespace MarkdownRenderer.Tests;
+
+public class ShakeLoggerTests
+{
+    [Fact]
+    public void DisabledLoggerDoesNotAdvanceFrameCounter()
+    {
+        bool wasEnabled = ShakeLogger.Enabled;
+        try
+        {
+            ShakeLogger.Enabled = false;
+            long before = ShakeLogger.CurrentFrame;
+
+            long frame = ShakeLogger.NextFrame();
+
+            Assert.Equal(0, frame);
+            Assert.Equal(before, ShakeLogger.CurrentFrame);
+        }
+        finally
+        {
+            ShakeLogger.Enabled = wasEnabled;
+        }
+    }
+
+    [Fact]
+    public void LoggerCanBeEnabledFromDiagnosticsEnvironmentVariable()
+    {
+        bool wasEnabled = ShakeLogger.Enabled;
+        string? oldDiagnostics = Environment.GetEnvironmentVariable(ShakeLogger.DiagnosticsEnvironmentVariable);
+        string? oldShakeLog = Environment.GetEnvironmentVariable(ShakeLogger.ShakeLogEnvironmentVariable);
+        try
+        {
+            Environment.SetEnvironmentVariable(ShakeLogger.DiagnosticsEnvironmentVariable, "1");
+            Environment.SetEnvironmentVariable(ShakeLogger.ShakeLogEnvironmentVariable, null);
+
+            Assert.True(ShakeLogger.ConfigureFromEnvironment());
+            Assert.True(ShakeLogger.IsEnabled);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(ShakeLogger.DiagnosticsEnvironmentVariable, oldDiagnostics);
+            Environment.SetEnvironmentVariable(ShakeLogger.ShakeLogEnvironmentVariable, oldShakeLog);
+            ShakeLogger.Enabled = wasEnabled;
+        }
+    }
+}

--- a/MarkdownRenderer/MarkdownRenderer.Tests/TextBoundaryHelperTests.cs
+++ b/MarkdownRenderer/MarkdownRenderer.Tests/TextBoundaryHelperTests.cs
@@ -141,6 +141,29 @@ public class TextBoundaryHelperTests
     }
 
     [Fact]
+    public void Punctuation_SeparatesWords()
+    {
+        var (start, end) = TextBoundaryHelper.FindWordBoundaries("hello,world", 6);
+        Assert.Equal(6, start);
+        Assert.Equal(11, end);
+    }
+
+    [Fact]
+    public void CombiningMark_StaysWithBaseCharacter()
+    {
+        var (start, end) = TextBoundaryHelper.FindWordBoundaries("cafe\u0301 noir", 4);
+        Assert.Equal(0, start);
+        Assert.Equal(5, end);
+    }
+
+    [Fact]
+    public void WordMovement_SkipsPunctuation()
+    {
+        Assert.Equal(7, TextBoundaryHelper.FindNextWordStart("hello, world", 0));
+        Assert.Equal(0, TextBoundaryHelper.FindPreviousWordStart("hello, world", 7));
+    }
+
+    [Fact]
     public void TrailingDoubleSpace_CursorOnLastSpace_SnapsLeftToWord()
     {
         // "hello  " — cursor on last char (index 6, second trailing space).

--- a/MarkdownRenderer/MarkdownRenderer/Accessibility/MarkdownAutomationPeer.cs
+++ b/MarkdownRenderer/MarkdownRenderer/Accessibility/MarkdownAutomationPeer.cs
@@ -1,118 +1,516 @@
 using System.Collections.Generic;
-using System.Text;
 using Microsoft.UI.Xaml.Automation;
 using Microsoft.UI.Xaml.Automation.Peers;
+using Microsoft.UI.Xaml.Automation.Provider;
 using MarkdownRenderer.Controls;
+using MarkdownRenderer.Document;
 using MarkdownRenderer.Layout;
 using MarkdownRenderer.Layout.Boxes;
 
 namespace MarkdownRenderer.Accessibility;
 
 /// <summary>
-/// Automation peer for <see cref="MarkdownRendererControl"/>. Exposes the
-/// Document control type so screen readers can announce content correctly,
-/// aggregates document text into <see cref="GetNameCore"/>, and surfaces
-/// inline-container blocks (paragraphs, headings, list-item content, etc.)
-/// as structural children with appropriate heading levels and control types.
+/// Automation peer for <see cref="MarkdownRendererControl"/>. It exposes a
+/// native UIA document surface backed by the committed layout snapshot:
+/// semantic child peers for structure, plus TextPattern ranges for Narrator
+/// word/line navigation and highlight rectangles.
 /// </summary>
-public sealed partial class MarkdownAutomationPeer : FrameworkElementAutomationPeer
+public sealed partial class MarkdownAutomationPeer : FrameworkElementAutomationPeer, ITextProvider, ITextProvider2
 {
     private readonly MarkdownRendererControl _owner;
-    // Reusable per-block peer cache keyed on the underlying box's identity.
-    // We don't cache the children *list* itself because returning the same
-    // List<AutomationPeer> across UIA traversals affects how XAML's UIA
-    // tree-walker enumerates descendants and ends up double-counting
-    // realised embed buttons under both this peer and the underlying
-    // visual tree. Caching just the individual MarkdownBlockPeer instances
-    // preserves identity-based focus tracking (Narrator's "where am I"
-    // remains stable) without disturbing the broader tree shape.
     private readonly System.Runtime.CompilerServices.ConditionalWeakTable<InlineContainerBox, MarkdownBlockPeer> _peerCache = new();
+    private readonly Dictionary<MarkdownSemanticNode, MarkdownNodePeer> _nodePeerCache = new();
+    private LayoutSnapshot? _semanticSnapshot;
+    private MarkdownSemanticDocument? _semanticDocument;
 
     public MarkdownAutomationPeer(MarkdownRendererControl owner) : base(owner)
     {
         _owner = owner;
     }
 
+    internal MarkdownRendererControl OwnerControl => _owner;
+
     protected override string GetClassNameCore() => "MarkdownRendererControl";
     protected override AutomationControlType GetAutomationControlTypeCore() => AutomationControlType.Document;
-    protected override AutomationLandmarkType GetLandmarkTypeCore() => AutomationLandmarkType.Custom;
+    protected override bool IsControlElementCore() => true;
+    protected override bool IsContentElementCore() => true;
+    protected override bool HasKeyboardFocusCore() =>
+        !_owner.HasKeyboardFocusOnPaintedLink && base.HasKeyboardFocusCore();
+
+    protected override void SetFocusCore()
+    {
+        _owner.FocusDocumentFromAutomation();
+    }
+
+    public ITextRangeProvider DocumentRange
+    {
+        get
+        {
+            var doc = GetSemanticDocument();
+            return new MarkdownTextRangeProvider(this, 0, doc.Text.Length);
+        }
+    }
+
+    public SupportedTextSelection SupportedTextSelection => SupportedTextSelection.Single;
 
     protected override string GetNameCore()
     {
-        var snap = _owner.CurrentSnapshot;
-        if (snap is null) return "Markdown document";
+        var doc = GetSemanticDocumentOrNull();
+        if (doc is null) return MarkdownLocalizedStrings.MarkdownDocumentName;
 
-        var sb = new StringBuilder();
-        foreach (var b in snap.Blocks) AppendText(b, sb);
-        var text = sb.ToString().Trim();
-        if (text.Length == 0) return "Markdown document";
-        // Cap to a reasonable size — narrators typically truncate anyway, and
-        // very large strings make automation traversal slow.
-        return text.Length > 4096 ? text.Substring(0, 4096) : text;
+        foreach (var node in EnumerateSemanticNodes(doc.Root))
+        {
+            if (node.Role != MarkdownSemanticRole.Heading)
+                continue;
+
+            var heading = doc.GetText(node);
+            if (!string.IsNullOrWhiteSpace(heading))
+                return heading.Length > 120 ? heading.Substring(0, 120) : heading;
+        }
+
+        return MarkdownLocalizedStrings.MarkdownDocumentName;
     }
 
     protected override IList<AutomationPeer> GetChildrenCore()
     {
-        var children = new List<AutomationPeer>();
-        var snap = _owner.CurrentSnapshot;
-        if (snap is null) return children;
-        foreach (var b in snap.Blocks) CollectChildren(b, children);
-        return children;
+        var doc = GetSemanticDocumentOrNull();
+        return doc is null ? new List<AutomationPeer>() : GetChildPeersForSemanticNode(doc.Root);
     }
 
-    private void CollectChildren(BlockBox box, List<AutomationPeer> sink)
+    protected override object GetPatternCore(PatternInterface patternInterface)
     {
-        switch (box)
+        if (patternInterface == PatternInterface.Text || patternInterface == PatternInterface.Text2) return this;
+        return base.GetPatternCore(patternInterface);
+    }
+
+    public ITextRangeProvider[] GetSelection()
+    {
+        var doc = GetSemanticDocument();
+        var range = _owner.CurrentSelectionRange;
+        if (!range.IsEmpty)
         {
-            case InlineContainerBox icb:
-                if (!_peerCache.TryGetValue(icb, out var peer))
+            var normalized = range.Normalized();
+            int start = doc.TextOffsetFromDocumentPosition(normalized.Start);
+            int end = doc.TextOffsetFromDocumentPosition(normalized.End);
+            return new ITextRangeProvider[] { new MarkdownTextRangeProvider(this, start, end) };
+        }
+
+        return new ITextRangeProvider[] { new MarkdownTextRangeProvider(this, 0, 0) };
+    }
+
+    public ITextRangeProvider[] GetVisibleRanges()
+    {
+        var doc = GetSemanticDocument();
+        if (!_owner.TryGetVisibleDocumentRect(out var viewport))
+            return new ITextRangeProvider[] { new MarkdownTextRangeProvider(this, 0, doc.Text.Length) };
+
+        int? start = null;
+        int? end = null;
+        foreach (var span in doc.TextSpans)
+        {
+            var bounds = span.InlineBox?.Bounds ?? span.ImageBox?.Bounds ?? span.EmbedBox?.Bounds ?? default;
+            if (bounds.Height <= 0 || bounds.Bottom < viewport.Top || bounds.Top > viewport.Bottom) continue;
+            start = start is null ? span.TextStart : System.Math.Min(start.Value, span.TextStart);
+            end = end is null ? span.TextEnd : System.Math.Max(end.Value, span.TextEnd);
+        }
+
+        return new ITextRangeProvider[] { new MarkdownTextRangeProvider(this, start ?? 0, end ?? 0) };
+    }
+
+    public ITextRangeProvider RangeFromChild(IRawElementProviderSimple childElement)
+    {
+        var doc = GetSemanticDocument();
+        if (TryPeerFromProvider(childElement, out var childPeer) &&
+            TryGetRangeForAutomationPeer(childPeer, doc, out var peerStart, out var peerEnd))
+        {
+            return new MarkdownTextRangeProvider(this, peerStart, peerEnd);
+        }
+
+        foreach (var node in EnumerateSemanticNodes(doc.Root))
+        {
+            if (ReferenceEquals(node, doc.Root))
+                continue;
+
+            if (TryGetProviderForSemanticNode(node, out var provider) &&
+                ProvidersMatch(provider, childElement))
+            {
+                return new MarkdownTextRangeProvider(this, node.TextStart, node.TextEnd);
+            }
+        }
+
+        return new MarkdownTextRangeProvider(this, 0, 0);
+    }
+
+    public ITextRangeProvider RangeFromPoint(Windows.Foundation.Point screenLocation)
+    {
+        var doc = GetSemanticDocument();
+        if (_owner.CurrentSnapshot is { } snapshot &&
+            TryScreenPointToDocumentPoint(screenLocation, out var docPoint) &&
+            snapshot.HitTest(docPoint, out var position))
+        {
+            int offset = doc.TextOffsetFromDocumentPosition(position);
+            return new MarkdownTextRangeProvider(this, offset, offset);
+        }
+
+        return new MarkdownTextRangeProvider(this, 0, 0);
+    }
+
+    public ITextRangeProvider RangeFromAnnotation(IRawElementProviderSimple annotationElement) =>
+        new MarkdownTextRangeProvider(this, 0, 0);
+
+    public ITextRangeProvider GetCaretRange(out bool isActive)
+    {
+        isActive = _owner.FocusState != Microsoft.UI.Xaml.FocusState.Unfocused;
+        var selection = GetSelection();
+        return selection.Length > 0
+            ? selection[0]
+            : new MarkdownTextRangeProvider(this, 0, 0);
+    }
+
+    internal MarkdownSemanticDocument GetSemanticDocument()
+    {
+        var doc = GetSemanticDocumentOrNull();
+        return doc ?? MarkdownSemanticDocument.Build(new LayoutSnapshot(System.Array.Empty<BlockBox>(), new MarkdownSourceMap(string.Empty), 0, 0));
+    }
+
+    internal IList<AutomationPeer> GetChildPeersForSemanticNode(MarkdownSemanticNode node)
+    {
+        var list = new List<AutomationPeer>();
+        foreach (var child in node.Children)
+        {
+            if (child.Role == MarkdownSemanticRole.Link)
+                continue;
+
+            if (child.Role is MarkdownSemanticRole.Paragraph or MarkdownSemanticRole.Heading or MarkdownSemanticRole.CodeBlock &&
+                child.InlineBox is { } inline)
+            {
+                list.Add(GetOrCreateBlockPeer(inline));
+                continue;
+            }
+
+            list.Add(GetOrCreateNodePeer(child));
+        }
+
+        return list;
+    }
+
+    internal IList<AutomationPeer> GetInlineChildPeers(InlineContainerBox box)
+    {
+        var doc = GetSemanticDocumentOrNull();
+        if (doc is null) return new List<AutomationPeer>();
+
+        foreach (var node in EnumerateSemanticNodes(doc.Root))
+        {
+            if (ReferenceEquals(node.InlineBox, box) &&
+                node.Role is MarkdownSemanticRole.Paragraph or MarkdownSemanticRole.Heading or MarkdownSemanticRole.CodeBlock)
+            {
+                var peers = new List<AutomationPeer>();
+                foreach (var child in node.Children)
                 {
-                    peer = new MarkdownBlockPeer(_owner, icb);
-                    _peerCache.Add(icb, peer);
+                    if (TryGetPeerForSemanticNode(child, out var peer))
+                        peers.Add(peer);
                 }
-                sink.Add(peer);
-                break;
-            case ListItemBox lib:
-                CollectChildren(lib.Marker, sink);
-                CollectChildren(lib.Content, sink);
-                break;
-            case TableBox tb:
-                foreach (var c in tb.GetCellBoxes()) CollectChildren(c, sink);
-                break;
-            case StackBox sb:
-                foreach (var c in sb.Children) CollectChildren(c, sink);
-                break;
+
+                return peers;
+            }
+        }
+
+        return new List<AutomationPeer>();
+    }
+
+    internal bool TryGetProviderForSemanticNode(MarkdownSemanticNode node, out IRawElementProviderSimple provider)
+    {
+        if (TryGetPeerForSemanticNode(node, out var peer))
+        {
+            provider = ProviderFromPeer(peer);
+            return true;
+        }
+
+        provider = null!;
+        return false;
+    }
+
+    internal bool TryGetPeerForSemanticNode(MarkdownSemanticNode node, out AutomationPeer peer)
+    {
+        if (node.Role is MarkdownSemanticRole.Paragraph or MarkdownSemanticRole.Heading or MarkdownSemanticRole.CodeBlock &&
+            node.InlineBox is { } blockInline)
+        {
+            peer = GetOrCreateBlockPeer(blockInline);
+            return true;
+        }
+
+        if (node.Role == MarkdownSemanticRole.Link &&
+            node.InlineBox is { } inline &&
+            node.InlineRun is LinkRun link)
+        {
+            var blockPeer = GetOrCreateBlockPeer(inline);
+            peer = _owner.GetOrCreateLinkPeer(blockPeer, link);
+            return true;
+        }
+
+        if (node.Role == MarkdownSemanticRole.Embed)
+        {
+            var element = node.InlineRun is InlineEmbedRun inlineEmbed
+                ? inlineEmbed.RealizedElement
+                : node.EmbedBox?.RealizedElement;
+            if (element is not null)
+            {
+                var elementPeer = FrameworkElementAutomationPeer.FromElement(element)
+                                  ?? FrameworkElementAutomationPeer.CreatePeerForElement(element);
+                if (elementPeer is not null)
+                {
+                    peer = elementPeer;
+                    return true;
+                }
+            }
+        }
+
+        peer = GetOrCreateNodePeer(node);
+        return true;
+    }
+
+    internal void RaiseFocusForLink(InlineContainerBox inline, LinkRun link)
+    {
+        var blockPeer = GetOrCreateBlockPeer(inline);
+        var linkPeer = _owner.GetOrCreateLinkPeer(blockPeer, link);
+        linkPeer.RaiseAutomationFocusChanged();
+    }
+
+    internal IRawElementProviderSimple ProviderFromPeerForTextRange(AutomationPeer peer) => ProviderFromPeer(peer);
+
+    internal Windows.Foundation.Rect GetScreenRectForDocumentRect(Windows.Foundation.Rect docRect)
+    {
+        var ownerScreen = GetBoundingRectangleCore();
+        if (ownerScreen.Width <= 0 || ownerScreen.Height <= 0) return default;
+
+        double scale = _owner.XamlRoot?.RasterizationScale ?? 1.0;
+        return new Windows.Foundation.Rect(
+            ownerScreen.X + docRect.X * scale,
+            ownerScreen.Y + (_owner.CurrentContentOffsetY + docRect.Y - _owner.CurrentScrollOffsetY) * scale,
+            docRect.Width * scale,
+            docRect.Height * scale);
+    }
+
+    private bool TryScreenPointToDocumentPoint(
+        Windows.Foundation.Point screenLocation,
+        out Windows.Foundation.Point documentPoint)
+    {
+        var ownerScreen = GetBoundingRectangleCore();
+        if (ownerScreen.Width <= 0 || ownerScreen.Height <= 0)
+        {
+            documentPoint = default;
+            return false;
+        }
+
+        double scale = _owner.XamlRoot?.RasterizationScale ?? 1.0;
+        if (scale <= 0) scale = 1.0;
+        var rawPoint = new Windows.Foundation.Point(
+            (screenLocation.X - ownerScreen.X) / scale,
+            (screenLocation.Y - ownerScreen.Y) / scale - _owner.CurrentContentOffsetY + _owner.CurrentScrollOffsetY);
+        documentPoint = CoerceToNearestTextRect(GetSemanticDocument(), rawPoint);
+        return true;
+    }
+
+    private static Windows.Foundation.Point CoerceToNearestTextRect(
+        MarkdownSemanticDocument doc,
+        Windows.Foundation.Point point)
+    {
+        Windows.Foundation.Rect best = default;
+        double bestScore = double.PositiveInfinity;
+
+        foreach (var span in doc.TextSpans)
+        {
+            foreach (var rect in doc.GetDocumentRects(span.TextStart, span.TextEnd))
+            {
+                if (rect.Width <= 0 || rect.Height <= 0)
+                    continue;
+
+                double x = System.Math.Clamp(point.X, rect.Left, rect.Right);
+                double y = System.Math.Clamp(point.Y, rect.Top, rect.Bottom);
+                double dx = point.X - x;
+                double dy = point.Y - y;
+                double score = dx * dx + dy * dy;
+                if (score < bestScore)
+                {
+                    bestScore = score;
+                    best = rect;
+                }
+            }
+        }
+
+        if (!double.IsFinite(bestScore))
+            return point;
+
+        return new Windows.Foundation.Point(
+            System.Math.Clamp(point.X, best.Left, best.Right),
+            System.Math.Clamp(point.Y, best.Top, best.Bottom));
+    }
+
+    internal bool TryGetTextRangeForInlineBox(InlineContainerBox box, out int start, out int end)
+    {
+        var doc = GetSemanticDocument();
+        foreach (var span in doc.TextSpans)
+        {
+            if (ReferenceEquals(span.InlineBox, box))
+            {
+                start = span.TextStart;
+                end = span.TextEnd;
+                return true;
+            }
+        }
+
+        start = 0;
+        end = 0;
+        return false;
+    }
+
+    private MarkdownSemanticDocument? GetSemanticDocumentOrNull()
+    {
+        var snap = _owner.CurrentSnapshot;
+        if (snap is null) return null;
+
+        if (!ReferenceEquals(snap, _semanticSnapshot) || _semanticDocument is null)
+        {
+            _semanticSnapshot = snap;
+            _semanticDocument = MarkdownSemanticDocument.Build(snap);
+            _nodePeerCache.Clear();
+        }
+
+        return _semanticDocument;
+    }
+
+    private MarkdownBlockPeer GetOrCreateBlockPeer(InlineContainerBox box)
+    {
+        if (!_peerCache.TryGetValue(box, out var peer))
+        {
+            peer = new MarkdownBlockPeer(_owner, this, box);
+            _peerCache.Add(box, peer);
+        }
+
+        return peer;
+    }
+
+    private MarkdownNodePeer GetOrCreateNodePeer(MarkdownSemanticNode node)
+    {
+        if (!_nodePeerCache.TryGetValue(node, out var peer))
+        {
+            peer = new MarkdownNodePeer(_owner, this, node);
+            _nodePeerCache[node] = peer;
+        }
+
+        return peer;
+    }
+
+    private bool TryGetRangeForAutomationPeer(AutomationPeer peer, MarkdownSemanticDocument doc, out int start, out int end)
+    {
+        if (ReferenceEquals(peer, this))
+        {
+            start = 0;
+            end = doc.Text.Length;
+            return true;
+        }
+
+        foreach (var node in EnumerateSemanticNodes(doc.Root))
+        {
+            if (ReferenceEquals(node, doc.Root))
+                continue;
+
+            if (PeerMatchesSemanticNode(peer, node))
+            {
+                start = node.TextStart;
+                end = node.TextEnd;
+                return true;
+            }
+        }
+
+        start = 0;
+        end = 0;
+        return false;
+    }
+
+    private bool PeerMatchesSemanticNode(AutomationPeer peer, MarkdownSemanticNode node)
+    {
+        return peer switch
+        {
+            MarkdownNodePeer nodePeer => ReferenceEquals(nodePeer.Node, node),
+            MarkdownBlockPeer blockPeer => node.InlineBox is { } inline &&
+                                           ReferenceEquals(blockPeer.Box, inline),
+            MarkdownLinkPeer linkPeer => node.InlineRun is LinkRun link &&
+                                         ReferenceEquals(linkPeer.Run, link),
+            _ => PeerMatchesHostedElement(peer, node),
+        };
+    }
+
+    private static bool PeerMatchesHostedElement(AutomationPeer peer, MarkdownSemanticNode node)
+    {
+        if (node.Role != MarkdownSemanticRole.Embed)
+            return false;
+
+        var element = node.InlineRun is InlineEmbedRun inlineEmbed
+            ? inlineEmbed.RealizedElement
+            : node.EmbedBox?.RealizedElement;
+        if (element is null)
+            return false;
+
+        var elementPeer = FrameworkElementAutomationPeer.FromElement(element)
+                          ?? FrameworkElementAutomationPeer.CreatePeerForElement(element);
+        return ReferenceEquals(peer, elementPeer);
+    }
+
+    private bool TryPeerFromProvider(IRawElementProviderSimple provider, out AutomationPeer peer)
+    {
+        try
+        {
+            peer = PeerFromProvider(provider);
+            return peer is not null;
+        }
+        catch
+        {
+            peer = null!;
+            return false;
         }
     }
 
-    private static void AppendText(BlockBox box, StringBuilder sb)
+    private static IEnumerable<MarkdownSemanticNode> EnumerateSemanticNodes(MarkdownSemanticNode node)
     {
-        switch (box)
+        yield return node;
+        foreach (var child in node.Children)
         {
-            case InlineContainerBox icb:
-                foreach (var run in icb.Runs) sb.Append(run.Text);
-                sb.Append('\n');
-                break;
-            case ListItemBox lib:
-                AppendText(lib.Marker, sb);
-                sb.Append(' ');
-                AppendText(lib.Content, sb);
-                break;
-            case TableBox tb:
-                foreach (var c in tb.GetCellBoxes()) { AppendText(c, sb); sb.Append(' '); }
-                sb.Append('\n');
-                break;
-            case StackBox stack:
-                foreach (var c in stack.Children) AppendText(c, sb);
-                break;
-            case ImageBox ib:
-                // Prefer the explicit alt text. When the SVG provides
-                // <title>/<desc> and alt is empty, fall back to those so
-                // assistive tech still has a meaningful name.
-                if (!string.IsNullOrEmpty(ib.Alt)) { sb.Append(ib.Alt); sb.Append('\n'); }
-                else if (!string.IsNullOrEmpty(ib.SvgTitle)) { sb.Append(ib.SvgTitle); sb.Append('\n'); }
-                if (!string.IsNullOrEmpty(ib.SvgDesc)) { sb.Append(ib.SvgDesc); sb.Append('\n'); }
-                break;
+            foreach (var descendant in EnumerateSemanticNodes(child))
+                yield return descendant;
+        }
+    }
+
+    private static bool ProvidersMatch(IRawElementProviderSimple provider, IRawElementProviderSimple childElement)
+    {
+        if (ReferenceEquals(provider, childElement)) return true;
+        try
+        {
+            if (provider.Equals(childElement) || childElement.Equals(provider))
+                return true;
+        }
+        catch
+        {
+        }
+
+        var providerUnknown = System.IntPtr.Zero;
+        var childUnknown = System.IntPtr.Zero;
+        try
+        {
+            providerUnknown = System.Runtime.InteropServices.Marshal.GetIUnknownForObject(provider);
+            childUnknown = System.Runtime.InteropServices.Marshal.GetIUnknownForObject(childElement);
+            return providerUnknown != System.IntPtr.Zero && providerUnknown == childUnknown;
+        }
+        catch
+        {
+            return false;
+        }
+        finally
+        {
+            if (providerUnknown != System.IntPtr.Zero)
+                System.Runtime.InteropServices.Marshal.Release(providerUnknown);
+            if (childUnknown != System.IntPtr.Zero)
+                System.Runtime.InteropServices.Marshal.Release(childUnknown);
         }
     }
 }

--- a/MarkdownRenderer/MarkdownRenderer/Accessibility/MarkdownBlockPeer.cs
+++ b/MarkdownRenderer/MarkdownRenderer/Accessibility/MarkdownBlockPeer.cs
@@ -1,5 +1,9 @@
+using System.Collections.Generic;
 using System.Text;
+using Microsoft.UI.Xaml.Automation;
+using Microsoft.UI.Xaml.Automation.Provider;
 using Microsoft.UI.Xaml.Automation.Peers;
+using Microsoft.UI.Xaml.Automation.Text;
 using MarkdownRenderer.Controls;
 using MarkdownRenderer.Layout;
 using MarkdownRenderer.Layout.Boxes;
@@ -13,31 +17,42 @@ namespace MarkdownRenderer.Accessibility;
 /// as the accessible name and maps headings/links to the appropriate
 /// AutomationControlType so screen readers can announce structure.
 /// </summary>
-internal sealed partial class MarkdownBlockPeer : FrameworkElementAutomationPeer
+internal sealed partial class MarkdownBlockPeer : FrameworkElementAutomationPeer, ITextProvider, ITextProvider2
 {
     private readonly MarkdownRendererControl _owner;
+    private readonly MarkdownAutomationPeer _root;
     private readonly InlineContainerBox _box;
 
-    public MarkdownBlockPeer(MarkdownRendererControl owner, InlineContainerBox box) : base(owner)
+    public MarkdownBlockPeer(MarkdownRendererControl owner, MarkdownAutomationPeer root, InlineContainerBox box) : base(owner)
     {
         _owner = owner;
+        _root = root;
         _box = box;
     }
 
+    public ITextRangeProvider DocumentRange
+    {
+        get
+        {
+            var (start, end) = GetTextRange();
+            return new MarkdownTextRangeProvider(_root, start, end);
+        }
+    }
+
+    public SupportedTextSelection SupportedTextSelection => _root.SupportedTextSelection;
+
     protected override string GetClassNameCore() => "MarkdownBlock";
+    protected override bool IsControlElementCore() => true;
+    protected override bool IsContentElementCore() => true;
+    protected override bool IsKeyboardFocusableCore() => false;
 
     protected override System.Collections.Generic.IList<AutomationPeer> GetChildrenCore()
     {
         // Surface inline links so screen readers can navigate hyperlinks
-        // within a paragraph/heading independent of the surrounding text.
-        // Link peers are cached per LinkRun on the owner so peer identity is
-        // stable across repeated UIA traversals.
-        var list = new System.Collections.Generic.List<AutomationPeer>();
-        foreach (var run in _box.Runs)
-        {
-            if (run is LinkRun lr) list.Add(_owner.GetOrCreateLinkPeer(this, lr));
-        }
-        return list;
+        // within a paragraph/heading independent of the surrounding text, and
+        // keep inline images/embeds as real semantic children instead of
+        // flattening them into the paragraph text peer.
+        return _root.GetInlineChildPeers(_box);
     }
 
     protected override AutomationControlType GetAutomationControlTypeCore()
@@ -73,6 +88,72 @@ internal sealed partial class MarkdownBlockPeer : FrameworkElementAutomationPeer
         return sb.ToString();
     }
 
+    protected override string GetHelpTextCore()
+    {
+        return _box.ElementKey == MarkdownElementKeys.CodeBlock && !string.IsNullOrWhiteSpace(_box.CodeLanguage)
+            ? MarkdownLocalizedStrings.CodeLanguageHelp(_box.CodeLanguage)
+            : string.Empty;
+    }
+
+    protected override object GetPatternCore(PatternInterface patternInterface)
+    {
+        if (patternInterface == PatternInterface.Text || patternInterface == PatternInterface.Text2) return this;
+        return base.GetPatternCore(patternInterface);
+    }
+
+    public ITextRangeProvider[] GetSelection()
+    {
+        var (blockStart, blockEnd) = GetTextRange();
+        var selection = _root.GetSelection();
+        var clipped = new List<ITextRangeProvider>();
+        foreach (var range in selection)
+        {
+            if (range is not MarkdownTextRangeProvider markdownRange)
+                continue;
+
+            int start = System.Math.Max(blockStart, markdownRange.Start);
+            int end = System.Math.Min(blockEnd, markdownRange.End);
+            if (end >= start)
+                clipped.Add(new MarkdownTextRangeProvider(_root, start, end));
+        }
+
+        return clipped.Count > 0
+            ? clipped.ToArray()
+            : new ITextRangeProvider[] { new MarkdownTextRangeProvider(_root, blockStart, blockStart) };
+    }
+
+    public ITextRangeProvider[] GetVisibleRanges()
+    {
+        var (blockStart, blockEnd) = GetTextRange();
+        return new ITextRangeProvider[] { new MarkdownTextRangeProvider(_root, blockStart, blockEnd) };
+    }
+
+    public ITextRangeProvider RangeFromChild(IRawElementProviderSimple childElement) =>
+        _root.RangeFromChild(childElement);
+
+    public ITextRangeProvider RangeFromPoint(Windows.Foundation.Point screenLocation)
+    {
+        var range = _root.RangeFromPoint(screenLocation);
+        if (range is not MarkdownTextRangeProvider markdownRange)
+            return range;
+
+        var (blockStart, blockEnd) = GetTextRange();
+        int offset = System.Math.Clamp(markdownRange.Start, blockStart, blockEnd);
+        return new MarkdownTextRangeProvider(_root, offset, offset);
+    }
+
+    public ITextRangeProvider RangeFromAnnotation(IRawElementProviderSimple annotationElement) =>
+        new MarkdownTextRangeProvider(_root, GetTextRange().Start, GetTextRange().Start);
+
+    public ITextRangeProvider GetCaretRange(out bool isActive)
+    {
+        isActive = _owner.FocusState != Microsoft.UI.Xaml.FocusState.Unfocused;
+        var selection = GetSelection();
+        return selection.Length > 0
+            ? selection[0]
+            : new MarkdownTextRangeProvider(_root, GetTextRange().Start, GetTextRange().Start);
+    }
+
     protected override Windows.Foundation.Rect GetBoundingRectangleCore()
     {
         // Default FrameworkElementAutomationPeer reports the owning control's
@@ -85,6 +166,7 @@ internal sealed partial class MarkdownBlockPeer : FrameworkElementAutomationPeer
         if (ownerScreen.Width <= 0 || ownerScreen.Height <= 0) return ownerScreen;
 
         double scrollY = _owner.CurrentScrollOffsetY;
+        double contentOffsetY = _owner.CurrentContentOffsetY;
         double scale = _owner.XamlRoot?.RasterizationScale ?? 1.0;
         double relX = _box.Bounds.X;
         double relY = _box.Bounds.Y - scrollY;
@@ -97,7 +179,7 @@ internal sealed partial class MarkdownBlockPeer : FrameworkElementAutomationPeer
         // do NOT mirror here — applying a blanket reflect-about-right-edge
         // would double-mirror children that are already placed in RTL.
         double x = ownerScreen.X + relX * scale;
-        double y = ownerScreen.Y + relY * scale;
+        double y = ownerScreen.Y + (contentOffsetY + relY) * scale;
         return new Windows.Foundation.Rect(x, y, w, h);
     }
 
@@ -107,4 +189,11 @@ internal sealed partial class MarkdownBlockPeer : FrameworkElementAutomationPeer
     /// child link peers can compose against the same screen-space math without
     /// duplicating it.</summary>
     internal Windows.Foundation.Rect GetBoundingRectangleCoreInternal() => GetBoundingRectangleCore();
+
+    private (int Start, int End) GetTextRange()
+    {
+        return _root.TryGetTextRangeForInlineBox(_box, out int start, out int end)
+            ? (start, end)
+            : (0, 0);
+    }
 }

--- a/MarkdownRenderer/MarkdownRenderer/Accessibility/MarkdownLinkPeer.cs
+++ b/MarkdownRenderer/MarkdownRenderer/Accessibility/MarkdownLinkPeer.cs
@@ -30,9 +30,15 @@ internal sealed partial class MarkdownLinkPeer : FrameworkElementAutomationPeer,
 
     protected override string GetClassNameCore() => "MarkdownLink";
     protected override AutomationControlType GetAutomationControlTypeCore() => AutomationControlType.Hyperlink;
-    protected override string GetLocalizedControlTypeCore() => "hyperlink";
     protected override string GetNameCore() => _run.Text;
     protected override string GetHelpTextCore() => _run.Url;
+    protected override bool IsKeyboardFocusableCore() => true;
+    protected override bool HasKeyboardFocusCore() => _owner.IsKeyboardFocusOnLink(_run);
+
+    protected override void SetFocusCore()
+    {
+        _owner.FocusLinkFromAutomation(_run);
+    }
 
     protected override object GetPatternCore(PatternInterface patternInterface)
     {
@@ -49,11 +55,24 @@ internal sealed partial class MarkdownLinkPeer : FrameworkElementAutomationPeer,
 
     protected override Windows.Foundation.Rect GetBoundingRectangleCore()
     {
-        // Fall back to the parent block's rect: it's a much tighter bound than
-        // the whole renderer and gives spatial UIA navigation (touch-explore,
-        // Narrator scan-mode) the correct hit region for the paragraph/heading
-        // that contains this link.
-        return _parent.GetBoundingRectangleCoreInternal();
+        var docRect = _parent.Box.GetRunRect(_run.InlineIndex);
+        if (docRect.Width <= 0 || docRect.Height <= 0)
+            return _parent.GetBoundingRectangleCoreInternal();
+
+        var ownerScreen = base.GetBoundingRectangleCore();
+        if (ownerScreen.Width <= 0 || ownerScreen.Height <= 0)
+            return _parent.GetBoundingRectangleCoreInternal();
+
+        double scale = _owner.XamlRoot?.RasterizationScale ?? 1.0;
+        return new Windows.Foundation.Rect(
+            ownerScreen.X + docRect.X * scale,
+            ownerScreen.Y + (_owner.CurrentContentOffsetY + docRect.Y - _owner.CurrentScrollOffsetY) * scale,
+            docRect.Width * scale,
+            docRect.Height * scale);
+    }
+
+    internal void RaiseAutomationFocusChanged()
+    {
+        RaiseAutomationEvent(AutomationEvents.AutomationFocusChanged);
     }
 }
-

--- a/MarkdownRenderer/MarkdownRenderer/Accessibility/MarkdownLocalizedStrings.cs
+++ b/MarkdownRenderer/MarkdownRenderer/Accessibility/MarkdownLocalizedStrings.cs
@@ -1,0 +1,56 @@
+using System.Globalization;
+using System.Resources;
+
+namespace MarkdownRenderer.Accessibility;
+
+internal static class MarkdownLocalizedStrings
+{
+    private static readonly ResourceManager Resources = new(
+        "MarkdownRenderer.Properties.Resources",
+        typeof(MarkdownLocalizedStrings).Assembly);
+
+    public static string MarkdownDocumentName => Get("MarkdownDocumentName", "Markdown document");
+    public static string ImageName => Get("ImageName", "Image");
+    public static string TableName => Get("TableName", "Table");
+    public static string ListName => Get("ListName", "List");
+    public static string EmbeddedContentName => Get("EmbeddedContentName", "Embedded content");
+    public static string ContextMenuCopy => Get("ContextMenuCopy", "Copy");
+    public static string ContextMenuSelectAll => Get("ContextMenuSelectAll", "Select All");
+
+    public static string CodeLanguageHelp(string language) =>
+        string.Format(CultureInfo.CurrentUICulture, Get("CodeLanguageHelpFormat", "Language: {0}"), language);
+
+    public static string StyleName(string elementKey) => elementKey switch
+    {
+        Theming.MarkdownElementKeys.Body => Get("StyleBody", "Body"),
+        Theming.MarkdownElementKeys.Heading1 => Get("StyleHeading1", "Heading 1"),
+        Theming.MarkdownElementKeys.Heading2 => Get("StyleHeading2", "Heading 2"),
+        Theming.MarkdownElementKeys.Heading3 => Get("StyleHeading3", "Heading 3"),
+        Theming.MarkdownElementKeys.Heading4 => Get("StyleHeading4", "Heading 4"),
+        Theming.MarkdownElementKeys.Heading5 => Get("StyleHeading5", "Heading 5"),
+        Theming.MarkdownElementKeys.Heading6 => Get("StyleHeading6", "Heading 6"),
+        Theming.MarkdownElementKeys.CodeBlock => Get("StyleCodeBlock", "Code block"),
+        Theming.MarkdownElementKeys.CodeInline => Get("StyleInlineCode", "Inline code"),
+        Theming.MarkdownElementKeys.Quote => Get("StyleQuote", "Quote"),
+        Theming.MarkdownElementKeys.Link => Get("StyleLink", "Link"),
+        Theming.MarkdownElementKeys.Strong => Get("StyleStrong", "Strong"),
+        Theming.MarkdownElementKeys.Emphasis => Get("StyleEmphasis", "Emphasis"),
+        Theming.MarkdownElementKeys.Strikethrough => Get("StyleStrikethrough", "Strikethrough"),
+        Theming.MarkdownElementKeys.ListMarker => Get("StyleListMarker", "List marker"),
+        Theming.MarkdownElementKeys.TableHeader => Get("StyleTableHeader", "Table header"),
+        Theming.MarkdownElementKeys.TableCell => Get("StyleTableCell", "Table cell"),
+        _ => elementKey,
+    };
+
+    private static string Get(string key, string fallback)
+    {
+        try
+        {
+            return Resources.GetString(key, CultureInfo.CurrentUICulture) ?? fallback;
+        }
+        catch
+        {
+            return fallback;
+        }
+    }
+}

--- a/MarkdownRenderer/MarkdownRenderer/Accessibility/MarkdownNodePeer.cs
+++ b/MarkdownRenderer/MarkdownRenderer/Accessibility/MarkdownNodePeer.cs
@@ -1,0 +1,177 @@
+using System.Collections.Generic;
+using Microsoft.UI.Xaml.Automation;
+using Microsoft.UI.Xaml.Automation.Peers;
+using Microsoft.UI.Xaml.Automation.Provider;
+using MarkdownRenderer.Controls;
+
+namespace MarkdownRenderer.Accessibility;
+
+internal sealed partial class MarkdownNodePeer : FrameworkElementAutomationPeer, IGridProvider, ITableProvider, IGridItemProvider, ITableItemProvider
+{
+    private readonly MarkdownAutomationPeer _root;
+    private readonly MarkdownSemanticNode _node;
+
+    public MarkdownNodePeer(MarkdownRendererControl owner, MarkdownAutomationPeer root, MarkdownSemanticNode node) : base(owner)
+    {
+        _root = root;
+        _node = node;
+    }
+
+    internal MarkdownSemanticNode Node => _node;
+
+    protected override string GetClassNameCore() => _node.Role switch
+    {
+        MarkdownSemanticRole.List => "MarkdownList",
+        MarkdownSemanticRole.ListItem => "MarkdownListItem",
+        MarkdownSemanticRole.Table => "MarkdownTable",
+        MarkdownSemanticRole.TableCell => "MarkdownTableCell",
+        MarkdownSemanticRole.Image => "MarkdownImage",
+        MarkdownSemanticRole.Embed => "MarkdownEmbed",
+        _ => "MarkdownGroup",
+    };
+
+    protected override bool IsControlElementCore() => true;
+    protected override bool IsContentElementCore() => true;
+    protected override bool IsKeyboardFocusableCore() => false;
+
+    protected override AutomationControlType GetAutomationControlTypeCore() => _node.Role switch
+    {
+        MarkdownSemanticRole.List => AutomationControlType.List,
+        MarkdownSemanticRole.ListItem => AutomationControlType.ListItem,
+        MarkdownSemanticRole.Table => AutomationControlType.Table,
+        MarkdownSemanticRole.TableCell => AutomationControlType.DataItem,
+        MarkdownSemanticRole.Image => AutomationControlType.Image,
+        MarkdownSemanticRole.Embed => AutomationControlType.Custom,
+        _ => AutomationControlType.Group,
+    };
+
+    protected override string GetNameCore()
+    {
+        var text = _root.GetSemanticDocument().GetText(_node);
+        if (!string.IsNullOrWhiteSpace(text)) return text;
+        return _node.Role switch
+        {
+            MarkdownSemanticRole.Image => MarkdownLocalizedStrings.ImageName,
+            MarkdownSemanticRole.Table => MarkdownLocalizedStrings.TableName,
+            MarkdownSemanticRole.List => MarkdownLocalizedStrings.ListName,
+            MarkdownSemanticRole.Embed => MarkdownLocalizedStrings.EmbeddedContentName,
+            _ => string.Empty,
+        };
+    }
+
+    protected override string GetHelpTextCore() => _node.HelpText ?? string.Empty;
+
+    protected override IList<AutomationPeer> GetChildrenCore() => _root.GetChildPeersForSemanticNode(_node);
+
+    protected override object GetPatternCore(PatternInterface patternInterface)
+    {
+        if (_node.Role == MarkdownSemanticRole.Table &&
+            (patternInterface == PatternInterface.Grid || patternInterface == PatternInterface.Table))
+        {
+            return this;
+        }
+
+        if (_node.Role == MarkdownSemanticRole.TableCell &&
+            (patternInterface == PatternInterface.GridItem || patternInterface == PatternInterface.TableItem))
+        {
+            return this;
+        }
+
+        return base.GetPatternCore(patternInterface);
+    }
+
+    protected override Windows.Foundation.Rect GetBoundingRectangleCore()
+    {
+        var rect = _node.Bounds;
+        return rect.Width <= 0 || rect.Height <= 0
+            ? base.GetBoundingRectangleCore()
+            : _root.GetScreenRectForDocumentRect(rect);
+    }
+
+    int IGridProvider.ColumnCount => _node.ColumnCount;
+    int IGridProvider.RowCount => _node.RowCount;
+
+    IRawElementProviderSimple IGridProvider.GetItem(int row, int column)
+    {
+        foreach (var child in _node.Children)
+        {
+            if (child.Role == MarkdownSemanticRole.TableCell &&
+                child.Row == row &&
+                child.Column == column &&
+                _root.TryGetProviderForSemanticNode(child, out var provider))
+            {
+                return provider;
+            }
+        }
+
+        return null!;
+    }
+
+    IRawElementProviderSimple[] ITableProvider.GetColumnHeaders()
+    {
+        var providers = new List<IRawElementProviderSimple>();
+        foreach (var child in _node.Children)
+        {
+            if (child.Role == MarkdownSemanticRole.TableCell &&
+                child.IsHeader &&
+                _root.TryGetProviderForSemanticNode(child, out var provider))
+            {
+                providers.Add(provider);
+            }
+        }
+
+        return providers.ToArray();
+    }
+
+    IRawElementProviderSimple[] ITableProvider.GetRowHeaders() => System.Array.Empty<IRawElementProviderSimple>();
+
+    RowOrColumnMajor ITableProvider.RowOrColumnMajor => RowOrColumnMajor.RowMajor;
+
+    int IGridItemProvider.Column => _node.Column;
+    int IGridItemProvider.ColumnSpan => _node.ColumnSpan;
+    int IGridItemProvider.Row => _node.Row;
+    int IGridItemProvider.RowSpan => _node.RowSpan;
+
+    IRawElementProviderSimple IGridItemProvider.ContainingGrid
+    {
+        get
+        {
+            var table = FindAncestorTable(_node);
+            return table is not null && _root.TryGetProviderForSemanticNode(table, out var provider)
+                ? provider
+                : null!;
+        }
+    }
+
+    IRawElementProviderSimple[] ITableItemProvider.GetColumnHeaderItems()
+    {
+        var table = FindAncestorTable(_node);
+        if (table is null) return System.Array.Empty<IRawElementProviderSimple>();
+
+        var providers = new List<IRawElementProviderSimple>();
+        foreach (var child in table.Children)
+        {
+            if (child.Role == MarkdownSemanticRole.TableCell &&
+                child.IsHeader &&
+                child.Column == _node.Column &&
+                _root.TryGetProviderForSemanticNode(child, out var provider))
+            {
+                providers.Add(provider);
+            }
+        }
+
+        return providers.ToArray();
+    }
+
+    IRawElementProviderSimple[] ITableItemProvider.GetRowHeaderItems() => System.Array.Empty<IRawElementProviderSimple>();
+
+    private static MarkdownSemanticNode? FindAncestorTable(MarkdownSemanticNode node)
+    {
+        for (var current = node.Parent; current is not null; current = current.Parent)
+        {
+            if (current.Role == MarkdownSemanticRole.Table) return current;
+        }
+
+        return null;
+    }
+}

--- a/MarkdownRenderer/MarkdownRenderer/Accessibility/MarkdownSemanticDocument.cs
+++ b/MarkdownRenderer/MarkdownRenderer/Accessibility/MarkdownSemanticDocument.cs
@@ -1,0 +1,512 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Windows.Foundation;
+using MarkdownRenderer.Document;
+using MarkdownRenderer.Layout;
+using MarkdownRenderer.Layout.Boxes;
+using MarkdownRenderer.Theming;
+
+namespace MarkdownRenderer.Accessibility;
+
+internal enum MarkdownSemanticRole
+{
+    Document,
+    Group,
+    Paragraph,
+    Heading,
+    CodeBlock,
+    Link,
+    List,
+    ListItem,
+    Table,
+    TableCell,
+    Image,
+    Embed,
+}
+
+internal sealed class MarkdownSemanticNode
+{
+    private readonly List<MarkdownSemanticNode> _children = new();
+
+    public MarkdownSemanticNode(MarkdownSemanticRole role, BlockBox? box = null)
+    {
+        Role = role;
+        Box = box;
+    }
+
+    public MarkdownSemanticRole Role { get; }
+    public BlockBox? Box { get; }
+    public InlineContainerBox? InlineBox { get; init; }
+    public ImageBox? ImageBox { get; init; }
+    public EmbedBox? EmbedBox { get; init; }
+    public TableBox? TableBox { get; init; }
+    public InlineRun? InlineRun { get; init; }
+    public MarkdownSemanticNode? Parent { get; private set; }
+    public IReadOnlyList<MarkdownSemanticNode> Children => _children;
+    public int TextStart { get; set; }
+    public int TextEnd { get; set; }
+    public int HeadingLevel { get; init; }
+    public string? CodeLanguage { get; init; }
+    public string? HelpText { get; init; }
+    public int Row { get; init; } = -1;
+    public int Column { get; init; } = -1;
+    public int RowSpan { get; init; } = 1;
+    public int ColumnSpan { get; init; } = 1;
+    public int RowCount { get; init; }
+    public int ColumnCount { get; init; }
+    public bool IsHeader { get; init; }
+
+    public Rect Bounds
+    {
+        get
+        {
+            if (InlineBox is not null && InlineRun is not null)
+            {
+                var runRect = InlineBox.GetRunRect(InlineRun.InlineIndex);
+                if (runRect.Width > 0 && runRect.Height > 0)
+                    return runRect;
+            }
+
+            return Box?.Bounds ?? InlineBox?.Bounds ?? ImageBox?.Bounds ?? EmbedBox?.Bounds ?? default;
+        }
+    }
+
+    public void Add(MarkdownSemanticNode child)
+    {
+        child.Parent = this;
+        _children.Add(child);
+    }
+}
+
+internal sealed record MarkdownTextSpan(
+    int TextStart,
+    int TextEnd,
+    InlineContainerBox? InlineBox,
+    ImageBox? ImageBox,
+    EmbedBox? EmbedBox);
+
+internal sealed class MarkdownSemanticDocument
+{
+    private MarkdownSemanticDocument(MarkdownSemanticNode root, string text, IReadOnlyList<MarkdownTextSpan> spans)
+    {
+        Root = root;
+        Text = text;
+        TextSpans = spans;
+    }
+
+    public MarkdownSemanticNode Root { get; }
+    public string Text { get; }
+    public IReadOnlyList<MarkdownTextSpan> TextSpans { get; }
+
+    public static MarkdownSemanticDocument Build(LayoutSnapshot snapshot)
+    {
+        var builder = new Builder();
+        return builder.Build(snapshot);
+    }
+
+    public string GetText(MarkdownSemanticNode node)
+    {
+        int start = Math.Clamp(node.TextStart, 0, Text.Length);
+        int end = Math.Clamp(node.TextEnd, start, Text.Length);
+        return Text.Substring(start, end - start).Trim();
+    }
+
+    public int TextOffsetFromDocumentPosition(DocumentPosition position)
+    {
+        foreach (var span in TextSpans)
+        {
+            if (span.InlineBox is { } icb && icb.BlockIndex == position.BlockIndex)
+            {
+                return Math.Clamp(span.TextStart + icb.GetBufferCharOffset(position), span.TextStart, span.TextEnd);
+            }
+        }
+
+        foreach (var span in TextSpans)
+        {
+            if (span.InlineBox?.BlockIndex == position.BlockIndex ||
+                span.ImageBox?.BlockIndex == position.BlockIndex ||
+                span.EmbedBox?.BlockIndex == position.BlockIndex)
+            {
+                return span.TextStart;
+            }
+        }
+
+        return position.BlockIndex <= 0 ? 0 : Text.Length;
+    }
+
+    public bool TryGetDocumentRange(int textStart, int textEnd, out DocumentRange range)
+    {
+        var start = PositionFromTextOffset(textStart);
+        var end = PositionFromTextOffset(textEnd);
+        if (start is { } s && end is { } e)
+        {
+            range = new DocumentRange(s, e);
+            return true;
+        }
+
+        range = DocumentRange.Empty;
+        return false;
+    }
+
+    public DocumentPosition? PositionFromTextOffset(int textOffset)
+    {
+        textOffset = Math.Clamp(textOffset, 0, Text.Length);
+        MarkdownTextSpan? previous = null;
+        foreach (var span in TextSpans)
+        {
+            if (textOffset >= span.TextStart && textOffset <= span.TextEnd)
+            {
+                if (span.InlineBox is { } icb)
+                {
+                    int bufferOffset = Math.Clamp(textOffset - span.TextStart, 0, Math.Max(0, span.TextEnd - span.TextStart));
+                    return icb.GetPositionFromBufferOffset(bufferOffset);
+                }
+
+                if (span.ImageBox is { } image)
+                    return new DocumentPosition(image.BlockIndex, 0, textOffset <= span.TextStart ? 0 : 1);
+
+                if (span.EmbedBox is { } embed)
+                    return new DocumentPosition(embed.BlockIndex, 0, textOffset <= span.TextStart ? 0 : 1);
+            }
+
+            if (textOffset < span.TextStart && previous is not null)
+                return PositionFromSpanEnd(previous);
+
+            previous = span;
+        }
+
+        return previous is not null ? PositionFromSpanEnd(previous) : DocumentPosition.Zero;
+    }
+
+    public IEnumerable<Rect> GetDocumentRects(int textStart, int textEnd)
+    {
+        textStart = Math.Clamp(textStart, 0, Text.Length);
+        textEnd = Math.Clamp(textEnd, textStart, Text.Length);
+
+        if (textStart == textEnd && Text.Length > 0)
+        {
+            if (textStart < Text.Length) textEnd = textStart + 1;
+            else textStart = Math.Max(0, textStart - 1);
+        }
+
+        foreach (var span in TextSpans)
+        {
+            if (span.TextEnd < textStart || span.TextStart > textEnd) continue;
+
+            int start = Math.Max(textStart, span.TextStart);
+            int end = Math.Min(textEnd, span.TextEnd);
+            if (end < start) continue;
+
+            if (span.InlineBox is { } icb)
+            {
+                var startPos = icb.GetPositionFromBufferOffset(start - span.TextStart);
+                var endPos = icb.GetPositionFromBufferOffset(end - span.TextStart);
+                foreach (var rect in icb.GetRangeRects(new DocumentRange(startPos, endPos)))
+                    yield return rect;
+            }
+            else if (span.ImageBox is { } image)
+            {
+                yield return image.Bounds;
+            }
+            else if (span.EmbedBox is { } embed)
+            {
+                yield return embed.Bounds;
+            }
+        }
+    }
+
+    public IEnumerable<MarkdownSemanticNode> GetNodesIntersectingTextRange(int textStart, int textEnd)
+    {
+        textStart = Math.Clamp(textStart, 0, Text.Length);
+        textEnd = Math.Clamp(textEnd, textStart, Text.Length);
+        foreach (var node in EnumerateDepthFirst(Root))
+        {
+            if (node == Root) continue;
+            if (node.TextEnd < textStart || node.TextStart > textEnd) continue;
+            if (node.Role is MarkdownSemanticRole.Link or MarkdownSemanticRole.Image or MarkdownSemanticRole.Embed or
+                MarkdownSemanticRole.Table or MarkdownSemanticRole.TableCell or MarkdownSemanticRole.List or MarkdownSemanticRole.ListItem)
+            {
+                yield return node;
+            }
+        }
+    }
+
+    public static IEnumerable<MarkdownSemanticNode> EnumerateDepthFirst(MarkdownSemanticNode node)
+    {
+        yield return node;
+        foreach (var child in node.Children)
+        {
+            foreach (var descendant in EnumerateDepthFirst(child))
+                yield return descendant;
+        }
+    }
+
+    private static DocumentPosition PositionFromSpanEnd(MarkdownTextSpan span)
+    {
+        if (span.InlineBox is { } icb)
+            return icb.GetPositionFromBufferOffset(span.TextEnd - span.TextStart);
+        if (span.ImageBox is { } image)
+            return new DocumentPosition(image.BlockIndex, 0, 1);
+        if (span.EmbedBox is { } embed)
+            return new DocumentPosition(embed.BlockIndex, 0, 1);
+        return DocumentPosition.Zero;
+    }
+
+    private sealed class Builder
+    {
+        private readonly StringBuilder _text = new();
+        private readonly List<MarkdownTextSpan> _spans = new();
+
+        public MarkdownSemanticDocument Build(LayoutSnapshot snapshot)
+        {
+            var root = new MarkdownSemanticNode(MarkdownSemanticRole.Document)
+            {
+                TextStart = 0
+            };
+
+            foreach (var block in snapshot.Blocks)
+            {
+                var node = BuildBlock(block);
+                if (node is not null) root.Add(node);
+            }
+
+            TrimTrailingNewline();
+            root.TextEnd = _text.Length;
+            return new MarkdownSemanticDocument(root, _text.ToString(), _spans);
+        }
+
+        private MarkdownSemanticNode? BuildBlock(BlockBox box)
+        {
+            return box switch
+            {
+                InlineContainerBox inline => BuildInline(inline),
+                ImageBox image => BuildImage(image),
+                EmbedBox embed => BuildEmbed(embed),
+                ListItemBox listItem => BuildListItem(listItem),
+                TableBox table => BuildTable(table),
+                StackBox stack when IsListStack(stack) => BuildList(stack),
+                StackBox stack => BuildGroup(stack),
+                _ => null,
+            };
+        }
+
+        private MarkdownSemanticNode BuildInline(InlineContainerBox inline)
+        {
+            var role = inline.ElementKey == MarkdownElementKeys.CodeBlock
+                ? MarkdownSemanticRole.CodeBlock
+                : IsHeading(inline.ElementKey)
+                    ? MarkdownSemanticRole.Heading
+                    : MarkdownSemanticRole.Paragraph;
+            var node = new MarkdownSemanticNode(role, inline)
+            {
+                InlineBox = inline,
+                TextStart = _text.Length,
+                HeadingLevel = GetHeadingLevel(inline.ElementKey),
+                CodeLanguage = inline.CodeLanguage,
+                HelpText = inline.ElementKey == MarkdownElementKeys.CodeBlock && !string.IsNullOrWhiteSpace(inline.CodeLanguage)
+                    ? MarkdownLocalizedStrings.CodeLanguageHelp(inline.CodeLanguage)
+                    : null,
+            };
+
+            int spanStart = _text.Length;
+            foreach (var run in inline.Runs)
+                _text.Append(run.Text);
+            int spanEnd = _text.Length;
+            _spans.Add(new MarkdownTextSpan(spanStart, spanEnd, inline, null, null));
+            node.TextEnd = _text.Length;
+
+            foreach (var run in inline.Runs)
+            {
+                if (run is LinkRun link)
+                {
+                    node.Add(new MarkdownSemanticNode(MarkdownSemanticRole.Link, inline)
+                    {
+                        InlineBox = inline,
+                        InlineRun = link,
+                        TextStart = spanStart + inline.GetBufferCharOffset(new DocumentPosition(inline.BlockIndex, run.InlineIndex, 0)),
+                        TextEnd = spanStart + inline.GetBufferCharOffset(new DocumentPosition(inline.BlockIndex, run.InlineIndex, run.Text.Length)),
+                        HelpText = link.Url,
+                    });
+                }
+                else if (run is InlineEmbedRun embedRun)
+                {
+                    node.Add(new MarkdownSemanticNode(MarkdownSemanticRole.Embed, inline)
+                    {
+                        InlineBox = inline,
+                        InlineRun = embedRun,
+                        TextStart = spanStart + inline.GetBufferCharOffset(new DocumentPosition(inline.BlockIndex, run.InlineIndex, 0)),
+                        TextEnd = spanStart + inline.GetBufferCharOffset(new DocumentPosition(inline.BlockIndex, run.InlineIndex, run.Text.Length)),
+                    });
+                }
+                else if (run is InlineImageRun imageRun)
+                {
+                    node.Add(new MarkdownSemanticNode(MarkdownSemanticRole.Image, inline)
+                    {
+                        InlineBox = inline,
+                        InlineRun = imageRun,
+                        TextStart = spanStart + inline.GetBufferCharOffset(new DocumentPosition(inline.BlockIndex, run.InlineIndex, 0)),
+                        TextEnd = spanStart + inline.GetBufferCharOffset(new DocumentPosition(inline.BlockIndex, run.InlineIndex, run.Text.Length)),
+                        HelpText = !string.IsNullOrWhiteSpace(imageRun.Title) ? imageRun.Title : imageRun.Url,
+                    });
+                }
+            }
+
+            AppendBlockSeparator();
+            return node;
+        }
+
+        private MarkdownSemanticNode BuildImage(ImageBox image)
+        {
+            var node = new MarkdownSemanticNode(MarkdownSemanticRole.Image, image)
+            {
+                ImageBox = image,
+                TextStart = _text.Length,
+                HelpText = image.SvgDesc,
+            };
+
+            string name = !string.IsNullOrWhiteSpace(image.Alt)
+                ? image.Alt
+                : !string.IsNullOrWhiteSpace(image.SvgTitle)
+                    ? image.SvgTitle!
+                    : MarkdownLocalizedStrings.ImageName;
+            int start = _text.Length;
+            _text.Append(name);
+            int end = _text.Length;
+            _spans.Add(new MarkdownTextSpan(start, end, null, image, null));
+            node.TextEnd = _text.Length;
+            AppendBlockSeparator();
+            return node;
+        }
+
+        private MarkdownSemanticNode BuildEmbed(EmbedBox embed)
+        {
+            var node = new MarkdownSemanticNode(MarkdownSemanticRole.Embed, embed)
+            {
+                EmbedBox = embed,
+                TextStart = _text.Length,
+            };
+            int start = _text.Length;
+            _text.Append(InlineEmbedRun.PlaceholderChar);
+            int end = _text.Length;
+            _spans.Add(new MarkdownTextSpan(start, end, null, null, embed));
+            node.TextEnd = _text.Length;
+            AppendBlockSeparator();
+            return node;
+        }
+
+        private MarkdownSemanticNode BuildList(StackBox stack)
+        {
+            var node = new MarkdownSemanticNode(MarkdownSemanticRole.List, stack)
+            {
+                TextStart = _text.Length,
+            };
+
+            foreach (var child in stack.Children)
+            {
+                var childNode = BuildBlock(child);
+                if (childNode is not null) node.Add(childNode);
+            }
+
+            node.TextEnd = _text.Length;
+            return node;
+        }
+
+        private MarkdownSemanticNode BuildListItem(ListItemBox listItem)
+        {
+            var node = new MarkdownSemanticNode(MarkdownSemanticRole.ListItem, listItem)
+            {
+                TextStart = _text.Length,
+            };
+
+            if (BuildBlock(listItem.Marker) is { } marker) node.Add(marker);
+            if (BuildBlock(listItem.Content) is { } content) node.Add(content);
+            node.TextEnd = _text.Length;
+            return node;
+        }
+
+        private MarkdownSemanticNode BuildTable(TableBox table)
+        {
+            var node = new MarkdownSemanticNode(MarkdownSemanticRole.Table, table)
+            {
+                TableBox = table,
+                TextStart = _text.Length,
+                RowCount = table.RowCount,
+                ColumnCount = table.ColumnCount,
+            };
+
+            foreach (var cellInfo in table.GetCellInfos())
+            {
+                var cellNode = new MarkdownSemanticNode(MarkdownSemanticRole.TableCell, cellInfo.Box)
+                {
+                    InlineBox = cellInfo.Box,
+                    TextStart = _text.Length,
+                    Row = cellInfo.Row,
+                    Column = cellInfo.Column,
+                    IsHeader = cellInfo.IsHeader,
+                };
+
+                if (BuildInline(cellInfo.Box) is { } inlineNode)
+                    cellNode.Add(inlineNode);
+                cellNode.TextEnd = _text.Length;
+                node.Add(cellNode);
+            }
+
+            node.TextEnd = _text.Length;
+            return node;
+        }
+
+        private MarkdownSemanticNode BuildGroup(StackBox stack)
+        {
+            var node = new MarkdownSemanticNode(MarkdownSemanticRole.Group, stack)
+            {
+                TextStart = _text.Length,
+            };
+
+            foreach (var child in stack.Children)
+            {
+                var childNode = BuildBlock(child);
+                if (childNode is not null) node.Add(childNode);
+            }
+
+            node.TextEnd = _text.Length;
+            return node;
+        }
+
+        private void AppendBlockSeparator()
+        {
+            if (_text.Length == 0 || _text[^1] != '\n')
+                _text.Append('\n');
+        }
+
+        private void TrimTrailingNewline()
+        {
+            while (_text.Length > 0 && _text[^1] == '\n')
+                _text.Length--;
+        }
+
+        private static bool IsListStack(StackBox stack)
+        {
+            if (stack.Children.Count == 0) return false;
+            foreach (var child in stack.Children)
+            {
+                if (child is not ListItemBox) return false;
+            }
+            return true;
+        }
+
+        private static bool IsHeading(string elementKey) =>
+            GetHeadingLevel(elementKey) > 0;
+
+        private static int GetHeadingLevel(string elementKey) => elementKey switch
+        {
+            MarkdownElementKeys.Heading1 => 1,
+            MarkdownElementKeys.Heading2 => 2,
+            MarkdownElementKeys.Heading3 => 3,
+            MarkdownElementKeys.Heading4 => 4,
+            MarkdownElementKeys.Heading5 => 5,
+            MarkdownElementKeys.Heading6 => 6,
+            _ => 0,
+        };
+    }
+}

--- a/MarkdownRenderer/MarkdownRenderer/Accessibility/MarkdownTextRangeProvider.cs
+++ b/MarkdownRenderer/MarkdownRenderer/Accessibility/MarkdownTextRangeProvider.cs
@@ -1,0 +1,630 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Runtime.InteropServices;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Automation;
+using Microsoft.UI.Xaml.Automation.Peers;
+using Microsoft.UI.Xaml.Automation.Provider;
+using Microsoft.UI.Xaml.Automation.Text;
+using MarkdownRenderer.Layout;
+using MarkdownRenderer.Layout.Boxes;
+using MarkdownRenderer.Theming;
+using Windows.UI;
+using Windows.UI.Text;
+
+namespace MarkdownRenderer.Accessibility;
+
+internal sealed partial class MarkdownTextRangeProvider : ITextRangeProvider
+{
+    private readonly MarkdownAutomationPeer _peer;
+    private int _start;
+    private int _end;
+
+    public MarkdownTextRangeProvider(MarkdownAutomationPeer peer, int start, int end)
+    {
+        _peer = peer;
+        var doc = _peer.GetSemanticDocument();
+        _start = Math.Clamp(start, 0, doc.Text.Length);
+        _end = Math.Clamp(end, _start, doc.Text.Length);
+    }
+
+    public void AddToSelection() => Select();
+
+    public ITextRangeProvider Clone() => new MarkdownTextRangeProvider(_peer, _start, _end);
+
+    public bool Compare(ITextRangeProvider range)
+    {
+        return range is MarkdownTextRangeProvider other &&
+               ReferenceEquals(other._peer, _peer) &&
+               other._start == _start &&
+               other._end == _end;
+    }
+
+    public int CompareEndpoints(TextPatternRangeEndpoint endpoint, ITextRangeProvider targetRange, TextPatternRangeEndpoint targetEndpoint)
+    {
+        if (targetRange is not MarkdownTextRangeProvider other) return 0;
+        int a = endpoint == TextPatternRangeEndpoint.Start ? _start : _end;
+        int b = targetEndpoint == TextPatternRangeEndpoint.Start ? other._start : other._end;
+        return a.CompareTo(b);
+    }
+
+    public void ExpandToEnclosingUnit(TextUnit unit)
+    {
+        var doc = _peer.GetSemanticDocument();
+        switch (unit)
+        {
+            case TextUnit.Character:
+                if (_start == _end && _start < doc.Text.Length) _end = _start + 1;
+                break;
+            case TextUnit.Word:
+            case TextUnit.Format:
+            {
+                int pivot = Math.Clamp(_start, 0, Math.Max(0, doc.Text.Length - 1));
+                var (s, e) = FindWordBoundaries(doc.Text, pivot);
+                _start = s;
+                _end = e;
+                break;
+            }
+            case TextUnit.Line:
+            case TextUnit.Paragraph:
+            case TextUnit.Page:
+            {
+                var (s, e) = FindLineBoundaries(doc.Text, _start);
+                _start = s;
+                _end = e;
+                break;
+            }
+            case TextUnit.Document:
+                _start = 0;
+                _end = doc.Text.Length;
+                break;
+        }
+    }
+
+    public ITextRangeProvider? FindAttribute(int attributeId, object value, bool backward)
+    {
+        var attribute = (AutomationTextAttributesEnum)attributeId;
+        var fixedValue = GetFixedAttributeValue(attribute);
+        if (fixedValue is not UnsupportedAttributeValue)
+        {
+            return AttributeValuesEqual(fixedValue, value) ? Clone() : null;
+        }
+
+        var runs = EnumerateTextStyleRuns().ToList();
+        if (backward) runs.Reverse();
+        foreach (var run in runs)
+        {
+            var candidate = GetStyleAttributeValue(attribute, run);
+            if (AttributeValuesEqual(candidate, value))
+                return new MarkdownTextRangeProvider(_peer, run.Start, run.End);
+        }
+
+        return null;
+    }
+
+    public ITextRangeProvider? FindText(string text, bool backward, bool ignoreCase)
+    {
+        if (string.IsNullOrEmpty(text)) return null;
+        var doc = _peer.GetSemanticDocument();
+        var comparison = ignoreCase ? StringComparison.CurrentCultureIgnoreCase : StringComparison.CurrentCulture;
+        int rangeStart = Math.Clamp(_start, 0, doc.Text.Length);
+        int rangeEnd = Math.Clamp(_end, rangeStart, doc.Text.Length);
+        if (rangeEnd - rangeStart < text.Length) return null;
+
+        string segment = doc.Text.Substring(rangeStart, rangeEnd - rangeStart);
+        int relative = backward
+            ? segment.LastIndexOf(text, comparison)
+            : segment.IndexOf(text, comparison);
+        int index = relative >= 0 ? rangeStart + relative : -1;
+
+        return index >= 0
+            ? new MarkdownTextRangeProvider(_peer, index, index + text.Length)
+            : null;
+    }
+
+    public object GetAttributeValue(int attributeId)
+    {
+        var attribute = (AutomationTextAttributesEnum)attributeId;
+        var fixedValue = GetFixedAttributeValue(attribute);
+        if (fixedValue is not UnsupportedAttributeValue)
+            return fixedValue!;
+
+        bool haveValue = false;
+        object? first = null;
+        foreach (var run in EnumerateTextStyleRuns())
+        {
+            var value = GetStyleAttributeValue(attribute, run);
+            if (value is null)
+                return UiaReservedAttributeValues.NotSupported;
+
+            if (!haveValue)
+            {
+                first = value;
+                haveValue = true;
+                continue;
+            }
+
+            if (!AttributeValuesEqual(first, value))
+                return UiaReservedAttributeValues.Mixed;
+        }
+
+        return haveValue ? first! : UiaReservedAttributeValues.NotSupported;
+    }
+
+    public void GetBoundingRectangles(out double[] boundingRectangles)
+    {
+        var doc = _peer.GetSemanticDocument();
+        var values = new List<double>();
+        foreach (var rect in doc.GetDocumentRects(_start, _end))
+        {
+            var screen = _peer.GetScreenRectForDocumentRect(rect);
+            if (screen.Width <= 0 || screen.Height <= 0) continue;
+            values.Add(screen.X);
+            values.Add(screen.Y);
+            values.Add(screen.Width);
+            values.Add(screen.Height);
+        }
+
+        boundingRectangles = values.ToArray();
+    }
+
+    public IRawElementProviderSimple[] GetChildren()
+    {
+        var providers = new List<IRawElementProviderSimple>();
+        var doc = _peer.GetSemanticDocument();
+        foreach (var node in doc.GetNodesIntersectingTextRange(_start, _end))
+        {
+            if (_peer.TryGetProviderForSemanticNode(node, out var provider))
+                providers.Add(provider);
+        }
+
+        return providers.ToArray();
+    }
+
+    public IRawElementProviderSimple GetEnclosingElement() => _peer.ProviderFromPeerForTextRange(_peer);
+
+    public string GetText(int maxLength)
+    {
+        var doc = _peer.GetSemanticDocument();
+        int start = Math.Clamp(_start, 0, doc.Text.Length);
+        int end = Math.Clamp(_end, start, doc.Text.Length);
+        int length = end - start;
+        if (maxLength >= 0) length = Math.Min(length, maxLength);
+        return length <= 0 ? string.Empty : doc.Text.Substring(start, length);
+    }
+
+    public int Move(TextUnit unit, int count)
+    {
+        if (count == 0) return 0;
+        var doc = _peer.GetSemanticDocument();
+        string text = doc.Text;
+        if (text.Length == 0)
+        {
+            _start = 0;
+            _end = 0;
+            return 0;
+        }
+
+        int normalizedStart = UnitStart(text, _start, unit);
+        int movedStart = MoveOffset(text, normalizedStart, unit, count, out int moved);
+        _start = UnitStart(text, movedStart, unit);
+        _end = UnitEnd(text, _start, unit);
+        return moved;
+    }
+
+    public void MoveEndpointByRange(TextPatternRangeEndpoint endpoint, ITextRangeProvider targetRange, TextPatternRangeEndpoint targetEndpoint)
+    {
+        if (targetRange is not MarkdownTextRangeProvider other) return;
+        int target = targetEndpoint == TextPatternRangeEndpoint.Start ? other._start : other._end;
+        SetEndpoint(endpoint, target);
+    }
+
+    public int MoveEndpointByUnit(TextPatternRangeEndpoint endpoint, TextUnit unit, int count)
+    {
+        int current = endpoint == TextPatternRangeEndpoint.Start ? _start : _end;
+        int moved = MoveOffset(_peer.GetSemanticDocument().Text, current, unit, count, out int actual);
+        SetEndpoint(endpoint, moved);
+        return actual;
+    }
+
+    public void RemoveFromSelection()
+    {
+        _peer.OwnerControl.ClearAutomationSelection();
+    }
+
+    public void ScrollIntoView(bool alignToTop)
+    {
+        var doc = _peer.GetSemanticDocument();
+        foreach (var rect in doc.GetDocumentRects(_start, _end))
+        {
+            _peer.OwnerControl.ScrollDocumentRectIntoView(rect, alignToTop);
+            return;
+        }
+    }
+
+    public void Select()
+    {
+        var doc = _peer.GetSemanticDocument();
+        if (doc.TryGetDocumentRange(_start, _end, out var range))
+            _peer.OwnerControl.SelectAutomationRange(range);
+    }
+
+    internal int Start => _start;
+    internal int End => _end;
+
+    private sealed class UnsupportedAttributeValue
+    {
+        public static readonly UnsupportedAttributeValue Instance = new();
+        private UnsupportedAttributeValue() { }
+    }
+
+    private static class UiaReservedAttributeValues
+    {
+        public static object Mixed => GetReservedValue(UiaGetReservedMixedAttributeValue, FallbackMixedAttributeValue.Instance);
+        public static object NotSupported => GetReservedValue(UiaGetReservedNotSupportedValue, FallbackNotSupportedValue.Instance);
+
+        private delegate int ReservedValueFactory(out IntPtr value);
+
+        [DllImport("UIAutomationCore.dll", PreserveSig = true)]
+        private static extern int UiaGetReservedMixedAttributeValue(out IntPtr value);
+
+        [DllImport("UIAutomationCore.dll", PreserveSig = true)]
+        private static extern int UiaGetReservedNotSupportedValue(out IntPtr value);
+
+        private static object GetReservedValue(ReservedValueFactory factory, object fallback)
+        {
+            IntPtr value = IntPtr.Zero;
+            try
+            {
+                int hr = factory(out value);
+                if (hr >= 0 && value != IntPtr.Zero)
+                    return Marshal.GetObjectForIUnknown(value);
+            }
+            catch
+            {
+            }
+            finally
+            {
+                if (value != IntPtr.Zero)
+                    Marshal.Release(value);
+            }
+
+            return fallback;
+        }
+
+        private sealed class FallbackMixedAttributeValue
+        {
+            public static readonly FallbackMixedAttributeValue Instance = new();
+            private FallbackMixedAttributeValue() { }
+        }
+
+        private sealed class FallbackNotSupportedValue
+        {
+            public static readonly FallbackNotSupportedValue Instance = new();
+            private FallbackNotSupportedValue() { }
+        }
+    }
+
+    private readonly record struct TextStyleRun(
+        int Start,
+        int End,
+        string ElementKey,
+        InlineRun? Run,
+        ElementStyle Style);
+
+    private object? GetFixedAttributeValue(AutomationTextAttributesEnum attribute)
+    {
+        return attribute switch
+        {
+            AutomationTextAttributesEnum.CultureAttribute => CultureInfo.CurrentUICulture.LCID,
+            AutomationTextAttributesEnum.IsActiveAttribute => _peer.OwnerControl.FocusState != FocusState.Unfocused,
+            AutomationTextAttributesEnum.IsHiddenAttribute => false,
+            AutomationTextAttributesEnum.IsReadOnlyAttribute => true,
+            AutomationTextAttributesEnum.CaretBidiModeAttribute => _peer.OwnerControl.FlowDirection == FlowDirection.RightToLeft
+                ? AutomationCaretBidiMode.RTL
+                : AutomationCaretBidiMode.LTR,
+            AutomationTextAttributesEnum.TextFlowDirectionsAttribute => _peer.OwnerControl.FlowDirection == FlowDirection.RightToLeft
+                ? AutomationFlowDirections.RightToLeft
+                : AutomationFlowDirections.Default,
+            _ => UnsupportedAttributeValue.Instance,
+        };
+    }
+
+    private object? GetStyleAttributeValue(AutomationTextAttributesEnum attribute, TextStyleRun run)
+    {
+        var style = run.Style;
+        return attribute switch
+        {
+            AutomationTextAttributesEnum.BackgroundColorAttribute => ToColorRef(
+                style.Background ?? _peer.OwnerControl.CurrentThemeSnapshot?.SurfaceColor ?? Microsoft.UI.Colors.Transparent),
+            AutomationTextAttributesEnum.FontNameAttribute => style.FontFamily,
+            AutomationTextAttributesEnum.FontSizeAttribute => (double)style.FontSize,
+            AutomationTextAttributesEnum.FontWeightAttribute => (int)style.FontWeight.Weight,
+            AutomationTextAttributesEnum.ForegroundColorAttribute => ToColorRef(style.Foreground),
+            AutomationTextAttributesEnum.IsItalicAttribute => style.FontStyle == FontStyle.Italic,
+            AutomationTextAttributesEnum.IsSubscriptAttribute => false,
+            AutomationTextAttributesEnum.IsSuperscriptAttribute => run.Run is LinkRun { IsSuperscript: true },
+            AutomationTextAttributesEnum.OverlineColorAttribute => ToColorRef(style.Foreground),
+            AutomationTextAttributesEnum.OverlineStyleAttribute => AutomationTextDecorationLineStyle.None,
+            AutomationTextAttributesEnum.StrikethroughColorAttribute => ToColorRef(style.Foreground),
+            AutomationTextAttributesEnum.StrikethroughStyleAttribute => style.Strikethrough
+                ? AutomationTextDecorationLineStyle.Single
+                : AutomationTextDecorationLineStyle.None,
+            AutomationTextAttributesEnum.StyleIdAttribute => GetStyleId(run.ElementKey),
+            AutomationTextAttributesEnum.StyleNameAttribute => GetStyleName(run.ElementKey),
+            AutomationTextAttributesEnum.UnderlineColorAttribute => ToColorRef(style.Foreground),
+            AutomationTextAttributesEnum.UnderlineStyleAttribute => style.Underline
+                ? AutomationTextDecorationLineStyle.Single
+                : AutomationTextDecorationLineStyle.None,
+            _ => null,
+        };
+    }
+
+    private IEnumerable<TextStyleRun> EnumerateTextStyleRuns()
+    {
+        var doc = _peer.GetSemanticDocument();
+        int rangeStart = Math.Clamp(_start, 0, doc.Text.Length);
+        int rangeEnd = Math.Clamp(_end, rangeStart, doc.Text.Length);
+        bool collapsed = rangeStart == rangeEnd;
+        bool yielded = false;
+
+        foreach (var span in doc.TextSpans)
+        {
+            if (span.TextEnd < rangeStart || span.TextStart > rangeEnd)
+                continue;
+
+            if (span.InlineBox is { } inline)
+            {
+                foreach (var run in EnumerateInlineStyleRuns(inline, span.TextStart, rangeStart, rangeEnd, collapsed))
+                {
+                    yielded = true;
+                    yield return run;
+                }
+            }
+            else if (span.ImageBox is not null || span.EmbedBox is not null)
+            {
+                if (!SpanIntersects(span.TextStart, span.TextEnd, rangeStart, rangeEnd, collapsed))
+                    continue;
+
+                yielded = true;
+                yield return new TextStyleRun(
+                    collapsed ? rangeStart : Math.Max(rangeStart, span.TextStart),
+                    collapsed ? rangeStart : Math.Min(rangeEnd, span.TextEnd),
+                    MarkdownElementKeys.Body,
+                    null,
+                    GetStyle(MarkdownElementKeys.Body));
+            }
+        }
+
+        if (!yielded)
+        {
+            yield return new TextStyleRun(
+                rangeStart,
+                rangeEnd,
+                MarkdownElementKeys.Body,
+                null,
+                GetStyle(MarkdownElementKeys.Body));
+        }
+    }
+
+    private IEnumerable<TextStyleRun> EnumerateInlineStyleRuns(
+        InlineContainerBox inline,
+        int textSpanStart,
+        int rangeStart,
+        int rangeEnd,
+        bool collapsed)
+    {
+        int cumulative = 0;
+        foreach (var run in inline.Runs)
+        {
+            int length = run.Text.Length;
+            if (length <= 0)
+                continue;
+
+            int runStart = textSpanStart + cumulative;
+            int runEnd = runStart + length;
+            cumulative += length;
+
+            if (!SpanIntersects(runStart, runEnd, rangeStart, rangeEnd, collapsed))
+                continue;
+
+            var elementKey = string.IsNullOrEmpty(run.ElementKey) ? inline.ElementKey : run.ElementKey;
+            yield return new TextStyleRun(
+                collapsed ? rangeStart : Math.Max(rangeStart, runStart),
+                collapsed ? rangeStart : Math.Min(rangeEnd, runEnd),
+                elementKey,
+                run,
+                GetStyle(elementKey));
+        }
+    }
+
+    private ElementStyle GetStyle(string elementKey) =>
+        _peer.OwnerControl.CurrentThemeSnapshot?.GetStyle(elementKey) ?? new ElementStyle();
+
+    private static bool SpanIntersects(int spanStart, int spanEnd, int rangeStart, int rangeEnd, bool collapsed)
+    {
+        if (collapsed)
+            return rangeStart >= spanStart && rangeStart <= spanEnd;
+
+        return spanEnd > rangeStart && spanStart < rangeEnd;
+    }
+
+    private static AutomationStyleId GetStyleId(string elementKey) => elementKey switch
+    {
+        MarkdownElementKeys.Heading1 => AutomationStyleId.Heading1,
+        MarkdownElementKeys.Heading2 => AutomationStyleId.Heading2,
+        MarkdownElementKeys.Heading3 => AutomationStyleId.Heading3,
+        MarkdownElementKeys.Heading4 => AutomationStyleId.Heading4,
+        MarkdownElementKeys.Heading5 => AutomationStyleId.Heading5,
+        MarkdownElementKeys.Heading6 => AutomationStyleId.Heading6,
+        MarkdownElementKeys.Quote => AutomationStyleId.Quote,
+        MarkdownElementKeys.Emphasis => AutomationStyleId.Emphasis,
+        MarkdownElementKeys.ListMarker => AutomationStyleId.BulletedList,
+        _ => AutomationStyleId.Normal,
+    };
+
+    private static string GetStyleName(string elementKey) => MarkdownLocalizedStrings.StyleName(elementKey);
+
+    private static int ToColorRef(Color color) =>
+        color.R | (color.G << 8) | (color.B << 16);
+
+    private static bool AttributeValuesEqual(object? left, object? right)
+    {
+        if (ReferenceEquals(left, right)) return true;
+        if (left is null || right is null) return false;
+
+        if (left is string ls && right is string rs)
+            return string.Equals(ls, rs, StringComparison.Ordinal);
+
+        if (TryConvertToDouble(left, out var dl) &&
+            TryConvertToDouble(right, out var dr))
+            return Math.Abs(dl - dr) < 0.001;
+
+        return left.Equals(right);
+    }
+
+    private static bool TryConvertToDouble(object value, out double result)
+    {
+        var type = Nullable.GetUnderlyingType(value.GetType()) ?? value.GetType();
+        if (type.IsEnum)
+        {
+            result = Convert.ToDouble(value, CultureInfo.InvariantCulture);
+            return true;
+        }
+
+        switch (Type.GetTypeCode(type))
+        {
+            case TypeCode.Byte:
+            case TypeCode.SByte:
+            case TypeCode.Int16:
+            case TypeCode.UInt16:
+            case TypeCode.Int32:
+            case TypeCode.UInt32:
+            case TypeCode.Int64:
+            case TypeCode.UInt64:
+            case TypeCode.Single:
+            case TypeCode.Double:
+            case TypeCode.Decimal:
+                result = Convert.ToDouble(value, CultureInfo.InvariantCulture);
+                return true;
+            default:
+                result = 0;
+                return false;
+        }
+    }
+
+    private void SetEndpoint(TextPatternRangeEndpoint endpoint, int value)
+    {
+        var doc = _peer.GetSemanticDocument();
+        value = Math.Clamp(value, 0, doc.Text.Length);
+        if (endpoint == TextPatternRangeEndpoint.Start)
+        {
+            if (value > _end)
+                _end = value;
+            _start = value;
+        }
+        else
+        {
+            if (value < _start)
+                _start = value;
+            _end = value;
+        }
+    }
+
+    private static int MoveOffset(string text, int offset, TextUnit unit, int count, out int moved)
+    {
+        moved = 0;
+        int current = Math.Clamp(offset, 0, text.Length);
+        int direction = Math.Sign(count);
+        int steps = Math.Abs(count);
+        for (int i = 0; i < steps; i++)
+        {
+            int next = unit switch
+            {
+                TextUnit.Character => current + direction,
+                TextUnit.Word or TextUnit.Format => direction > 0 ? NextWordStart(text, current) : PreviousWordStart(text, current),
+                TextUnit.Line or TextUnit.Paragraph or TextUnit.Page => direction > 0 ? NextLineStart(text, current) : PreviousLineStart(text, current),
+                TextUnit.Document => direction > 0 ? text.Length : 0,
+                _ => current,
+            };
+            next = Math.Clamp(next, 0, text.Length);
+            if (next == current) break;
+            current = next;
+            moved += direction;
+        }
+
+        return current;
+    }
+
+    private static int UnitStart(string text, int offset, TextUnit unit)
+    {
+        offset = Math.Clamp(offset, 0, text.Length);
+        if (offset >= text.Length) return text.Length;
+
+        return unit switch
+        {
+            TextUnit.Word or TextUnit.Format => FindWordBoundaries(text, offset).Start,
+            TextUnit.Line or TextUnit.Paragraph or TextUnit.Page => FindLineBoundaries(text, offset).Start,
+            TextUnit.Document => 0,
+            _ => offset,
+        };
+    }
+
+    private static int UnitEnd(string text, int start, TextUnit unit)
+    {
+        start = Math.Clamp(start, 0, text.Length);
+        if (start >= text.Length) return text.Length;
+
+        return unit switch
+        {
+            TextUnit.Character => Math.Min(text.Length, start + 1),
+            TextUnit.Word or TextUnit.Format => FindWordBoundaries(text, start).End,
+            TextUnit.Line or TextUnit.Paragraph or TextUnit.Page => FindLineBoundaries(text, start).End,
+            TextUnit.Document => text.Length,
+            _ => start,
+        };
+    }
+
+    private static (int Start, int End) FindWordBoundaries(string text, int offset)
+    {
+        if (string.IsNullOrEmpty(text)) return (0, 0);
+        return TextBoundaryHelper.FindWordBoundaries(text, offset);
+    }
+
+    private static (int Start, int End) FindLineBoundaries(string text, int offset)
+    {
+        if (text.Length == 0) return (0, 0);
+        offset = Math.Clamp(offset, 0, text.Length);
+        int start = offset;
+        while (start > 0 && text[start - 1] != '\n') start--;
+        int end = offset;
+        while (end < text.Length && text[end] != '\n') end++;
+        return (start, end);
+    }
+
+    private static int NextWordStart(string text, int offset)
+    {
+        return TextBoundaryHelper.FindNextWordStart(text, offset);
+    }
+
+    private static int PreviousWordStart(string text, int offset)
+    {
+        return TextBoundaryHelper.FindPreviousWordStart(text, offset);
+    }
+
+    private static int NextLineStart(string text, int offset)
+    {
+        int i = Math.Clamp(offset, 0, text.Length);
+        while (i < text.Length && text[i] != '\n') i++;
+        return Math.Min(text.Length, i + 1);
+    }
+
+    private static int PreviousLineStart(string text, int offset)
+    {
+        int i = Math.Clamp(offset - 1, 0, Math.Max(0, text.Length - 1));
+        while (i > 0 && text[i - 1] != '\n') i--;
+        return i;
+    }
+}

--- a/MarkdownRenderer/MarkdownRenderer/Controls/MarkdownRendererControl.cs
+++ b/MarkdownRenderer/MarkdownRenderer/Controls/MarkdownRendererControl.cs
@@ -1,19 +1,21 @@
 using System;
 using System.Collections.Generic;
+using System.Numerics;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Graphics.Canvas;
 using Microsoft.Graphics.Canvas.UI.Xaml;
+using Microsoft.UI.System;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Automation.Peers;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Input;
 using Microsoft.UI.Xaml.Media;
-using Microsoft.UI.Xaml.Shapes;
 using Windows.Foundation;
 using Windows.System;
 using Windows.UI;
 using MarkdownRenderer.Accessibility;
+using MarkdownRenderer.Diagnostics;
 using MarkdownRenderer.Document;
 using MarkdownRenderer.Hosting;
 using MarkdownRenderer.Layout;
@@ -44,22 +46,14 @@ public sealed partial class MarkdownRendererControl : UserControl
     private readonly SelectionController _selection = new();
     private DocumentPosition? _selectionAnchor;
 
-    // XAML Rectangle elements drawn on _overlay to show the selection highlight.
-    // Keeping selection on the XAML layer means the DirectWrite canvas tiles are
-    // never invalidated during a drag — eliminating tile-offset-driven glyph shake.
-    // The list acts as a pool: Rectangles are never removed from _overlay.Children
-    // during a drag update — only their Width/Height/Canvas.Left/Top/Visibility are
-    // mutated.  Inserting/removing Canvas children triggers a XAML layout pass on
-    // every pointer-move event and causes sub-pixel visual jitter of surrounding
-    // XAML elements (embedded buttons, etc.).  With the pool we pay the one-time
-    // Insert cost when a new stripe is first needed and zero tree-modification cost
-    // on subsequent updates.  The pool is invalidated (Cleared) whenever
-    // _overlay.Children.Clear() fires (on rebuild/unload).
-    private readonly List<Rectangle> _selectionOverlayRects = new();
-    // Brush cache: reuse the same SolidColorBrush across drag frames so we don't
-    // allocate a new brush object on every pointer-move event.
-    private SolidColorBrush? _selectionBrush;
-    private Windows.UI.Color _selectionBrushColor;
+    // Single Win2D adorner for text selection. It draws both the native
+    // selection background and selected glyph foreground above the already
+    // painted document, while the base CanvasVirtualControl remains untouched
+    // during selection drag. Keeping this to one stable XAML child avoids the
+    // measure/compositor churn that caused the historical text-shake bug.
+    private readonly List<Rect> _selectionAdornerRects = new();
+    private CanvasControl? _selectionAdorner;
+    private double _selectionAdornerOffsetY;
 
     // Background color used to clear each canvas tile before painting.  Captured
     // from ActualTheme at rebuild time so that OnRegionsInvalidated (UI thread,
@@ -72,12 +66,14 @@ public sealed partial class MarkdownRendererControl : UserControl
     // Last committed theme snapshot. Used by UI operations (focus ring, etc.)
     // that need theme colors after the rebuild is complete.
     private Theming.ThemeSnapshot? _themeSnapshot;
+    private ThemeSettings? _themeSettings;
 
     // ---- Keyboard navigation ----
     // Ordered list of focusable items (LinkRuns + InlineEmbedRuns) in the current
     // snapshot.  Rebuilt after each snapshot commit.  -1 means "nothing focused".
     private System.Collections.Generic.IReadOnlyList<Layout.FocusableItem>? _focusableItems;
     private int _focusedItemIndex = -1;
+    private int _focusResumeItemIndex = -1;
     // XAML Border element used to show a focus ring around the focused item.
     // Lives on _overlay at ZIndex 1 (above selection at -1, below embeds at 0).
     private Microsoft.UI.Xaml.Controls.Border? _focusRing;
@@ -166,18 +162,21 @@ public sealed partial class MarkdownRendererControl : UserControl
                 double top  = Math.Round(Box.Bounds.Y + Box.Margin.Top);
                 Canvas.SetLeft(fe, left);
                 Canvas.SetTop(fe, top);
+                Canvas.SetZIndex(fe, 2);
+                fe.KeyDown += owner.OnHostedEmbedKeyDown;
                 owner._overlay!.Children.Add(fe);
                 // _blockEmbedRects rebuilt in RealizeVisibleEmbeds.
             }
             catch (Exception ex)
             {
-                System.Diagnostics.Debug.WriteLine($"[MarkdownRendererControl] EmbedBox factory threw: {ex.Message}");
+                MarkdownDiagnostics.WriteLine($"[MarkdownRendererControl] EmbedBox factory threw: {ex.Message}");
             }
         }
         public override void Derealize(MarkdownRendererControl owner)
         {
             if (Realized is null) return;
             var fe = Realized;
+            fe.KeyDown -= owner.OnHostedEmbedKeyDown;
             try { owner._overlay!.Children.Remove(fe); } catch { }
             try { Box.Factory.RecycleBlock(Box.SourceBlock, fe); } catch { }
             Box.RealizedElement = null;
@@ -205,29 +204,41 @@ public sealed partial class MarkdownRendererControl : UserControl
                 fe.Height = iH;
                 Canvas.SetLeft(fe, iLeft);
                 Canvas.SetTop(fe, iTop);
+                Canvas.SetZIndex(fe, 2);
+                fe.KeyDown += owner.OnHostedEmbedKeyDown;
                 owner._overlay!.Children.Add(fe);
                 // _embedRects rebuilt in RealizeVisibleEmbeds.
             }
             catch (Exception ex)
             {
-                System.Diagnostics.Debug.WriteLine($"[MarkdownRendererControl] inline embed factory threw: {ex.Message}");
+                MarkdownDiagnostics.WriteLine($"[MarkdownRendererControl] inline embed factory threw: {ex.Message}");
             }
         }
         public override void Derealize(MarkdownRendererControl owner)
         {
             if (Realized is null) return;
             var fe = Realized;
+            fe.KeyDown -= owner.OnHostedEmbedKeyDown;
             try { owner._overlay!.Children.Remove(fe); } catch { }
             try { Run.Recycle?.Invoke(fe); }
             catch (Exception ex)
             {
-                System.Diagnostics.Debug.WriteLine($"[MarkdownRendererControl] inline embed Recycle threw: {ex.Message}");
+                MarkdownDiagnostics.WriteLine($"[MarkdownRendererControl] inline embed Recycle threw: {ex.Message}");
             }
             Run.RealizedElement = null;
             Realized = null;
         }
     }
     private readonly List<EmbedPlan> _embedPlans = new();
+    private bool _promotingKeyboardFocusEntry;
+    private bool _lastFocusEntryWasKeyboardTraversal;
+    private bool _lastFocusEntryWasKeyboardInput;
+    private bool _lastFocusEntryWasReverse;
+    private bool _suppressNextFocusPromotion;
+    private bool _contextMenuOpen;
+    private UIElement? _selectionDismissalRoot;
+    private PointerEventHandler? _selectionDismissalPointerPressedHandler;
+    private KeyEventHandler? _selectionCopyKeyDownHandler;
 
     // Lazy-load queue: all ImageBox instances in the current snapshot.
     // EnsureLoading() is called for each when its bounds enter the
@@ -329,6 +340,41 @@ public sealed partial class MarkdownRendererControl : UserControl
         return _linkPeerCache.GetValue(run, r => new MarkdownLinkPeer(this, parent, r));
     }
 
+    internal bool IsKeyboardFocusOnLink(LinkRun run)
+    {
+        return TryGetFocusedLink(out _, out var focusedRun) &&
+               ReferenceEquals(focusedRun, run);
+    }
+
+    internal bool HasKeyboardFocusOnPaintedLink => TryGetFocusedLink(out _, out _);
+
+    internal bool FocusLinkFromAutomation(LinkRun run)
+    {
+        if (!TryGetFocusableIndexForLink(run, out var index))
+            return Focus(FocusState.Programmatic);
+
+        _focusedItemIndex = index;
+        _focusResumeItemIndex = -1;
+        ScrollFocusedItemIntoView();
+        bool focused = Focus(FocusState.Programmatic);
+        UpdateFocusRing();
+        NotifyFocusedItemAutomation();
+        return focused;
+    }
+
+    internal bool FocusDocumentFromAutomation()
+    {
+        _suppressNextFocusPromotion = true;
+        _focusedItemIndex = -1;
+        UpdateFocusRing();
+        bool focused = Focus(FocusState.Programmatic);
+        if (!focused)
+            _suppressNextFocusPromotion = false;
+        else
+            DispatcherQueue.TryEnqueue(() => _suppressNextFocusPromotion = false);
+        return focused;
+    }
+
     /// <summary>Invoked by <see cref="MarkdownLinkPeer.Invoke"/> so UIA clients
     /// can activate a link the same way as pointer interaction. UIA callers
     /// can arrive on the RPC thread, so marshal back to the UI dispatcher
@@ -361,6 +407,23 @@ public sealed partial class MarkdownRendererControl : UserControl
     /// <summary>Current vertical scroll offset of the host scroll viewer.</summary>
     internal double CurrentScrollOffsetY => _scroll?.VerticalOffset ?? 0;
 
+    /// <summary>
+    /// Offset applied by ScrollViewer when short content is centered inside the
+    /// viewport. UIA screen rectangles must include this or range-from-text
+    /// probe points land in the blank band above the canvas content.
+    /// </summary>
+    internal double CurrentContentOffsetY
+    {
+        get
+        {
+            if (_scroll is null || _root is null) return 0;
+            double viewportHeight = _scroll.ViewportHeight;
+            double contentHeight = _root.ActualHeight > 0 ? _root.ActualHeight : _root.Height;
+            if (viewportHeight <= 0 || contentHeight <= 0 || contentHeight >= viewportHeight) return 0;
+            return (viewportHeight - contentHeight) / 2.0;
+        }
+    }
+
     protected override AutomationPeer OnCreateAutomationPeer() => new MarkdownAutomationPeer(this);
 
     /// <summary>
@@ -369,6 +432,12 @@ public sealed partial class MarkdownRendererControl : UserControl
     /// May be null before the first layout completes.
     /// </summary>
     internal LayoutSnapshot? CurrentSnapshot => _snapshot;
+
+    /// <summary>
+    /// Last committed theme snapshot. Used by automation peers to expose UIA
+    /// text attributes that match the pixels currently painted on the canvas.
+    /// </summary>
+    internal Theming.ThemeSnapshot? CurrentThemeSnapshot => _themeSnapshot;
 
     /// <summary>
     /// Number of currently-realised hosted embed elements (block + inline).
@@ -385,28 +454,33 @@ public sealed partial class MarkdownRendererControl : UserControl
         }
     }
 
-    /// <summary>
-    /// Map a document-local box rectangle into screen coordinates. Used by
-    /// per-block automation peers to report accurate bounding rectangles so
-    /// Narrator's "scan by element" gestures move focus to the correct spot
-    /// on screen, including after scrolling.
-    /// </summary>
-    internal Windows.Foundation.Rect GetScreenRectForBox(Windows.Foundation.Rect docRect)
+    private void OnHostedEmbedKeyDown(object sender, KeyRoutedEventArgs e)
     {
-        try
+        if (sender is not FrameworkElement element)
+            return;
+
+        bool shift = (Microsoft.UI.Input.InputKeyboardSource
+            .GetKeyStateForCurrentThread(VirtualKey.Shift) & Windows.UI.Core.CoreVirtualKeyStates.Down)
+            == Windows.UI.Core.CoreVirtualKeyStates.Down;
+
+        if (!TrySetFocusedItemForHostedElement(element)) return;
+
+        if (e.Key == VirtualKey.Tab)
         {
-            double yOffset = _scroll?.VerticalOffset ?? 0;
-            var local = new Windows.Foundation.Point(docRect.X, docRect.Y - yOffset);
-            var transform = TransformToVisual(null);
-            var topLeft = transform.TransformPoint(local);
-            return new Windows.Foundation.Rect(topLeft.X, topLeft.Y, docRect.Width, docRect.Height);
+            if (TryMoveFocusWithinHostedEmbed(element, e.OriginalSource, shift))
+            {
+                e.Handled = true;
+                return;
+            }
+
+            e.Handled = MoveFocus(reverse: shift);
+            return;
         }
-        catch
+
+        if (e.Key is VirtualKey.Left or VirtualKey.Right or VirtualKey.Up or VirtualKey.Down &&
+            element is not TextBox)
         {
-            // Element may not be in a tree yet (e.g. peer requested before
-            // first layout pass). Fall back to a zero-rect; UIA will treat
-            // it as "no bounding rect" and skip it.
-            return default;
+            e.Handled = MoveFocusSpatial(e.Key);
         }
     }
 
@@ -417,6 +491,44 @@ public sealed partial class MarkdownRendererControl : UserControl
     /// </summary>
     internal string CurrentMarkdownSource => Markdown ?? string.Empty;
 
+    internal DocumentRange CurrentSelectionRange => _selection.Range;
+
+    internal void SelectAutomationRange(DocumentRange range)
+    {
+        if (!IsSelectionEnabled) return;
+        var normalized = range.Normalized();
+        _selection.SetAnchor(normalized.Start);
+        _selection.ExtendTo(normalized.End);
+    }
+
+    internal void ClearAutomationSelection() => _selection.Clear();
+
+    internal bool TryGetVisibleDocumentRect(out Windows.Foundation.Rect rect)
+    {
+        if (_scroll is null)
+        {
+            rect = default;
+            return false;
+        }
+
+        rect = new Windows.Foundation.Rect(0, _scroll.VerticalOffset, ActualWidth, _scroll.ViewportHeight);
+        return true;
+    }
+
+    internal void ScrollDocumentRectIntoView(Windows.Foundation.Rect rect, bool alignToTop)
+    {
+        if (_scroll is null) return;
+        const double margin = 24.0;
+        double target = alignToTop
+            ? rect.Top
+            : rect.Top < _scroll.VerticalOffset + margin
+                ? rect.Top - margin
+                : rect.Bottom > _scroll.VerticalOffset + _scroll.ViewportHeight - margin
+                    ? rect.Bottom - _scroll.ViewportHeight + margin
+                    : _scroll.VerticalOffset;
+        _scroll.ChangeView(null, Math.Max(0, target), null, disableAnimation: false);
+    }
+
     public MarkdownRendererControl()
     {
         IsTabStop = true;
@@ -426,7 +538,7 @@ public sealed partial class MarkdownRendererControl : UserControl
         ActualThemeChanged += (_, _) => OnThemeChanged();
         // Selection changes update the XAML overlay (not the DirectWrite canvas),
         // so tiles are never invalidated during a drag.
-        _selection.Changed += (_, _) => UpdateSelectionOverlay();
+        _selection.Changed += (_, _) => OnSelectionChanged();
         // FlowDirection has no DP-changed callback we can register at the
         // class level (it's defined by FrameworkElement). Listen for live
         // changes via the dependency-property-changed callback API so RTL
@@ -473,13 +585,239 @@ public sealed partial class MarkdownRendererControl : UserControl
         _canvas.PointerCanceled += OnPointerCanceledOrCaptureLost;
         _canvas.PointerCaptureLost += OnPointerCanceledOrCaptureLost;
         _canvas.RightTapped += OnRightTapped;
+        GettingFocus += OnGettingFocus;
+        GotFocus += OnGotFocus;
+        LosingFocus += OnLosingFocus;
         KeyDown += OnKeyDown;
 
         Content = _scroll;
     }
 
+    private void OnGettingFocus(UIElement sender, GettingFocusEventArgs e)
+    {
+        if (!ReferenceEquals(e.NewFocusedElement, this))
+            return;
+
+        var direction = e.Direction;
+        _lastFocusEntryWasKeyboardInput = e.InputDevice == FocusInputDeviceKind.Keyboard;
+        _lastFocusEntryWasKeyboardTraversal =
+            direction is Microsoft.UI.Xaml.Input.FocusNavigationDirection.Next
+                      or Microsoft.UI.Xaml.Input.FocusNavigationDirection.Previous;
+        _lastFocusEntryWasReverse = direction == Microsoft.UI.Xaml.Input.FocusNavigationDirection.Previous;
+    }
+
+    private void OnGotFocus(object sender, RoutedEventArgs e)
+    {
+        if (_promotingKeyboardFocusEntry || _isUnloaded)
+            return;
+
+        if (!ReferenceEquals(e.OriginalSource, this) || FocusState == FocusState.Pointer)
+            return;
+
+        if (_suppressNextFocusPromotion)
+        {
+            _suppressNextFocusPromotion = false;
+            _lastFocusEntryWasKeyboardTraversal = false;
+            _lastFocusEntryWasKeyboardInput = false;
+            return;
+        }
+
+        if (!_lastFocusEntryWasKeyboardTraversal &&
+            !_lastFocusEntryWasKeyboardInput &&
+            FocusState != FocusState.Keyboard)
+            return;
+
+        if (_focusedItemIndex >= 0)
+        {
+            UpdateFocusRing();
+            NotifyFocusedItemAutomation();
+            return;
+        }
+
+        _promotingKeyboardFocusEntry = true;
+        try
+        {
+            MoveFocus(_lastFocusEntryWasReverse);
+        }
+        finally
+        {
+            _promotingKeyboardFocusEntry = false;
+            _lastFocusEntryWasKeyboardTraversal = false;
+            _lastFocusEntryWasKeyboardInput = false;
+        }
+    }
+
+    private void OnLosingFocus(UIElement sender, LosingFocusEventArgs e)
+    {
+        _suppressNextFocusPromotion = false;
+
+        if (e.NewFocusedElement is DependencyObject next && IsElementWithinRenderer(next))
+            return;
+
+        _focusedItemIndex = -1;
+        UpdateFocusRing();
+        if (!_contextMenuOpen)
+        {
+            _selectionAnchor = null;
+            _clickMode = ClickMode.Single;
+        }
+    }
+
+    private bool IsElementWithinRenderer(DependencyObject element)
+    {
+        for (DependencyObject? current = element; current is not null;)
+        {
+            if (ReferenceEquals(current, this))
+                return true;
+
+            try { current = VisualTreeHelper.GetParent(current); }
+            catch { return false; }
+        }
+
+        return false;
+    }
+
+    private void RegisterSelectionDismissalHook()
+    {
+        if (_selectionDismissalRoot is not null)
+            return;
+
+        var root = XamlRoot?.Content as UIElement;
+        if (root is null)
+            return;
+
+        _selectionDismissalPointerPressedHandler = OnAppRootPointerPressed;
+        root.AddHandler(UIElement.PointerPressedEvent, _selectionDismissalPointerPressedHandler, handledEventsToo: true);
+        _selectionCopyKeyDownHandler = OnAppRootKeyDown;
+        root.AddHandler(UIElement.KeyDownEvent, _selectionCopyKeyDownHandler, handledEventsToo: true);
+        _selectionDismissalRoot = root;
+    }
+
+    private void UnregisterSelectionDismissalHook()
+    {
+        if (_selectionDismissalRoot is not null && _selectionDismissalPointerPressedHandler is not null)
+        {
+            try { _selectionDismissalRoot.RemoveHandler(UIElement.PointerPressedEvent, _selectionDismissalPointerPressedHandler); }
+            catch { }
+        }
+
+        if (_selectionDismissalRoot is not null && _selectionCopyKeyDownHandler is not null)
+        {
+            try { _selectionDismissalRoot.RemoveHandler(UIElement.KeyDownEvent, _selectionCopyKeyDownHandler); }
+            catch { }
+        }
+
+        _selectionDismissalRoot = null;
+        _selectionDismissalPointerPressedHandler = null;
+        _selectionCopyKeyDownHandler = null;
+    }
+
+    private void OnAppRootPointerPressed(object sender, PointerRoutedEventArgs e)
+    {
+        if (_isUnloaded)
+            return;
+
+        var point = e.GetCurrentPoint(sender as UIElement ?? this);
+        var properties = point.Properties;
+        if (properties.IsRightButtonPressed || properties.IsMiddleButtonPressed || properties.IsXButton1Pressed || properties.IsXButton2Pressed)
+            return;
+
+        if (e.OriginalSource is DependencyObject source && IsElementWithinRenderer(source))
+        {
+            MarkdownSelectionCoordinator.ClearSelectionsExcept(this);
+            if (!IsPointerOverCanvasTextSurface(e, out var canvasPoint) || IsPointOverEmbed(canvasPoint))
+                ClearSelectionForExternalInteraction();
+            return;
+        }
+
+        ClearSelectionForExternalInteraction();
+    }
+
+    private void OnAppRootKeyDown(object sender, KeyRoutedEventArgs e)
+    {
+        if (_isUnloaded || _snapshot is null || !_selection.IsActive)
+            return;
+
+        bool ctrl = (Microsoft.UI.Input.InputKeyboardSource
+            .GetKeyStateForCurrentThread(VirtualKey.Control) & Windows.UI.Core.CoreVirtualKeyStates.Down)
+            == Windows.UI.Core.CoreVirtualKeyStates.Down;
+        if (!ctrl || e.Key != VirtualKey.C)
+            return;
+
+        if (CopySelectionToClipboard())
+            e.Handled = true;
+    }
+
+    private bool CopySelectionToClipboard()
+    {
+        var snapshot = _snapshot;
+        if (snapshot is null || !_selection.IsActive)
+            return false;
+
+        return MarkdownClipboardWriter.Copy(snapshot.SourceMap, _selection.Range);
+    }
+
+    internal void ClearSelectionFromCoordinator()
+    {
+        ClearSelectionForExternalInteraction();
+    }
+
+    private void ClearSelectionForExternalInteraction(bool resetClickTracking = true)
+    {
+        _selectionAnchor = null;
+        _clickMode = ClickMode.Single;
+        if (resetClickTracking)
+        {
+            _consecutiveClickCount = 0;
+            _lastPressTickMs = 0;
+            _lastPressPoint = default;
+        }
+
+        if (_selection.IsActive || !_selection.Range.IsEmpty)
+            _selection.Clear();
+
+        if (_focusedItemIndex >= 0)
+        {
+            _focusedItemIndex = -1;
+            UpdateFocusRing();
+        }
+    }
+
+    private bool IsPointerOverCanvasTextSurface(PointerRoutedEventArgs e, out Point canvasPoint)
+    {
+        canvasPoint = default;
+        if (_canvas is null)
+            return false;
+
+        try
+        {
+            canvasPoint = e.GetCurrentPoint(_canvas).Position;
+            return canvasPoint.X >= 0 &&
+                   canvasPoint.Y >= 0 &&
+                   canvasPoint.X <= _canvas.ActualWidth &&
+                   canvasPoint.Y <= _canvas.ActualHeight;
+        }
+        catch
+        {
+            canvasPoint = default;
+            return false;
+        }
+    }
+
+    private void OnSelectionChanged()
+    {
+        if (_selection.IsActive)
+            MarkdownSelectionCoordinator.ClearSelectionsExcept(this);
+
+        UpdateSelectionOverlay();
+    }
+
     private void OnLoadedInternal()
     {
+        _isUnloaded = false;
+        MarkdownSelectionCoordinator.Register(this);
+        RegisterSelectionDismissalHook();
+        EnsureThemeSettingsSubscription();
         _sizeChangedHandler = (_, e) =>
         {
             if (Math.Abs(_lastWidth - (float)e.NewSize.Width) > 0.5f) RequestRebuild();
@@ -514,6 +852,13 @@ public sealed partial class MarkdownRendererControl : UserControl
         {
             t.Changed -= OnThemeRevisionChanged;
         }
+        if (_themeSettings is not null)
+        {
+            _themeSettings.Changed -= OnThemeSettingsChanged;
+            _themeSettings = null;
+        }
+        UnregisterSelectionDismissalHook();
+        MarkdownSelectionCoordinator.Unregister(this);
         // Cancel and dispose the CTS. At unload no new RequestRebuild can be called
         // (the control is being torn down), so there is no concurrent ContinueWith
         // disposal race. Disposing explicitly avoids leaking the WaitHandle until GC.
@@ -551,12 +896,12 @@ public sealed partial class MarkdownRendererControl : UserControl
         _cursorIBeam?.Dispose();
         _cursorHand = null;
         _cursorIBeam = null;
-        // Clear the selection-rect pool: after the overlay is wiped the pooled
-        // Rectangles are no longer in _overlay.Children, so the pool references
-        // are stale.  CommitSnapshot does the same; mirror it here so a re-attach
-        // cycle (Unload → Load) starts with a clean pool.
-        _selectionOverlayRects.Clear();
-        _selectionBrush = null;
+        _selectionAdornerRects.Clear();
+        if (_selectionAdorner is not null)
+        {
+            _selectionAdorner.Draw -= OnSelectionAdornerDraw;
+            _selectionAdorner = null;
+        }
         _focusRing = null; // evicted from overlay above; lazily re-created on re-attach
         var snap = _snapshot;
         _snapshot = null;
@@ -570,6 +915,34 @@ public sealed partial class MarkdownRendererControl : UserControl
         // builds and immediately cancel the first one on every theme change.
         if (Theme is { } t) t.Invalidate();
         else RequestRebuild(); // no Theme object: must trigger rebuild directly
+    }
+
+    private void OnThemeSettingsChanged(ThemeSettings sender, object args)
+    {
+        var dq = DispatcherQueue;
+        if (dq is null) return;
+        if (dq.HasThreadAccess)
+        {
+            if (IsLoaded) OnThemeChanged();
+            return;
+        }
+
+        dq.TryEnqueue(() =>
+        {
+            if (IsLoaded) OnThemeChanged();
+        });
+    }
+
+    private void EnsureThemeSettingsSubscription()
+    {
+        if (_themeSettings is not null) return;
+        try
+        {
+            if (XamlRoot?.ContentIslandEnvironment is null) return;
+            _themeSettings = ThemeSettings.CreateForWindowId(XamlRoot.ContentIslandEnvironment.AppWindowId);
+            _themeSettings.Changed += OnThemeSettingsChanged;
+        }
+        catch { }
     }
 
     private void OnThemeDpChanged(DependencyPropertyChangedEventArgs e)
@@ -617,7 +990,7 @@ public sealed partial class MarkdownRendererControl : UserControl
             // no more ct.Register() calls can fire on it.
             oldCts?.Dispose();
             if (t.IsFaulted)
-                System.Diagnostics.Debug.WriteLine($"[MarkdownRendererControl] Rebuild faulted: {t.Exception}");
+                MarkdownDiagnostics.WriteLine($"[MarkdownRendererControl] Rebuild faulted: {t.Exception}");
         }, TaskScheduler.Default);
     }
 
@@ -630,7 +1003,7 @@ public sealed partial class MarkdownRendererControl : UserControl
         catch (OperationCanceledException) { /* expected – a new build was requested */ }
         catch (Exception ex)
         {
-            System.Diagnostics.Debug.WriteLine($"[MarkdownRendererControl] Rebuild failed: {ex}");
+            MarkdownDiagnostics.WriteLine($"[MarkdownRendererControl] Rebuild failed: {ex}");
         }
     }
 
@@ -652,12 +1025,9 @@ public sealed partial class MarkdownRendererControl : UserControl
         var sourceMap = new MarkdownSourceMap(parsed.SourceText);
         var theme = Theme ?? _defaultTheme;
         var themeSnapshot = new ThemeResolver(this, theme).CreateSnapshot();
-        // Capture background color on the UI thread now — ActualTheme is correct
-        // at this point (ActualThemeChanged fires before we call RequestRebuild).
-        // Win11 surface colors: dark = #202020, light = white.
-        _canvasBackground = ActualTheme == ElementTheme.Dark
-            ? Windows.UI.Color.FromArgb(0xFF, 0x20, 0x20, 0x20)
-            : Windows.UI.Color.FromArgb(0xFF, 0xFF, 0xFF, 0xFF);
+        // Capture the resolved surface color on the UI thread. In high
+        // contrast this is the native Window color, not a light/dark token.
+        _canvasBackground = themeSnapshot.SurfaceColor;
         // Use the shared CanvasDevice (always available, no visual-tree required).
         // CanvasVirtualControl only has a device after CreateResources fires, so
         // passing _canvas directly would crash if layout runs before first draw.
@@ -757,15 +1127,11 @@ public sealed partial class MarkdownRendererControl : UserControl
         // Identities change across rebuild even when the count happens to
         // match — reset so the first post-rebuild realisation always fires.
         _lastFiredRealizedCount = -1;
-        _selectionOverlayRects.Clear(); // overlay was just cleared above
-        // Pre-populate enough stripes to cover a full-document selection without
-        // any Children.Add() calls during the first drag.  Each block can produce
-        // at most ~3 line-stripes (partial first line, full interior lines, partial
-        // last line) so blocks×3 is a conservative upper bound.  Floor at 32 so
-        // tiny documents still get a sensible pool.
-        PreWarmSelectionPool(Math.Max(32, snapshot.Blocks.Count * 3));
+        _selectionAdornerRects.Clear();
+        EnsureSelectionAdorner();
         _selection.Clear();             // stale selection no longer valid after re-layout
         _focusedItemIndex = -1;         // selection/focus stale after re-layout
+        _focusResumeItemIndex = -1;
         _focusRing = null;              // evicted from overlay; will be lazily re-created on next Tab
         _focusableItems = snapshot.CollectFocusableItems();
         foreach (var b in snapshot.Blocks) CollectEmbedPlans(b);
@@ -775,6 +1141,7 @@ public sealed partial class MarkdownRendererControl : UserControl
             _scroll.ViewChanged += OnScrollViewChanged;
         }
         RealizeVisibleEmbeds();
+        UpdateSelectionAdornerViewport();
 
         _canvas.Invalidate();
         } // end of snapshot try-block
@@ -789,6 +1156,8 @@ public sealed partial class MarkdownRendererControl : UserControl
 
     private void OnScrollViewChanged(object? sender, ScrollViewerViewChangedEventArgs e)
     {
+        UpdateSelectionAdornerViewport();
+        _selectionAdorner?.Invalidate();
         // Run a final realisation pass after intermediate-view bursts settle
         // so we don't thrash during fling/inertia. ViewChanged with
         // IsIntermediate=false fires at the end of inertia; we also realise on
@@ -974,13 +1343,14 @@ public sealed partial class MarkdownRendererControl : UserControl
     private void OnRegionsInvalidated(CanvasVirtualControl sender, CanvasRegionsInvalidatedEventArgs args)
     {
         if (_snapshot is null) return;
-        var frame = MarkdownRenderer.Diagnostics.ShakeLogger.NextFrame();
+        var frame = ShakeLogger.NextFrame();
         int regionCount = 0;
         foreach (var region in args.InvalidatedRegions)
         {
             regionCount++;
-            MarkdownRenderer.Diagnostics.ShakeLogger.LogPaint(
-                "region", regionCount, region.X, region.Y, region.Width, region.Height);
+            if (ShakeLogger.IsEnabled)
+                ShakeLogger.LogPaint(
+                    "region", regionCount, region.X, region.Y, region.Width, region.Height);
             using var ds = sender.CreateDrawingSession(region);
             // Clear to the theme-appropriate background color so that switching between
             // light and dark mode (or any theme change) fully overwrites old tile content.
@@ -996,12 +1366,13 @@ public sealed partial class MarkdownRendererControl : UserControl
             // different sub-pixel RGB values.  Switching to grayscale makes
             // glyph edges background-independent.
             ds.TextAntialiasing = Microsoft.Graphics.Canvas.Text.CanvasTextAntialiasing.Grayscale;
-            // Selection is rendered on the XAML overlay (Rectangle elements),
-            // not here — canvas tiles are never dirtied during drag.
+            // Selection is rendered by the separate Win2D adorner, not here;
+            // base document tiles are never dirtied during a drag.
             _snapshot.Paint(ds, region);
         }
-        MarkdownRenderer.Diagnostics.ShakeLogger.Log("frame-end",
-            $"frame={frame} regions={regionCount} hovered={(_lastHoveredRun is null ? "null" : _lastHoveredRun.GetType().Name)} dragging={_selectionAnchor is not null}");
+        if (ShakeLogger.IsEnabled)
+            ShakeLogger.Log("frame-end",
+                $"frame={frame} regions={regionCount} hovered={(_lastHoveredRun is null ? "null" : _lastHoveredRun.GetType().Name)} dragging={_selectionAnchor is not null}");
     }
 
     // ---- Input ----
@@ -1013,6 +1384,7 @@ public sealed partial class MarkdownRendererControl : UserControl
         // OnRightTapped and must not affect the multi-click counter or selection anchor.
         if (!e.GetCurrentPoint(_canvas).Properties.IsLeftButtonPressed) return;
         var pt = e.GetCurrentPoint(_canvas).Position;
+        RememberFocusResumePoint(pt);
 
         // Pressing *on* a hosted inline embed must NOT start a selection.
         // The embed is a real WinUI element layered above the canvas — its
@@ -1059,7 +1431,7 @@ public sealed partial class MarkdownRendererControl : UserControl
         else
             _consecutiveClickCount = 1;
 
-        Focus(FocusState.Pointer);
+        FocusRendererForPointerInteraction();
         if (_snapshot.HitTest(pt, out var pos))
         {
             // Advance clock/position only on successful text hits so a miss in the
@@ -1127,6 +1499,19 @@ public sealed partial class MarkdownRendererControl : UserControl
         }
     }
 
+    private void FocusRendererForPointerInteraction()
+    {
+        _suppressNextFocusPromotion = true;
+        bool focused = Focus(FocusState.Programmatic);
+        if (!focused)
+        {
+            _suppressNextFocusPromotion = false;
+            return;
+        }
+
+        DispatcherQueue.TryEnqueue(() => _suppressNextFocusPromotion = false);
+    }
+
     private InlineRun? _lastHoveredRun;
     private Layout.Boxes.InlineContainerBox? _lastHoveredBox; // box that contains _lastHoveredRun; used for targeted canvas invalidation
     // Tracks the ProtectedCursor shape we last set, or null when we have
@@ -1159,15 +1544,17 @@ public sealed partial class MarkdownRendererControl : UserControl
             // <textarea> inside contenteditable text.
             if (TryHitTestEmbed(pt, out var embedPos))
             {
-                MarkdownRenderer.Diagnostics.ShakeLogger.Log("ptr-move-drag-embed",
-                    $"px={pt.X:F4} py={pt.Y:F4} pos=blk{embedPos.BlockIndex}/inl{embedPos.InlineIndex}/c{embedPos.CharacterOffset}");
+                if (ShakeLogger.IsEnabled)
+                    ShakeLogger.Log("ptr-move-drag-embed",
+                        $"px={pt.X:F4} py={pt.Y:F4} pos=blk{embedPos.BlockIndex}/inl{embedPos.InlineIndex}/c{embedPos.CharacterOffset}");
                 _selection.ExtendTo(embedPos);
                 // No _canvas.Invalidate(): selection is on the XAML overlay.
             }
             else if (_snapshot.HitTest(pt, out var pos))
             {
-                MarkdownRenderer.Diagnostics.ShakeLogger.Log("ptr-move-drag",
-                    $"px={pt.X:F4} py={pt.Y:F4} pos=blk{pos.BlockIndex}/inl{pos.InlineIndex}/c{pos.CharacterOffset}");
+                if (ShakeLogger.IsEnabled)
+                    ShakeLogger.Log("ptr-move-drag",
+                        $"px={pt.X:F4} py={pt.Y:F4} pos=blk{pos.BlockIndex}/inl{pos.InlineIndex}/c{pos.CharacterOffset}");
                 // For word/block click modes extend selection snapped to the
                 // appropriate boundary so dragging after double/triple-click
                 // produces word-by-word or block-by-block selection, matching
@@ -1444,17 +1831,11 @@ public sealed partial class MarkdownRendererControl : UserControl
     }
 
     /// <summary>
-    /// Syncs the selection highlight to the XAML _overlay using Rectangle elements.
-    /// Called whenever _selection.Changed fires (SetAnchor / ExtendTo / Clear).
-    /// By keeping selection on the XAML layer the DirectWrite canvas tiles are
-    /// never dirtied during a drag, which eliminates tile-offset glyph shake.
-    ///
-    /// Pool pattern: Rectangles are never removed from _overlay.Children during a
-    /// drag update.  Only their geometry properties (Width/Height/Canvas.Left/Top)
-    /// and Visibility are mutated.  This avoids the XAML visual-tree mutation
-    /// (Children.Remove / Children.Insert) that was triggering a layout/render pass
-    /// on every pointer-move event and causing sub-pixel vertical jitter of nearby
-    /// XAML elements (embedded buttons, etc.).
+    /// Syncs the selection adorner geometry. The adorner is a single stable
+    /// Win2D child layered above the document text and below hosted controls.
+    /// Selection changes only mutate this in-memory rect list and invalidate
+    /// the adorner; they never invalidate the base document canvas or mutate
+    /// the XAML child tree during a drag.
     /// </summary>
     private void UpdateSelectionOverlay()
     {
@@ -1463,42 +1844,21 @@ public sealed partial class MarkdownRendererControl : UserControl
         var snapshot = _snapshot;
         if (snapshot is null || !_selection.IsActive)
         {
-            // Hide all pooled rectangles — don't remove them (cheaper).
-            foreach (var r in _selectionOverlayRects)
-                r.Visibility = Visibility.Collapsed;
+            _selectionAdornerRects.Clear();
+            _selectionAdorner?.Invalidate();
             return;
         }
 
-        // Compute the desired selection highlight color.
-        var theme = Theme ?? _defaultTheme;
-        var accentBase = theme.AccentColor ?? Color.FromArgb(0x66, 0x00, 0x67, 0xC0);
-        var hl = Color.FromArgb(0x55, accentBase.R, accentBase.G, accentBase.B);
-
-        // Reuse the cached brush when the color hasn't changed (common case during
-        // a drag: the highlight color is constant throughout the gesture).
-        if (_selectionBrush is null || _selectionBrushColor != hl)
-        {
-            _selectionBrush = new SolidColorBrush(hl);
-            _selectionBrushColor = hl;
-        }
-
         // Snap to *physical pixels*, not DIPs. At fractional DPI (125%, 150%)
-        // an integer-DIP edge lands at a fractional physical pixel, so XAML's
-        // own anti-aliased rasterization fans the rect edges across two
-        // physical rows.  As GetCharacterRegions returns *slightly* different
-        // float Y values frame-to-frame during a drag, Math.Floor on a value
-        // hovering near an integer can flip ±1 — that's the visible vertical
-        // shake the user perceives over heading text at 125/150%.
-        //   Snap formula: pick the physical pixel boundary (Floor for the
-        // leading edge, Ceiling for trailing) so the rect always lands on
-        // exact device pixels regardless of the floating-point noise.
+        // a DIP edge lands at a fractional physical pixel. The adorner uses the
+        // same snapped rectangles for background fill, clipping, diagnostics,
+        // and foreground overpaint so all selection pixels move together.
         double scale = XamlRoot?.RasterizationScale ?? 1.0;
         if (scale <= 0) scale = 1.0;
 
-        int poolIdx = 0;
+        _selectionAdornerRects.Clear();
         foreach (var rect in _selection.GetHighlightRects(snapshot))
         {
-            // Snap to physical pixel boundaries: convert to phys-px, snap, convert back.
             double pxX = Math.Floor(rect.X * scale);
             double pxY = Math.Floor(rect.Y * scale);
             double pxR = Math.Ceiling((rect.X + rect.Width) * scale);
@@ -1507,78 +1867,123 @@ public sealed partial class MarkdownRendererControl : UserControl
             double y = pxY / scale;
             double w = (pxR - pxX) / scale;
             double h = (pxB - pxY) / scale;
+            if (w <= 0 || h <= 0)
+                continue;
 
-            Rectangle r;
-            if (poolIdx < _selectionOverlayRects.Count)
-            {
-                // Reuse existing pooled rectangle — no Children mutation.
-                r = _selectionOverlayRects[poolIdx];
-            }
-            else
-            {
-                // Pool exhausted: allocate a new rectangle and add it once.
-                // UseLayoutRounding=true makes XAML itself snap the rect's
-                // final on-screen position to physical pixels as a belt-and-
-                // braces guard against any residual fractional offset.
-                r = new Rectangle { IsHitTestVisible = false, UseLayoutRounding = true };
-                // ZIndex -1 places it behind embedded controls (default ZIndex 0).
-                Canvas.SetZIndex(r, -1);
-                _overlay.Children.Add(r);
-                _selectionOverlayRects.Add(r);
-                // Log every pool-grow because Children.Add invalidates the
-                // overlay Canvas's measure, which in turn can ripple into a
-                // CanvasVirtualControl re-layout. If we see pool-grow events
-                // during a steady-state drag (not just the first stripe), the
-                // pool isn't being pre-warmed adequately.
-                MarkdownRenderer.Diagnostics.ShakeLogger.Log("sel-pool-grow",
-                    $"poolSize={_selectionOverlayRects.Count}");
-            }
+            _selectionAdornerRects.Add(new Rect(x, y, w, h));
 
-            r.Fill = _selectionBrush;
-            r.Width = w;
-            r.Height = h;
-            Canvas.SetLeft(r, x);
-            Canvas.SetTop(r, y);
-            r.Visibility = Visibility.Visible;
             // Diagnostic: log the *physical-pixel* coords for the first stripe
             // so we can verify they stay rock-stable across drag frames at
             // fractional DPI. If shake reappears these numbers will jitter.
-            if (poolIdx == 0)
+            if (_selectionAdornerRects.Count == 1)
             {
-                MarkdownRenderer.Diagnostics.ShakeLogger.LogPaint(
-                    "sel-rect-phys", -1, (float)(x * scale), (float)(y * scale),
-                    (float)(w * scale), (float)(h * scale));
+                if (ShakeLogger.IsEnabled)
+                    ShakeLogger.LogPaint(
+                        "sel-rect-phys", -1, (float)(x * scale), (float)(y * scale),
+                        (float)(w * scale), (float)(h * scale));
             }
-            poolIdx++;
         }
 
-        // Hide any remaining pooled rectangles beyond the current stripe count.
-        for (int i = poolIdx; i < _selectionOverlayRects.Count; i++)
-            _selectionOverlayRects[i].Visibility = Visibility.Collapsed;
+        EnsureSelectionAdorner();
+        UpdateSelectionAdornerViewport();
+        _selectionAdorner?.Invalidate();
     }
 
-    /// <summary>
-    /// Pre-populates the selection-highlight rectangle pool up to
-    /// <paramref name="count"/> stripes so the first drag gesture after a
-    /// document rebuild doesn't incur <c>Children.Add</c> overhead during
-    /// pointer-move events.  Callers should pass <c>blocks × 3</c> for a
-    /// full-document upper bound; 8 is kept as a safe default.
-    /// </summary>
-    private void PreWarmSelectionPool(int count = 8)
+    private void EnsureSelectionAdorner()
     {
-        if (_overlay is null) return;
-        for (int i = _selectionOverlayRects.Count; i < count; i++)
+        if (_overlay is null)
+            return;
+
+        if (_selectionAdorner is null)
         {
-            var r = new Rectangle
+            _selectionAdorner = new CanvasControl
             {
                 IsHitTestVisible = false,
                 UseLayoutRounding = true,
-                Visibility = Visibility.Collapsed,
             };
-            Canvas.SetZIndex(r, -1);
-            _overlay.Children.Add(r);
-            _selectionOverlayRects.Add(r);
+            _selectionAdorner.Draw += OnSelectionAdornerDraw;
+            Canvas.SetZIndex(_selectionAdorner, 0);
         }
+
+        if (VisualTreeHelper.GetParent(_selectionAdorner) is null)
+            _overlay.Children.Add(_selectionAdorner);
+    }
+
+    private void UpdateSelectionAdornerViewport()
+    {
+        if (_selectionAdorner is null)
+            return;
+
+        double width = Math.Max(1.0, _scroll?.ViewportWidth > 0 ? _scroll.ViewportWidth : ActualWidth);
+        double height = Math.Max(1.0, _scroll?.ViewportHeight > 0 ? _scroll.ViewportHeight : ActualHeight);
+        double top = _scroll?.VerticalOffset ?? 0.0;
+
+        if (double.IsNaN(_selectionAdorner.Width) || Math.Abs(_selectionAdorner.Width - width) > 0.5)
+            _selectionAdorner.Width = width;
+        if (double.IsNaN(_selectionAdorner.Height) || Math.Abs(_selectionAdorner.Height - height) > 0.5)
+            _selectionAdorner.Height = height;
+
+        double currentLeft = Canvas.GetLeft(_selectionAdorner);
+        if (double.IsNaN(currentLeft) || Math.Abs(currentLeft) > 0.1)
+            Canvas.SetLeft(_selectionAdorner, 0);
+
+        double currentTop = Canvas.GetTop(_selectionAdorner);
+        if (double.IsNaN(currentTop) || Math.Abs(currentTop - top) > 0.1)
+            Canvas.SetTop(_selectionAdorner, top);
+
+        _selectionAdornerOffsetY = top;
+    }
+
+    private void OnSelectionAdornerDraw(CanvasControl sender, CanvasDrawEventArgs args)
+    {
+        args.DrawingSession.Clear(Color.FromArgb(0, 0, 0, 0));
+
+        var snapshot = _snapshot;
+        if (snapshot is null || !_selection.IsActive || _selectionAdornerRects.Count == 0)
+            return;
+
+        if (ShakeLogger.IsEnabled)
+            ShakeLogger.Log("sel-adorner-draw",
+                $"rects={_selectionAdornerRects.Count} actual={sender.ActualWidth:0.####}x{sender.ActualHeight:0.####} size={sender.Width:0.####}x{sender.Height:0.####}");
+
+        var selectedBackground = _themeSnapshot?.SelectionHighlightColor
+                                 ?? Color.FromArgb(0xFF, 0x66, 0xAA, 0xE8);
+        var selectedForeground = _themeSnapshot?.SelectionForegroundColor
+                                 ?? Color.FromArgb(0xFF, 0xFF, 0xFF, 0xFF);
+        var range = _selection.Range.Normalized();
+        double yOffset = _selectionAdornerOffsetY;
+        var viewport = new Rect(0, yOffset, sender.ActualWidth, sender.ActualHeight);
+
+        args.DrawingSession.TextAntialiasing = Microsoft.Graphics.Canvas.Text.CanvasTextAntialiasing.Grayscale;
+        args.DrawingSession.Transform = Matrix3x2.CreateTranslation(0, (float)-yOffset);
+
+        // Native text controls effectively cover the old glyph pixels with the
+        // selection fill and then draw selected glyphs on top. Doing both in this
+        // adorner gives the same visual ordering without repainting document text.
+        foreach (var rect in _selectionAdornerRects)
+        {
+            if (rect.Right < viewport.Left || rect.Left > viewport.Right ||
+                rect.Bottom < viewport.Top || rect.Top > viewport.Bottom)
+            {
+                continue;
+            }
+
+            args.DrawingSession.FillRectangle(rect, selectedBackground);
+        }
+
+        foreach (var rect in _selectionAdornerRects)
+        {
+            if (rect.Right < viewport.Left || rect.Left > viewport.Right ||
+                rect.Bottom < viewport.Top || rect.Top > viewport.Bottom)
+            {
+                continue;
+            }
+
+            using var layer = args.DrawingSession.CreateLayer(1.0f, rect);
+            snapshot.PaintSelectionForeground(args.DrawingSession, range, selectedForeground, rect);
+        }
+
+        args.DrawingSession.Transform = Matrix3x2.Identity;
     }
 
     private void OnPointerCanceledOrCaptureLost(object sender, PointerRoutedEventArgs e)
@@ -1671,6 +2076,12 @@ public sealed partial class MarkdownRendererControl : UserControl
         _selectionAnchor = null;
         _canvas.ReleasePointerCapture(e.Pointer);
         if (!wasLeft) return;
+
+        if (!_selection.Range.Normalized().IsEmpty)
+        {
+            UpdateSelectionAdornerViewport();
+            _selectionAdorner?.Invalidate();
+        }
 
         // Click handling for links: if no real selection occurred, raise LinkClick
         // when the click lands on a LinkRun.
@@ -1782,8 +2193,7 @@ public sealed partial class MarkdownRendererControl : UserControl
         switch (e.Key)
         {
             case VirtualKey.C when ctrl && _selection.IsActive:
-                MarkdownClipboardWriter.Copy(_snapshot.SourceMap, _selection.Range);
-                e.Handled = true;
+                e.Handled = CopySelectionToClipboard();
                 return;
             case VirtualKey.A when ctrl:
                 _selection.SetAnchor(DocumentPosition.Zero);
@@ -1792,6 +2202,12 @@ public sealed partial class MarkdownRendererControl : UserControl
                 return;
             case VirtualKey.Tab:
                 e.Handled = MoveFocus(reverse: shift);
+                return;
+            case VirtualKey.Left:
+            case VirtualKey.Right:
+            case VirtualKey.Up:
+            case VirtualKey.Down:
+                e.Handled = MoveFocusSpatial(e.Key);
                 return;
             case VirtualKey.Enter:
             case VirtualKey.Space when _focusedItemIndex >= 0:
@@ -1822,31 +2238,123 @@ public sealed partial class MarkdownRendererControl : UserControl
         var items = _focusableItems;
         if (items is null || items.Count == 0) return false;
 
+        int nextIndex = FocusNavigationHelper.MoveTab(items.Count, _focusedItemIndex, _focusResumeItemIndex, reverse);
+        if (nextIndex < 0)
+        {
+            // Let Tab/Shift+Tab leave the control to the next focusable element.
+            _focusedItemIndex = -1;
+            _focusResumeItemIndex = -1;
+            UpdateFocusRing();
+            SuppressHostedTabStopsForNativeTab();
+            return false;
+        }
+
+        _focusedItemIndex = nextIndex;
+        _focusResumeItemIndex = -1;
+        return CommitFocusedItem(reverse);
+    }
+
+    private void SuppressHostedTabStopsForNativeTab()
+    {
+        var suppressed = new List<(Control Control, bool IsTabStop)>();
+        var seen = new HashSet<Control>();
+        foreach (var plan in _embedPlans)
+        {
+            if (plan.Realized is { } realized)
+                SuppressHostedTabStops(realized, suppressed, seen);
+        }
+
+        if (suppressed.Count == 0)
+            return;
+
+        DispatcherQueue.TryEnqueue(() =>
+        {
+            foreach (var (control, isTabStop) in suppressed)
+                control.IsTabStop = isTabStop;
+        });
+    }
+
+    private static void SuppressHostedTabStops(
+        DependencyObject root,
+        List<(Control Control, bool IsTabStop)> suppressed,
+        HashSet<Control> seen)
+    {
+        if (root is Control control && seen.Add(control))
+        {
+            suppressed.Add((control, control.IsTabStop));
+            control.IsTabStop = false;
+        }
+
+        int childCount = VisualTreeHelper.GetChildrenCount(root);
+        for (int i = 0; i < childCount; i++)
+        {
+            SuppressHostedTabStops(VisualTreeHelper.GetChild(root, i), suppressed, seen);
+        }
+    }
+
+    private bool MoveFocusSpatial(VirtualKey key)
+    {
+        var items = _focusableItems;
+        if (items is null || items.Count == 0) return false;
+
         if (_focusedItemIndex < 0)
         {
-            // No item is focused yet — enter focus cycling at the boundary.
-            _focusedItemIndex = reverse ? items.Count - 1 : 0;
+            if (_focusResumeItemIndex < 0) return false;
+            _focusedItemIndex = Math.Clamp(_focusResumeItemIndex, 0, items.Count - 1);
+            _focusResumeItemIndex = -1;
+            return CommitFocusedItem(reverse: false);
         }
-        else
+
+        var map = BuildFocusableRectMap();
+        int currentLocalIndex = -1;
+        for (int i = 0; i < map.Count; i++)
         {
-            // Already focused — check if we're at the exit boundary.
-            bool atEnd   = !reverse && _focusedItemIndex == items.Count - 1;
-            bool atStart = reverse  && _focusedItemIndex == 0;
-            if (atEnd || atStart)
+            if (map[i].Index == _focusedItemIndex)
             {
-                // Let Tab/Shift+Tab leave the control to the next focusable element.
-                _focusedItemIndex = -1;
-                UpdateFocusRing();
-                return false;
+                currentLocalIndex = i;
+                break;
             }
-            _focusedItemIndex = reverse ? _focusedItemIndex - 1 : _focusedItemIndex + 1;
         }
-        UpdateFocusRing();
-        ScrollFocusedItemIntoView();
+
+        if (currentLocalIndex < 0) return false;
+
+        var rects = new List<Rect>(map.Count);
+        foreach (var entry in map) rects.Add(entry.Rect);
+
+        var direction = key switch
+        {
+            VirtualKey.Left => Layout.FocusNavigationDirection.Left,
+            VirtualKey.Right => Layout.FocusNavigationDirection.Right,
+            VirtualKey.Up => Layout.FocusNavigationDirection.Up,
+            VirtualKey.Down => Layout.FocusNavigationDirection.Down,
+            _ => Layout.FocusNavigationDirection.Down,
+        };
+
+        int nextLocalIndex = FocusNavigationHelper.MoveSpatial(rects, currentLocalIndex, direction);
+        if (nextLocalIndex < 0) return false;
+
+        _focusedItemIndex = map[nextLocalIndex].Index;
+        _focusResumeItemIndex = -1;
+        return CommitFocusedItem(reverse: false);
+    }
+
+    private bool CommitFocusedItem(bool reverse)
+    {
+        bool scrolled = ScrollFocusedItemIntoView();
+        FocusCurrentItem(reverse);
+        if (scrolled)
+        {
+            DispatcherQueue.TryEnqueue(() =>
+            {
+                if (_isUnloaded) return;
+                RealizeVisibleEmbeds();
+                FocusCurrentItem(reverse);
+            });
+        }
         return true;
     }
 
-    /// <summary>Fires LinkClick or simulates click on an inline embed for the currently focused item.</summary>
+    /// <summary>Fires LinkClick for the currently focused painted link.</summary>
     private bool ActivateFocusedItem()
     {
         var items = _focusableItems;
@@ -1854,7 +2362,10 @@ public sealed partial class MarkdownRendererControl : UserControl
             return false;
 
         var item = items[_focusedItemIndex];
-        if (!item.IsLink) return false;
+        if (!item.IsLink)
+        {
+            return TryFocusHostedElement(item, reverse: false);
+        }
 
         // Find the LinkRun in the snapshot and fire LinkClick.
         if (_snapshot is null) return false;
@@ -1868,6 +2379,49 @@ public sealed partial class MarkdownRendererControl : UserControl
             return true;
         }
         return false;
+    }
+
+    private void FocusCurrentItem(bool reverse = false)
+    {
+        var items = _focusableItems;
+        if (items is null || _focusedItemIndex < 0 || _focusedItemIndex >= items.Count)
+        {
+            UpdateFocusRing();
+            return;
+        }
+
+        var item = items[_focusedItemIndex];
+        if (!item.IsLink && TryFocusHostedElement(item, reverse))
+        {
+            if (_focusRing is not null) _focusRing.Visibility = Visibility.Collapsed;
+            return;
+        }
+
+        Focus(FocusState.Keyboard);
+        UpdateFocusRing();
+        NotifyFocusedItemAutomation();
+    }
+
+    private void NotifyFocusedItemAutomation()
+    {
+        if (!TryGetFocusedLink(out var inline, out var link))
+            return;
+
+        void Raise()
+        {
+            var peer = FrameworkElementAutomationPeer.FromElement(this) as MarkdownAutomationPeer
+                       ?? FrameworkElementAutomationPeer.CreatePeerForElement(this) as MarkdownAutomationPeer;
+            peer?.RaiseFocusForLink(inline, link);
+        }
+
+        // Let WinUI finish the real focus transition to the renderer first,
+        // then publish the virtual hyperlink focus event. If we raise inside
+        // GotFocus, Narrator can observe the root document focus event last and
+        // announce the whole renderer instead of the focused painted link.
+        if (DispatcherQueue is { } dispatcher)
+            dispatcher.TryEnqueue(Raise);
+        else
+            Raise();
     }
 
     /// <summary>
@@ -1899,6 +2453,12 @@ public sealed partial class MarkdownRendererControl : UserControl
         }
 
         var item = items[_focusedItemIndex];
+        if (!item.IsLink)
+        {
+            _focusRing.Visibility = Visibility.Collapsed;
+            return;
+        }
+
         var rect = GetFocusableItemRect(item);
         if (rect is not { Width: > 0, Height: > 0 } r)
         {
@@ -1906,15 +2466,14 @@ public sealed partial class MarkdownRendererControl : UserControl
             return;
         }
 
-        // Style with accent color (use the link foreground, which is the accent).
-        var accent = _themeSnapshot?.GetStyle(MarkdownElementKeys.Link).Foreground
-                     ?? Windows.UI.Color.FromArgb(0xFF, 0x00, 0x78, 0xD4);
-        // Allocate a new SolidColorBrush only when the accent color actually changes;
+        var focusVisual = _themeSnapshot?.FocusVisualColor
+                          ?? Windows.UI.Color.FromArgb(0xFF, 0x00, 0x78, 0xD4);
+        // Allocate a new SolidColorBrush only when the focus color actually changes;
         // avoid per-keystroke GC pressure during Tab traversal.
-        if (_focusRing.BorderBrush is null || accent != _focusRingBrushColor)
+        if (_focusRing.BorderBrush is null || focusVisual != _focusRingBrushColor)
         {
-            _focusRingBrushColor = accent;
-            _focusRing.BorderBrush = new SolidColorBrush(accent);
+            _focusRingBrushColor = focusVisual;
+            _focusRing.BorderBrush = new SolidColorBrush(focusVisual);
         }
 
         const double pad = 2.0;
@@ -1938,8 +2497,47 @@ public sealed partial class MarkdownRendererControl : UserControl
         return null;
     }
 
+    private void RememberFocusResumePoint(Point documentPoint)
+    {
+        var map = BuildFocusableRectMap();
+        if (map.Count == 0)
+        {
+            _focusResumeItemIndex = -1;
+            return;
+        }
+
+        var rects = new List<Rect>(map.Count);
+        foreach (var entry in map) rects.Add(entry.Rect);
+
+        int nearest = FocusNavigationHelper.FindNearestIndex(rects, documentPoint);
+        _focusResumeItemIndex = nearest >= 0 ? map[nearest].Index : -1;
+    }
+
+    private List<(int Index, Rect Rect)> BuildFocusableRectMap()
+    {
+        var result = new List<(int Index, Rect Rect)>();
+        var items = _focusableItems;
+        if (items is null) return result;
+
+        for (int i = 0; i < items.Count; i++)
+        {
+            if (GetFocusableItemRect(items[i]) is { Width: > 0, Height: > 0 } rect)
+                result.Add((i, rect));
+        }
+
+        return result;
+    }
+
     private static Rect? GetFocusableItemRectFromBlock(BlockBox box, Layout.FocusableItem item)
     {
+        if (box is Layout.Boxes.EmbedBox eb && eb.BlockIndex == item.BlockIndex)
+        {
+            return new Rect(
+                eb.Bounds.X + eb.Margin.Left,
+                eb.Bounds.Y + eb.Margin.Top,
+                eb.Bounds.Width - eb.Margin.Left - eb.Margin.Right,
+                eb.Bounds.Height - eb.Margin.Top - eb.Margin.Bottom);
+        }
         if (box is Layout.Boxes.InlineContainerBox icb && icb.BlockIndex == item.BlockIndex)
             return icb.GetRunRect(item.InlineIndex);
         if (box is Layout.Boxes.ListItemBox lib)
@@ -1967,21 +2565,211 @@ public sealed partial class MarkdownRendererControl : UserControl
     }
 
     /// <summary>Scrolls the focused item into view if it's outside the current viewport.</summary>
-    private void ScrollFocusedItemIntoView()
+    private bool ScrollFocusedItemIntoView()
     {
         var items = _focusableItems;
-        if (items is null || _focusedItemIndex < 0 || _scroll is null) return;
+        if (items is null || _focusedItemIndex < 0 || _scroll is null) return false;
         var item = items[_focusedItemIndex];
-        if (GetFocusableItemRect(item) is not { } rect) return;
+        if (GetFocusableItemRect(item) is not { } rect) return false;
 
         double top    = _scroll.VerticalOffset;
         double bottom = top + _scroll.ViewportHeight;
         const double margin = 24.0;
 
         if (rect.Top < top + margin)
-            _scroll.ChangeView(null, Math.Max(0, rect.Top - margin), null, disableAnimation: false);
+            return _scroll.ChangeView(null, Math.Max(0, rect.Top - margin), null, disableAnimation: false);
         else if (rect.Bottom > bottom - margin)
-            _scroll.ChangeView(null, rect.Bottom - _scroll.ViewportHeight + margin, null, disableAnimation: false);
+            return _scroll.ChangeView(null, rect.Bottom - _scroll.ViewportHeight + margin, null, disableAnimation: false);
+
+        return false;
+    }
+
+    private bool TryFocusHostedElement(Layout.FocusableItem item, bool reverse)
+    {
+        if (FindHostedElementForFocusable(item) is not { } element)
+            return false;
+
+        if (TryFocusHostedDescendant(element, reverse))
+            return true;
+
+        return element.Focus(FocusState.Keyboard);
+    }
+
+    private static bool TryMoveFocusWithinHostedEmbed(FrameworkElement host, object originalSource, bool reverse)
+    {
+        var focusables = CollectHostedFocusableControls(host);
+        if (focusables.Count <= 1)
+            return false;
+
+        var current = FindCurrentHostedFocusable(host, originalSource, focusables);
+        if (current is null)
+            return false;
+
+        int index = focusables.IndexOf(current);
+        if (index < 0)
+            return false;
+
+        int next = reverse ? index - 1 : index + 1;
+        if (next < 0 || next >= focusables.Count)
+            return false;
+
+        return focusables[next].Focus(FocusState.Keyboard);
+    }
+
+    private static bool TryFocusHostedDescendant(FrameworkElement host, bool reverse)
+    {
+        var focusables = CollectHostedFocusableControls(host);
+        if (focusables.Count == 0)
+            return false;
+
+        var target = reverse ? focusables[^1] : focusables[0];
+        return target.Focus(FocusState.Keyboard);
+    }
+
+    private static Control? FindCurrentHostedFocusable(
+        FrameworkElement host,
+        object originalSource,
+        IReadOnlyList<Control> focusables)
+    {
+        DependencyObject? focused = null;
+        try
+        {
+            if (host.XamlRoot is not null)
+                focused = FocusManager.GetFocusedElement(host.XamlRoot) as DependencyObject;
+        }
+        catch
+        {
+        }
+
+        var current = FindFocusableAncestorWithin(host, focused);
+        if (current is not null && ContainsHostedFocusable(focusables, current))
+            return current;
+
+        current = FindFocusableAncestorWithin(host, originalSource as DependencyObject);
+        return current is not null && ContainsHostedFocusable(focusables, current) ? current : null;
+    }
+
+    private static bool ContainsHostedFocusable(IReadOnlyList<Control> focusables, Control control)
+    {
+        for (int i = 0; i < focusables.Count; i++)
+        {
+            if (ReferenceEquals(focusables[i], control))
+                return true;
+        }
+
+        return false;
+    }
+
+    private static Control? FindFocusableAncestorWithin(FrameworkElement host, DependencyObject? node)
+    {
+        while (node is not null)
+        {
+            if (ReferenceEquals(node, host))
+                return node is Control hostControl && IsHostedFocusableControl(hostControl) ? hostControl : null;
+
+            if (node is Control control && IsHostedFocusableControl(control))
+                return control;
+
+            DependencyObject? parent = null;
+            try { parent = VisualTreeHelper.GetParent(node); }
+            catch { }
+            node = parent;
+        }
+
+        return null;
+    }
+
+    private static List<Control> CollectHostedFocusableControls(DependencyObject root)
+    {
+        var result = new List<Control>();
+        CollectHostedFocusableControls(root, result);
+        return result;
+    }
+
+    private static void CollectHostedFocusableControls(DependencyObject node, List<Control> result)
+    {
+        if (node is Control control && IsHostedFocusableControl(control))
+            result.Add(control);
+
+        int childCount;
+        try { childCount = VisualTreeHelper.GetChildrenCount(node); }
+        catch { return; }
+
+        for (int i = 0; i < childCount; i++)
+        {
+            DependencyObject child;
+            try { child = VisualTreeHelper.GetChild(node, i); }
+            catch { continue; }
+            CollectHostedFocusableControls(child, result);
+        }
+    }
+
+    private static bool IsHostedFocusableControl(Control control) =>
+        control.Visibility == Visibility.Visible &&
+        control.IsEnabled &&
+        control.IsTabStop;
+
+    private FrameworkElement? FindHostedElementForFocusable(Layout.FocusableItem item)
+    {
+        if (_snapshot is null) return null;
+        foreach (var block in _snapshot.Blocks)
+        {
+            var found = FindHostedElementForFocusable(block, item);
+            if (found is not null) return found;
+        }
+
+        return null;
+    }
+
+    private bool TrySetFocusedItemForHostedElement(FrameworkElement element)
+    {
+        var items = _focusableItems;
+        if (items is null) return false;
+        for (int i = 0; i < items.Count; i++)
+        {
+            if (ReferenceEquals(FindHostedElementForFocusable(items[i]), element))
+            {
+                _focusedItemIndex = i;
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static FrameworkElement? FindHostedElementForFocusable(BlockBox box, Layout.FocusableItem item)
+    {
+        switch (box)
+        {
+            case Layout.Boxes.EmbedBox eb when item.IsBlockEmbed && eb.BlockIndex == item.BlockIndex:
+                return eb.RealizedElement;
+            case Layout.Boxes.InlineContainerBox icb when item.IsInlineEmbed && icb.BlockIndex == item.BlockIndex:
+                foreach (var run in icb.Runs)
+                {
+                    if (run.InlineIndex == item.InlineIndex && run is InlineEmbedRun embed)
+                        return embed.RealizedElement;
+                }
+                return null;
+            case Layout.Boxes.ListItemBox lib:
+                return FindHostedElementForFocusable(lib.Marker, item)
+                       ?? FindHostedElementForFocusable(lib.Content, item);
+            case Layout.Boxes.TableBox tb:
+                foreach (var cell in tb.GetCellBoxes())
+                {
+                    var found = FindHostedElementForFocusable(cell, item);
+                    if (found is not null) return found;
+                }
+                return null;
+            case Layout.Boxes.StackBox sb:
+                foreach (var child in sb.Children)
+                {
+                    var found = FindHostedElementForFocusable(child, item);
+                    if (found is not null) return found;
+                }
+                return null;
+            default:
+                return null;
+        }
     }
 
     private LinkRun? FindLinkAt(DocumentPosition pos)
@@ -1992,6 +2780,100 @@ public sealed partial class MarkdownRendererControl : UserControl
             if (FindLinkInBlock(b, pos) is { } found) return found;
         }
         return null;
+    }
+
+    private bool TryGetFocusedLink(out Layout.Boxes.InlineContainerBox inline, out LinkRun link)
+    {
+        inline = null!;
+        link = null!;
+
+        var items = _focusableItems;
+        if (items is null || _focusedItemIndex < 0 || _focusedItemIndex >= items.Count)
+            return false;
+
+        return TryGetLinkForFocusable(items[_focusedItemIndex], out inline, out link);
+    }
+
+    private bool TryGetFocusableIndexForLink(LinkRun run, out int index)
+    {
+        index = -1;
+        var items = _focusableItems;
+        if (items is null) return false;
+
+        for (int i = 0; i < items.Count; i++)
+        {
+            if (!items[i].IsLink)
+                continue;
+
+            if (TryGetLinkForFocusable(items[i], out _, out var link) &&
+                ReferenceEquals(link, run))
+            {
+                index = i;
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private bool TryGetLinkForFocusable(Layout.FocusableItem item, out Layout.Boxes.InlineContainerBox inline, out LinkRun link)
+    {
+        inline = null!;
+        link = null!;
+        if (!item.IsLink || _snapshot is null)
+            return false;
+
+        foreach (var b in _snapshot.Blocks)
+        {
+            if (TryGetLinkForFocusable(b, item, out inline, out link))
+                return true;
+        }
+
+        return false;
+    }
+
+    private static bool TryGetLinkForFocusable(
+        BlockBox box,
+        Layout.FocusableItem item,
+        out Layout.Boxes.InlineContainerBox inline,
+        out LinkRun link)
+    {
+        inline = null!;
+        link = null!;
+
+        switch (box)
+        {
+            case Layout.Boxes.InlineContainerBox icb when icb.BlockIndex == item.BlockIndex:
+                foreach (var r in icb.Runs)
+                {
+                    if (r.InlineIndex == item.InlineIndex && r is LinkRun lr)
+                    {
+                        inline = icb;
+                        link = lr;
+                        return true;
+                    }
+                }
+                return false;
+            case Layout.Boxes.ListItemBox lib:
+                return TryGetLinkForFocusable(lib.Marker, item, out inline, out link)
+                       || TryGetLinkForFocusable(lib.Content, item, out inline, out link);
+            case Layout.Boxes.TableBox tb:
+                foreach (var cell in tb.GetCellBoxes())
+                {
+                    if (TryGetLinkForFocusable(cell, item, out inline, out link))
+                        return true;
+                }
+                return false;
+            case Layout.Boxes.StackBox sb:
+                foreach (var c in sb.Children)
+                {
+                    if (TryGetLinkForFocusable(c, item, out inline, out link))
+                        return true;
+                }
+                return false;
+            default:
+                return false;
+        }
     }
 
     // ---- Word / line selection helpers ----
@@ -2087,17 +2969,18 @@ public sealed partial class MarkdownRendererControl : UserControl
         if (_canvas is null) return;
         var pt = e.GetPosition(_canvas);
         var menu = new MenuFlyout();
+        _contextMenuOpen = true;
+        menu.Closed += (_, _) => _contextMenuOpen = false;
 
-        var copyItem = new MenuFlyoutItem { Text = "Copy" };
+        var copyItem = new MenuFlyoutItem { Text = MarkdownLocalizedStrings.ContextMenuCopy };
         copyItem.IsEnabled = _selection.IsActive;
         copyItem.Click += (_, _) =>
         {
-            if (_snapshot is not null && _selection.IsActive)
-                MarkdownClipboardWriter.Copy(_snapshot.SourceMap, _selection.Range);
+            CopySelectionToClipboard();
         };
         menu.Items.Add(copyItem);
 
-        var selectAllItem = new MenuFlyoutItem { Text = "Select All" };
+        var selectAllItem = new MenuFlyoutItem { Text = MarkdownLocalizedStrings.ContextMenuSelectAll };
         selectAllItem.IsEnabled = IsSelectionEnabled;
         selectAllItem.Click += (_, _) =>
         {

--- a/MarkdownRenderer/MarkdownRenderer/Controls/MarkdownSystemIntegration.cs
+++ b/MarkdownRenderer/MarkdownRenderer/Controls/MarkdownSystemIntegration.cs
@@ -1,0 +1,160 @@
+using System;
+using System.Runtime.CompilerServices;
+using Microsoft.UI.Xaml;
+using Windows.ApplicationModel.Resources.Core;
+using Windows.Foundation.Collections;
+
+namespace MarkdownRenderer.Controls;
+
+/// <summary>
+/// Helpers for matching WinUI system integration behavior around layout direction.
+/// </summary>
+public static class MarkdownSystemIntegration
+{
+    public static readonly DependencyProperty UseSystemFlowDirectionProperty =
+        DependencyProperty.RegisterAttached(
+            "UseSystemFlowDirection",
+            typeof(bool),
+            typeof(MarkdownSystemIntegration),
+            new PropertyMetadata(false, OnUseSystemFlowDirectionChanged));
+
+    private static readonly ConditionalWeakTable<FrameworkElement, LayoutDirectionSubscription> _subscriptions = new();
+
+    public static bool GetUseSystemFlowDirection(FrameworkElement element) =>
+        (bool)element.GetValue(UseSystemFlowDirectionProperty);
+
+    public static void SetUseSystemFlowDirection(FrameworkElement element, bool value) =>
+        element.SetValue(UseSystemFlowDirectionProperty, value);
+
+    public static void ApplySystemFlowDirection(FrameworkElement element)
+    {
+        if (element is null) throw new ArgumentNullException(nameof(element));
+        element.FlowDirection = GetSystemFlowDirection();
+    }
+
+    public static FlowDirection GetSystemFlowDirection()
+    {
+        try
+        {
+            var qualifiers = ResourceManager.Current.DefaultContext.QualifierValues;
+            if ((qualifiers.TryGetValue("LayoutDirection", out var value) ||
+                 qualifiers.TryGetValue("LAYOUTDIRECTION", out value)) &&
+                TryParseLayoutDirection(value, out var flowDirection))
+            {
+                return flowDirection;
+            }
+        }
+        catch { }
+
+        return FlowDirection.LeftToRight;
+    }
+
+    internal static bool TryParseLayoutDirection(string? qualifier, out FlowDirection flowDirection)
+    {
+        if (string.Equals(qualifier, "RTL", StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(qualifier, "RightToLeft", StringComparison.OrdinalIgnoreCase))
+        {
+            flowDirection = FlowDirection.RightToLeft;
+            return true;
+        }
+
+        if (string.Equals(qualifier, "LTR", StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(qualifier, "LeftToRight", StringComparison.OrdinalIgnoreCase))
+        {
+            flowDirection = FlowDirection.LeftToRight;
+            return true;
+        }
+
+        flowDirection = FlowDirection.LeftToRight;
+        return false;
+    }
+
+    private static void OnUseSystemFlowDirectionChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+    {
+        if (d is not FrameworkElement element) return;
+
+        if (e.NewValue is true)
+        {
+            var subscription = _subscriptions.GetValue(element, static key => new LayoutDirectionSubscription(key));
+            subscription.Attach();
+        }
+        else if (_subscriptions.TryGetValue(element, out var subscription))
+        {
+            subscription.Detach();
+            _subscriptions.Remove(element);
+        }
+    }
+
+    private sealed class LayoutDirectionSubscription
+    {
+        private readonly FrameworkElement _element;
+        private ResourceContext? _context;
+        private MapChangedEventHandler<string, string>? _handler;
+        private bool _attached;
+
+        public LayoutDirectionSubscription(FrameworkElement element)
+        {
+            _element = element;
+        }
+
+        public void Attach()
+        {
+            if (_attached) return;
+            _attached = true;
+            _element.Loaded += OnLoaded;
+            _element.Unloaded += OnUnloaded;
+            if (_element.IsLoaded) OnLoaded(_element, new RoutedEventArgs());
+        }
+
+        public void Detach()
+        {
+            _element.Loaded -= OnLoaded;
+            _element.Unloaded -= OnUnloaded;
+            Unsubscribe();
+            _attached = false;
+        }
+
+        private void OnLoaded(object sender, RoutedEventArgs e)
+        {
+            ApplySystemFlowDirection(_element);
+            try
+            {
+                _context = ResourceManager.Current.DefaultContext;
+                _handler = (_, _) => EnqueueApply();
+                _context.QualifierValues.MapChanged += _handler;
+            }
+            catch { }
+        }
+
+        private void OnUnloaded(object sender, RoutedEventArgs e) => Unsubscribe();
+
+        private void Unsubscribe()
+        {
+            if (_context is not null && _handler is not null)
+            {
+                try { _context.QualifierValues.MapChanged -= _handler; }
+                catch { }
+            }
+
+            _context = null;
+            _handler = null;
+        }
+
+        private void EnqueueApply()
+        {
+            var dispatcher = _element.DispatcherQueue;
+            if (dispatcher is null) return;
+            if (dispatcher.HasThreadAccess)
+            {
+                if (_element.IsLoaded) ApplySystemFlowDirection(_element);
+            }
+            else
+            {
+                dispatcher.TryEnqueue(() =>
+                {
+                    if (_element.IsLoaded) ApplySystemFlowDirection(_element);
+                });
+            }
+        }
+    }
+}

--- a/MarkdownRenderer/MarkdownRenderer/Diagnostics/MarkdownDiagnostics.cs
+++ b/MarkdownRenderer/MarkdownRenderer/Diagnostics/MarkdownDiagnostics.cs
@@ -1,0 +1,13 @@
+using System.Diagnostics;
+
+namespace MarkdownRenderer.Diagnostics;
+
+internal static class MarkdownDiagnostics
+{
+    [Conditional("DEBUG")]
+    public static void WriteLine(string message)
+    {
+        if (ShakeLogger.IsEnabled)
+            Debug.WriteLine(message);
+    }
+}

--- a/MarkdownRenderer/MarkdownRenderer/Diagnostics/ShakeLogger.cs
+++ b/MarkdownRenderer/MarkdownRenderer/Diagnostics/ShakeLogger.cs
@@ -11,23 +11,41 @@ namespace MarkdownRenderer.Diagnostics;
 /// Ultra-low-overhead diagnostic logger used to investigate the "selection
 /// shake" bug. Producers enqueue value tuples on the UI thread; a single
 /// background drain task flushes them to a file and via Debug.WriteLine.
-/// Disabled by default — enable via <see cref="Enabled"/> from the sample app.
+/// Disabled by default. Enable via <see cref="Enabled"/> or the
+/// MARKDOWN_RENDERER_DIAGNOSTICS / MARKDOWN_RENDERER_SHAKE_LOG environment
+/// variables when collecting diagnostics.
 /// </summary>
 public static class ShakeLogger
 {
     private static readonly ConcurrentQueue<string> _queue = new();
     private static int _started;
     private static long _frame;
+    private static volatile bool _enabled = IsEnabledFromEnvironment();
+
+    public const string DiagnosticsEnvironmentVariable = "MARKDOWN_RENDERER_DIAGNOSTICS";
+    public const string ShakeLogEnvironmentVariable = "MARKDOWN_RENDERER_SHAKE_LOG";
 
     // Log file written to the repo root next to text_shaking.log
     private static readonly string LogPath = Path.Combine(
         AppContext.BaseDirectory,
         @"..\..\..\..\..\..\..\text_shaking2.log");
 
-    public static volatile bool Enabled;
+    public static bool Enabled
+    {
+        get => _enabled;
+        set => _enabled = value;
+    }
 
-    public static long NextFrame() => Interlocked.Increment(ref _frame);
+    public static bool IsEnabled => _enabled;
+
+    public static long NextFrame() => IsEnabled ? Interlocked.Increment(ref _frame) : 0;
     public static long CurrentFrame => Interlocked.Read(ref _frame);
+
+    public static bool ConfigureFromEnvironment()
+    {
+        Enabled = IsEnabledFromEnvironment();
+        return Enabled;
+    }
 
     public static void Log(string tag, string payload)
     {
@@ -49,6 +67,20 @@ public static class ShakeLogger
     {
         if (Interlocked.Exchange(ref _started, 1) == 1) return;
         Task.Run(DrainLoopAsync);
+    }
+
+    private static bool IsEnabledFromEnvironment()
+        => IsTruthy(Environment.GetEnvironmentVariable(DiagnosticsEnvironmentVariable))
+           || IsTruthy(Environment.GetEnvironmentVariable(ShakeLogEnvironmentVariable));
+
+    private static bool IsTruthy(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value)) return false;
+        return value.Trim().ToLowerInvariant() switch
+        {
+            "1" or "true" or "yes" or "on" => true,
+            _ => false,
+        };
     }
 
     private static async Task DrainLoopAsync()

--- a/MarkdownRenderer/MarkdownRenderer/Layout/BlockBox.cs
+++ b/MarkdownRenderer/MarkdownRenderer/Layout/BlockBox.cs
@@ -64,6 +64,19 @@ public abstract class BlockBox
     }
 
     /// <summary>
+    /// Repaints foreground chrome that would otherwise be covered by the
+    /// opaque native selection fill. Text containers repaint glyphs; visual
+    /// blocks such as thematic breaks repaint their separator line.
+    /// </summary>
+    public virtual void PaintSelectionForeground(
+        CanvasDrawingSession ds,
+        Document.DocumentRange range,
+        Windows.UI.Color color,
+        Rect viewport)
+    {
+    }
+
+    /// <summary>
     /// Releases native resources held by this box (e.g. <c>CanvasTextLayout</c>
     /// handles).  Containers must recurse into their children.  Called when
     /// a snapshot is replaced or the control unloads.

--- a/MarkdownRenderer/MarkdownRenderer/Layout/Boxes/ImageBox.cs
+++ b/MarkdownRenderer/MarkdownRenderer/Layout/Boxes/ImageBox.cs
@@ -7,6 +7,7 @@ using Microsoft.Graphics.Canvas;
 using Microsoft.Graphics.Canvas.Text;
 using Microsoft.UI.Xaml;
 using Windows.Foundation;
+using MarkdownRenderer.Diagnostics;
 using MarkdownRenderer.Document;
 using MarkdownRenderer.Theming;
 
@@ -173,7 +174,7 @@ public sealed class ImageBox : BlockBox
                 catch (Exception ex)
                 {
                     // Device-lost or similar — fall through to async re-rasterize.
-                    System.Diagnostics.Debug.WriteLine(
+                    MarkdownDiagnostics.WriteLine(
                         $"[ImageBox] cache-hit CanvasBitmap.CreateFromBytes failed: {ex.Message}");
                 }
             }
@@ -401,7 +402,7 @@ public sealed class ImageBox : BlockBox
         }
         catch (Exception ex)
         {
-            System.Diagnostics.Debug.WriteLine($"[ImageBox] bitmap load failed for {uri}: {ex.Message}");
+            MarkdownDiagnostics.WriteLine($"[ImageBox] bitmap load failed for {uri}: {ex.Message}");
             failed = true;
         }
         PublishOnUiThread(() =>
@@ -440,7 +441,7 @@ public sealed class ImageBox : BlockBox
             response.EnsureSuccessStatusCode();
             if (response.Content.Headers.ContentLength > MaxSvgBytes)
             {
-                System.Diagnostics.Debug.WriteLine(
+                MarkdownDiagnostics.WriteLine(
                     $"[ImageBox] SVG at {uri} Content-Length={response.Content.Headers.ContentLength} exceeds {MaxSvgBytes} bytes; skipping.");
                 failed = true;
             }
@@ -453,7 +454,7 @@ public sealed class ImageBox : BlockBox
                     read += chunk;
                 if (read > MaxSvgBytes)
                 {
-                    System.Diagnostics.Debug.WriteLine(
+                    MarkdownDiagnostics.WriteLine(
                         $"[ImageBox] SVG at {uri} exceeded {MaxSvgBytes} bytes mid-stream; skipping.");
                     failed = true;
                 }
@@ -465,7 +466,7 @@ public sealed class ImageBox : BlockBox
         }
         catch (Exception ex)
         {
-            System.Diagnostics.Debug.WriteLine($"[ImageBox] svg fetch failed for {uri}: {ex.Message}");
+            MarkdownDiagnostics.WriteLine($"[ImageBox] svg fetch failed for {uri}: {ex.Message}");
             failed = true;
         }
 
@@ -501,7 +502,7 @@ public sealed class ImageBox : BlockBox
                     : System.Text.Encoding.UTF8.GetBytes(Uri.UnescapeDataString(payload));
                 if (rawBytes.Length > MaxSvgBytes)
                 {
-                    System.Diagnostics.Debug.WriteLine(
+                    MarkdownDiagnostics.WriteLine(
                         $"[ImageBox] SVG data URI exceeds {MaxSvgBytes} bytes; skipping.");
                     rawBytes = null;
                     failed = true;
@@ -510,7 +511,7 @@ public sealed class ImageBox : BlockBox
         }
         catch (Exception ex)
         {
-            System.Diagnostics.Debug.WriteLine($"[ImageBox] svg data uri decode failed: {ex.Message}");
+            MarkdownDiagnostics.WriteLine($"[ImageBox] svg data uri decode failed: {ex.Message}");
             failed = true;
         }
 
@@ -607,7 +608,7 @@ public sealed class ImageBox : BlockBox
                 }
                 catch (Exception ex)
                 {
-                    System.Diagnostics.Debug.WriteLine(
+                    MarkdownDiagnostics.WriteLine(
                         $"[ImageBox] CanvasBitmap.CreateFromBytes failed: {ex.Message}");
                     _loadFailed = true;
                     if (!string.IsNullOrEmpty(_url)) { _failedUrls.TryAdd(_url, 0); TrimCache(_failedUrls, MaxFailedUrlEntries); }

--- a/MarkdownRenderer/MarkdownRenderer/Layout/Boxes/InlineContainerBox.cs
+++ b/MarkdownRenderer/MarkdownRenderer/Layout/Boxes/InlineContainerBox.cs
@@ -5,6 +5,7 @@ using Microsoft.Graphics.Canvas.Text;
 using Microsoft.UI.Xaml;
 using Windows.Foundation;
 using Windows.UI;
+using MarkdownRenderer.Diagnostics;
 using MarkdownRenderer.Document;
 using MarkdownRenderer.Theming;
 
@@ -20,6 +21,9 @@ public sealed class InlineContainerBox : BlockBox
     private readonly List<InlineRun> _runs = new();
     private readonly string _elementKey;
     private CanvasTextLayout? _layout;
+    private CanvasTextLayout? _selectionLayout;
+    private Color _selectionLayoutColor;
+    private float _selectionLayoutWidth;
     private string _buffer = string.Empty;
     private bool _bufferDirty;
     private float _lastWidth;
@@ -41,6 +45,7 @@ public sealed class InlineContainerBox : BlockBox
 
     public IReadOnlyList<InlineRun> Runs => _runs;
     public string ElementKey => _elementKey;
+    public string? CodeLanguage { get; init; }
 
     public InlineContainerBox(MarkdownLayoutContext context, string elementKey)
     {
@@ -149,6 +154,8 @@ public sealed class InlineContainerBox : BlockBox
             if (_bufferDirty) BuildBuffer();
             _layout?.Dispose();
             _layout = null; // null immediately so a layout-creation exception leaves _layout=null (safe for next Measure)
+            _selectionLayout?.Dispose();
+            _selectionLayout = null;
             using var format = new CanvasTextFormat
             {
                 FontFamily = style.FontFamily,
@@ -172,7 +179,7 @@ public sealed class InlineContainerBox : BlockBox
             {
                 // Enable DirectWrite color font path (Segoe UI Emoji / COLR-CPAL glyphs).
                 _layout.Options = CanvasDrawTextOptions.EnableColorFont;
-                ApplyRunStyles(_layout);
+                ApplyRunStyles(_layout, applyColors: true);
                 ApplyEmbedSpacing(_layout);
             }
             catch
@@ -244,13 +251,15 @@ public sealed class InlineContainerBox : BlockBox
         // for the rationale; the same snapped origin is used for hit-test,
         // selection rects and embed placement so they stay in sync.
         var (sx, sy) = GetSnappedOrigin(style);
-        MarkdownRenderer.Diagnostics.ShakeLogger.LogPaint(
-            "inline-paint",
-            BlockIndex,
-            sx,
-            sy,
-            _layout.LayoutBounds.Width,
-            _layout.LayoutBounds.Height);
+        if (ShakeLogger.IsEnabled)
+            ShakeLogger.LogPaint(
+                "inline-paint",
+                BlockIndex,
+                sx,
+                sy,
+                _layout.LayoutBounds.Width,
+                _layout.LayoutBounds.Height);
+        DrawRunBackgrounds(ds, sx, sy);
         ds.DrawTextLayout(_layout, sx, sy, style.Foreground);
 
         DrawDecorations(ds, sx, sy);
@@ -330,6 +339,32 @@ public sealed class InlineContainerBox : BlockBox
 
     public override IEnumerable<Rect> GetSelectionRects(DocumentRange range)
         => GetRangeRects(range);
+
+    public override void PaintSelectionForeground(CanvasDrawingSession ds, DocumentRange range, Color color, Rect viewport)
+    {
+        if (_layout is null) return;
+
+        bool intersectsSelection = false;
+        foreach (var rect in GetRangeRects(range))
+        {
+            if (rect.Right < viewport.Left || rect.Left > viewport.Right ||
+                rect.Bottom < viewport.Top || rect.Top > viewport.Bottom)
+            {
+                continue;
+            }
+
+            intersectsSelection = true;
+            break;
+        }
+
+        if (!intersectsSelection) return;
+
+        var style = _context.ThemeSnapshot.GetStyle(_elementKey);
+        var (sx, sy) = GetSnappedOrigin(style);
+        var layout = EnsureSelectionLayout(color, style);
+        ds.DrawTextLayout(layout, sx, sy, color);
+        DrawDecorations(ds, sx, sy, color);
+    }
 
     /// <summary>
     /// Returns the bounding rectangle in document coordinates for the run at
@@ -449,6 +484,8 @@ public sealed class InlineContainerBox : BlockBox
     {
         _layout?.Dispose();
         _layout = null;
+        _selectionLayout?.Dispose();
+        _selectionLayout = null;
     }
 
     private void BuildBuffer()
@@ -459,7 +496,7 @@ public sealed class InlineContainerBox : BlockBox
         _bufferDirty = false;
     }
 
-    private void ApplyRunStyles(CanvasTextLayout layout)
+    private void ApplyRunStyles(CanvasTextLayout layout, bool applyColors)
     {
         var containerStyle = _context.ThemeSnapshot.GetStyle(_elementKey);
         int cumulative = 0;
@@ -478,11 +515,53 @@ public sealed class InlineContainerBox : BlockBox
                     layout.SetFontStyle(cumulative, len, rs.FontStyle);
                 if (rs.FontSize != containerStyle.FontSize)
                     layout.SetFontSize(cumulative, len, rs.FontSize);
-                if (rs.Foreground != containerStyle.Foreground)
+                if (applyColors && rs.Foreground != containerStyle.Foreground)
                     layout.SetColor(cumulative, len, rs.Foreground);
             }
             cumulative += len;
         }
+    }
+
+    private CanvasTextLayout EnsureSelectionLayout(Color color, ElementStyle style)
+    {
+        EnsureBuffer();
+        if (_selectionLayout is not null &&
+            _selectionLayoutColor == color &&
+            Math.Abs(_selectionLayoutWidth - _lastWidth) <= 0.5f)
+        {
+            return _selectionLayout;
+        }
+
+        _selectionLayout?.Dispose();
+        _selectionLayout = null;
+
+        using var format = new CanvasTextFormat
+        {
+            FontFamily = style.FontFamily,
+            FontSize = style.FontSize,
+            FontWeight = style.FontWeight,
+            FontStyle = style.FontStyle,
+            WordWrapping = CanvasWordWrapping.Wrap,
+            LineSpacingMode = CanvasLineSpacingMode.Default,
+            Direction = _context.FlowDirection == FlowDirection.RightToLeft
+                ? CanvasTextDirection.RightToLeftThenTopToBottom
+                : CanvasTextDirection.LeftToRightThenTopToBottom,
+        };
+        float horizontalPadding = (float)(style.Padding.Left + style.Padding.Right);
+        _selectionLayout = new CanvasTextLayout(
+            _context.ResourceCreator,
+            _buffer,
+            format,
+            Math.Max(1f, _lastWidth - horizontalPadding),
+            float.MaxValue);
+        _selectionLayout.Options = CanvasDrawTextOptions.EnableColorFont;
+        ApplyRunStyles(_selectionLayout, applyColors: false);
+        if (_buffer.Length > 0)
+            _selectionLayout.SetColor(0, _buffer.Length, color);
+        ApplyEmbedSpacing(_selectionLayout);
+        _selectionLayoutColor = color;
+        _selectionLayoutWidth = _lastWidth;
+        return _selectionLayout;
     }
 
     private void ApplyEmbedSpacing(CanvasTextLayout layout)
@@ -499,7 +578,7 @@ public sealed class InlineContainerBox : BlockBox
                 }
                 catch (Exception ex)
                 {
-                    System.Diagnostics.Debug.WriteLine($"[InlineContainerBox] SetCharacterSpacing failed: {ex.Message}");
+                    MarkdownDiagnostics.WriteLine($"[InlineContainerBox] SetCharacterSpacing failed: {ex.Message}");
                 }
                 layout.SetColor(cumulative, len, Color.FromArgb(0, 0, 0, 0));
             }
@@ -508,6 +587,9 @@ public sealed class InlineContainerBox : BlockBox
     }
 
     private void DrawDecorations(CanvasDrawingSession ds, float baseX, float baseY)
+        => DrawDecorations(ds, baseX, baseY, null);
+
+    private void DrawDecorations(CanvasDrawingSession ds, float baseX, float baseY, Color? overrideColor)
     {
         if (_layout is null) return;
         var lineMetrics = _layout.LineMetrics;
@@ -529,27 +611,15 @@ public sealed class InlineContainerBox : BlockBox
             var rs = string.IsNullOrEmpty(run.ElementKey)
                 ? _context.ThemeSnapshot.GetStyle(_elementKey)
                 : _context.ThemeSnapshot.GetStyle(run.ElementKey);
+            var decorationColor = overrideColor ?? rs.Foreground;
 
-            bool drawRunBg = rs.Background is not null
-                && !string.IsNullOrEmpty(run.ElementKey)
-                && run.ElementKey != _elementKey;
-
-            if (drawRunBg || rs.Underline || rs.Strikethrough)
+            if (rs.Underline || rs.Strikethrough)
             {
                 var regions = _layout.GetCharacterRegions(cumulative, len);
                 if (regions is null) { cumulative += len; continue; } // Win2D can return null on DirectWrite errors
                 foreach (var r in regions)
                 {
                     var lb = r.LayoutBounds;
-                    if (drawRunBg && rs.Background is { } bg)
-                    {
-                        double bgTop = lb.Y + lb.Height * 0.05;
-                        double bgH = lb.Height * 0.90;
-                        ds.FillRoundedRectangle(
-                            new Rect(baseX + lb.X - 2, baseY + bgTop, lb.Width + 4, bgH),
-                            3, 3, bg);
-                    }
-
                     var lm = FindLineMetrics(lineMetrics, r);
                     // CanvasLineMetrics has Baseline (distance from line top to baseline).
                     // x-height ≈ 50% of baseline. Place strikethrough at baseline - xHeight/2.
@@ -561,15 +631,49 @@ public sealed class InlineContainerBox : BlockBox
                     if (rs.Underline)
                     {
                         ds.DrawLine((float)(baseX + lb.X), underlineY, (float)(baseX + lb.X + lb.Width),
-                            underlineY, rs.Foreground, 1.0f);
+                            underlineY, decorationColor, 1.0f);
                     }
                     if (rs.Strikethrough)
                     {
                         ds.DrawLine((float)(baseX + lb.X), strikeY, (float)(baseX + lb.X + lb.Width),
-                            strikeY, rs.Foreground, 1.0f);
+                            strikeY, decorationColor, 1.0f);
                     }
                 }
             }
+            cumulative += len;
+        }
+    }
+
+    private void DrawRunBackgrounds(CanvasDrawingSession ds, float baseX, float baseY)
+    {
+        if (_layout is null) return;
+
+        int cumulative = 0;
+        foreach (var run in _runs)
+        {
+            int len = run.Text.Length;
+            if (len == 0) { continue; }
+            if (run is InlineEmbedRun) { cumulative += len; continue; }
+
+            bool drawRunBg = !string.IsNullOrEmpty(run.ElementKey)
+                && run.ElementKey != _elementKey
+                && _context.ThemeSnapshot.GetStyle(run.ElementKey).Background is { };
+            if (!drawRunBg) { cumulative += len; continue; }
+
+            var rs = _context.ThemeSnapshot.GetStyle(run.ElementKey);
+            var regions = _layout.GetCharacterRegions(cumulative, len);
+            if (regions is null) { cumulative += len; continue; }
+
+            foreach (var r in regions)
+            {
+                var lb = r.LayoutBounds;
+                double bgTop = lb.Y + lb.Height * 0.05;
+                double bgH = lb.Height * 0.90;
+                ds.FillRoundedRectangle(
+                    new Rect(baseX + lb.X - 2, baseY + bgTop, lb.Width + 4, bgH),
+                    3, 3, rs.Background!.Value);
+            }
+
             cumulative += len;
         }
     }

--- a/MarkdownRenderer/MarkdownRenderer/Layout/Boxes/ListItemBox.cs
+++ b/MarkdownRenderer/MarkdownRenderer/Layout/Boxes/ListItemBox.cs
@@ -80,6 +80,18 @@ public sealed class ListItemBox : BlockBox
             _content.Paint(ds, viewport);
     }
 
+    public override void PaintSelectionForeground(
+        CanvasDrawingSession ds,
+        DocumentRange range,
+        Windows.UI.Color color,
+        Rect viewport)
+    {
+        if (_marker.Bounds.Bottom >= viewport.Top && _marker.Bounds.Top <= viewport.Bottom)
+            _marker.PaintSelectionForeground(ds, range, color, viewport);
+        if (_content.Bounds.Bottom >= viewport.Top && _content.Bounds.Top <= viewport.Bottom)
+            _content.PaintSelectionForeground(ds, range, color, viewport);
+    }
+
     public override bool HitTest(Point point, out DocumentPosition position)
     {
         if (_marker.HitTest(point, out position)) return true;

--- a/MarkdownRenderer/MarkdownRenderer/Layout/Boxes/StackBox.cs
+++ b/MarkdownRenderer/MarkdownRenderer/Layout/Boxes/StackBox.cs
@@ -84,6 +84,19 @@ public class StackBox : BlockBox
         }
     }
 
+    public override void PaintSelectionForeground(
+        CanvasDrawingSession ds,
+        DocumentRange range,
+        Windows.UI.Color color,
+        Rect viewport)
+    {
+        foreach (var c in _children)
+        {
+            if (c.Bounds.Bottom < viewport.Top || c.Bounds.Top > viewport.Bottom) continue;
+            c.PaintSelectionForeground(ds, range, color, viewport);
+        }
+    }
+
     public override bool HitTest(Point point, out DocumentPosition position)
     {
         foreach (var c in _children)

--- a/MarkdownRenderer/MarkdownRenderer/Layout/Boxes/TableBox.cs
+++ b/MarkdownRenderer/MarkdownRenderer/Layout/Boxes/TableBox.cs
@@ -15,6 +15,8 @@ namespace MarkdownRenderer.Layout.Boxes;
 /// </summary>
 public sealed class TableBox : BlockBox
 {
+    public readonly record struct CellInfo(InlineContainerBox Box, int Row, int Column, bool IsHeader);
+
     private readonly MarkdownLayoutContext _context;
     private readonly InlineContainerBox[][] _headerCells;  // [row][col]
     private readonly InlineContainerBox[][] _bodyCells;    // [row][col]
@@ -39,11 +41,33 @@ public sealed class TableBox : BlockBox
             _colCount = _bodyCells[0].Length;
     }
 
+    public int HeaderRowCount => _headerCells.Length;
+    public int BodyRowCount => _bodyCells.Length;
+    public int RowCount => _headerCells.Length + _bodyCells.Length;
+    public int ColumnCount => _colCount;
+
     /// <summary>All cell boxes (header rows first, then body rows), left-to-right within each row.</summary>
     public IEnumerable<InlineContainerBox> GetCellBoxes()
     {
         foreach (var row in _headerCells) foreach (var c in row) yield return c;
         foreach (var row in _bodyCells) foreach (var c in row) yield return c;
+    }
+
+    /// <summary>All cell boxes with their logical row/column coordinates.</summary>
+    public IEnumerable<CellInfo> GetCellInfos()
+    {
+        for (int r = 0; r < _headerCells.Length; r++)
+        {
+            for (int c = 0; c < _headerCells[r].Length; c++)
+                yield return new CellInfo(_headerCells[r][c], r, c, IsHeader: true);
+        }
+
+        for (int r = 0; r < _bodyCells.Length; r++)
+        {
+            int logicalRow = _headerCells.Length + r;
+            for (int c = 0; c < _bodyCells[r].Length; c++)
+                yield return new CellInfo(_bodyCells[r][c], logicalRow, c, IsHeader: false);
+        }
     }
 
     public override float Measure(float availableWidth)
@@ -132,7 +156,8 @@ public sealed class TableBox : BlockBox
 
         var headerStyle = _context.ThemeSnapshot.GetStyle(MarkdownElementKeys.TableHeader);
         var bodyStyle = _context.ThemeSnapshot.GetStyle(MarkdownElementKeys.TableCell);
-        var codeBgColor = _context.ThemeSnapshot.GetStyle(MarkdownElementKeys.CodeBlock).Background;
+        var headerBgColor = headerStyle.Background
+            ?? _context.ThemeSnapshot.GetStyle(MarkdownElementKeys.CodeBlock).Background;
 
         float startX = (float)(Bounds.X + Margin.Left);
         float innerWidth = (float)(Bounds.Width - Margin.Left - Margin.Right);
@@ -142,7 +167,7 @@ public sealed class TableBox : BlockBox
         // Full-width header row background (uses code-block bg as a subtle tint).
         float headerTotalH = 0;
         for (int i = 0; i < _headerCells.Length; i++) headerTotalH += _rowHeights[i];
-        if (_headerCells.Length > 0 && codeBgColor is { } hBg)
+        if (_headerCells.Length > 0 && headerBgColor is { } hBg)
             ds.FillRectangle(new Rect(startX, headerStartY, innerWidth, headerTotalH), hBg);
 
         // Paint all cell text layouts.
@@ -177,6 +202,19 @@ public sealed class TableBox : BlockBox
         }
     }
 
+    public override void PaintSelectionForeground(
+        CanvasDrawingSession ds,
+        DocumentRange range,
+        Color color,
+        Rect viewport)
+    {
+        foreach (var cell in GetCellBoxes())
+        {
+            if (cell.Bounds.Bottom < viewport.Top || cell.Bounds.Top > viewport.Bottom) continue;
+            cell.PaintSelectionForeground(ds, range, color, viewport);
+        }
+    }
+
     public override bool HitTest(Point point, out DocumentPosition position)
     {
         if (!Bounds.Contains(point))
@@ -188,8 +226,73 @@ public sealed class TableBox : BlockBox
         {
             if (cell.HitTest(point, out position)) return true;
         }
+
+        if (TryHitTestNearestCell(point, out position))
+            return true;
+
         position = new DocumentPosition(BlockIndex, 0, 0);
-        return true;
+        return false;
+    }
+
+    private bool TryHitTestNearestCell(Point point, out DocumentPosition position)
+    {
+        InlineContainerBox? nearest = null;
+        double nearestDistance = double.PositiveInfinity;
+
+        foreach (var cell in GetCellBoxes())
+        {
+            var r = cell.Bounds;
+            if (r.Width <= 0 || r.Height <= 0)
+                continue;
+
+            double x = Clamp(point.X, r.Left, r.Right);
+            double y = Clamp(point.Y, r.Top, r.Bottom);
+            double dx = point.X - x;
+            double dy = point.Y - y;
+            double distance = dx * dx + dy * dy;
+            if (distance < nearestDistance)
+            {
+                nearest = cell;
+                nearestDistance = distance;
+            }
+        }
+
+        if (nearest is null)
+        {
+            position = default;
+            return false;
+        }
+
+        var bounds = nearest.Bounds;
+        const double edgeInset = 0.5;
+        double left = bounds.Left;
+        double right = bounds.Right;
+        double top = bounds.Top;
+        double bottom = bounds.Bottom;
+
+        if (bounds.Width > edgeInset * 2)
+        {
+            left += edgeInset;
+            right -= edgeInset;
+        }
+
+        if (bounds.Height > edgeInset * 2)
+        {
+            top += edgeInset;
+            bottom -= edgeInset;
+        }
+
+        var clampedPoint = new Point(
+            Clamp(point.X, left, right),
+            Clamp(point.Y, top, bottom));
+        return nearest.HitTest(clampedPoint, out position);
+    }
+
+    private static double Clamp(double value, double min, double max)
+    {
+        if (min > max)
+            return (min + max) / 2.0;
+        return Math.Max(min, Math.Min(max, value));
     }
 
     public override void Dispose()

--- a/MarkdownRenderer/MarkdownRenderer/Layout/Boxes/ThematicBreakBox.cs
+++ b/MarkdownRenderer/MarkdownRenderer/Layout/Boxes/ThematicBreakBox.cs
@@ -1,5 +1,6 @@
 using Microsoft.Graphics.Canvas;
 using Windows.Foundation;
+using MarkdownRenderer.Document;
 using MarkdownRenderer.Theming;
 
 namespace MarkdownRenderer.Layout.Boxes;
@@ -29,5 +30,25 @@ public sealed class ThematicBreakBox : BlockBox
             (float)(Bounds.X + Margin.Left), y,
             (float)(Bounds.X + Bounds.Width - Margin.Right), y,
             style.Foreground, 1f);
+    }
+
+    public override void PaintSelectionForeground(
+        CanvasDrawingSession ds,
+        DocumentRange range,
+        Windows.UI.Color color,
+        Rect viewport)
+    {
+        var n = range.Normalized();
+        if (BlockIndex < n.Start.BlockIndex || BlockIndex > n.End.BlockIndex)
+            return;
+
+        float y = (float)(Bounds.Y + Margin.Top);
+        if (y < viewport.Top || y > viewport.Bottom)
+            return;
+
+        ds.DrawLine(
+            (float)(Bounds.X + Margin.Left), y,
+            (float)(Bounds.X + Bounds.Width - Margin.Right), y,
+            color, 1f);
     }
 }

--- a/MarkdownRenderer/MarkdownRenderer/Layout/Boxes/ThorVgRasterizer.cs
+++ b/MarkdownRenderer/MarkdownRenderer/Layout/Boxes/ThorVgRasterizer.cs
@@ -15,6 +15,7 @@
 using System;
 using System.Runtime.InteropServices;
 using System.Threading;
+using MarkdownRenderer.Diagnostics;
 using static MarkdownRenderer.Layout.Boxes.ThorVgNative;
 
 namespace MarkdownRenderer.Layout.Boxes;
@@ -51,7 +52,7 @@ public static class ThorVgRasterizer
                 var r = tvg_engine_init(0);
                 if (r != Tvg_Result.Success)
                 {
-                    System.Diagnostics.Debug.WriteLine(
+                    MarkdownDiagnostics.WriteLine(
                         $"[ThorVgRasterizer] tvg_engine_init failed: {r}");
                     return false;
                 }
@@ -60,13 +61,13 @@ public static class ThorVgRasterizer
             }
             catch (DllNotFoundException ex)
             {
-                System.Diagnostics.Debug.WriteLine(
+                MarkdownDiagnostics.WriteLine(
                     $"[ThorVgRasterizer] thorvg.dll not found: {ex.Message}");
                 return false;
             }
             catch (Exception ex)
             {
-                System.Diagnostics.Debug.WriteLine(
+                MarkdownDiagnostics.WriteLine(
                     $"[ThorVgRasterizer] engine init threw: {ex}");
                 return false;
             }
@@ -108,7 +109,7 @@ public static class ThorVgRasterizer
             canvas = tvg_swcanvas_create(Tvg_Engine_Option.Default);
             if (canvas == IntPtr.Zero)
             {
-                System.Diagnostics.Debug.WriteLine("[ThorVgRasterizer] swcanvas_create returned null");
+                MarkdownDiagnostics.WriteLine("[ThorVgRasterizer] swcanvas_create returned null");
                 return null;
             }
 
@@ -127,14 +128,14 @@ public static class ThorVgRasterizer
                     Tvg_Colorspace.Argb8888);
                 if (st != Tvg_Result.Success)
                 {
-                    System.Diagnostics.Debug.WriteLine($"[ThorVgRasterizer] set_target failed: {st}");
+                    MarkdownDiagnostics.WriteLine($"[ThorVgRasterizer] set_target failed: {st}");
                     return null;
                 }
 
                 picture = tvg_picture_new();
                 if (picture == IntPtr.Zero)
                 {
-                    System.Diagnostics.Debug.WriteLine("[ThorVgRasterizer] picture_new returned null");
+                    MarkdownDiagnostics.WriteLine("[ThorVgRasterizer] picture_new returned null");
                     return null;
                 }
 
@@ -147,7 +148,7 @@ public static class ThorVgRasterizer
                         mimetype: "svg", rpath: null, copy: true);
                     if (lr != Tvg_Result.Success)
                     {
-                        System.Diagnostics.Debug.WriteLine($"[ThorVgRasterizer] picture_load_data failed: {lr}");
+                        MarkdownDiagnostics.WriteLine($"[ThorVgRasterizer] picture_load_data failed: {lr}");
                         return null;
                     }
                 }
@@ -161,7 +162,7 @@ public static class ThorVgRasterizer
                 var ar = tvg_canvas_add(canvas, picture);
                 if (ar != Tvg_Result.Success)
                 {
-                    System.Diagnostics.Debug.WriteLine($"[ThorVgRasterizer] canvas_add failed: {ar}");
+                    MarkdownDiagnostics.WriteLine($"[ThorVgRasterizer] canvas_add failed: {ar}");
                     return null;
                 }
                 pictureOwnedByCanvas = true;
@@ -169,14 +170,14 @@ public static class ThorVgRasterizer
                 var ur = tvg_canvas_update(canvas);
                 if (ur != Tvg_Result.Success && ur != Tvg_Result.InsufficientCondition)
                 {
-                    System.Diagnostics.Debug.WriteLine($"[ThorVgRasterizer] canvas_update returned: {ur}");
+                    MarkdownDiagnostics.WriteLine($"[ThorVgRasterizer] canvas_update returned: {ur}");
                     // Continue — InsufficientCondition can mean "nothing to update".
                 }
 
                 var dr = tvg_canvas_draw(canvas, clear: true);
                 if (dr != Tvg_Result.Success)
                 {
-                    System.Diagnostics.Debug.WriteLine($"[ThorVgRasterizer] canvas_draw failed: {dr}");
+                    MarkdownDiagnostics.WriteLine($"[ThorVgRasterizer] canvas_draw failed: {dr}");
                     return null;
                 }
 
@@ -186,7 +187,7 @@ public static class ThorVgRasterizer
                 var sr = tvg_canvas_sync(canvas);
                 if (sr != Tvg_Result.Success)
                 {
-                    System.Diagnostics.Debug.WriteLine($"[ThorVgRasterizer] canvas_sync failed: {sr}");
+                    MarkdownDiagnostics.WriteLine($"[ThorVgRasterizer] canvas_sync failed: {sr}");
                     return null;
                 }
             }
@@ -199,7 +200,7 @@ public static class ThorVgRasterizer
         }
         catch (Exception ex)
         {
-            System.Diagnostics.Debug.WriteLine($"[ThorVgRasterizer] rasterize threw: {ex}");
+            MarkdownDiagnostics.WriteLine($"[ThorVgRasterizer] rasterize threw: {ex}");
             return null;
         }
         finally

--- a/MarkdownRenderer/MarkdownRenderer/Layout/FocusNavigationHelper.cs
+++ b/MarkdownRenderer/MarkdownRenderer/Layout/FocusNavigationHelper.cs
@@ -1,0 +1,147 @@
+using System;
+using System.Collections.Generic;
+using Windows.Foundation;
+
+namespace MarkdownRenderer.Layout;
+
+internal enum FocusNavigationDirection
+{
+    Left,
+    Right,
+    Up,
+    Down,
+}
+
+internal static class FocusNavigationHelper
+{
+    public static int MoveTab(int itemCount, int currentIndex, int resumeIndex, bool reverse)
+    {
+        if (itemCount <= 0) return -1;
+
+        if (currentIndex < 0)
+        {
+            if (resumeIndex >= 0)
+            {
+                return reverse
+                    ? Math.Clamp(resumeIndex - 1, 0, itemCount - 1)
+                    : Math.Clamp(resumeIndex, 0, itemCount - 1);
+            }
+
+            return reverse ? itemCount - 1 : 0;
+        }
+
+        bool atEnd = !reverse && currentIndex == itemCount - 1;
+        bool atStart = reverse && currentIndex == 0;
+        if (atEnd || atStart) return -1;
+
+        return reverse ? currentIndex - 1 : currentIndex + 1;
+    }
+
+    public static int FindNearestIndex(IReadOnlyList<Rect> rects, Point point)
+    {
+        if (rects.Count == 0) return -1;
+
+        int best = -1;
+        double bestScore = double.PositiveInfinity;
+        for (int i = 0; i < rects.Count; i++)
+        {
+            var rect = rects[i];
+            if (rect.Width <= 0 || rect.Height <= 0) continue;
+
+            double x = Math.Clamp(point.X, rect.Left, rect.Right);
+            double y = Math.Clamp(point.Y, rect.Top, rect.Bottom);
+            double dx = point.X - x;
+            double dy = point.Y - y;
+            double score = dx * dx + dy * dy;
+            if (score < bestScore)
+            {
+                bestScore = score;
+                best = i;
+            }
+        }
+
+        return best;
+    }
+
+    public static int MoveSpatial(IReadOnlyList<Rect> rects, int currentIndex, FocusNavigationDirection direction)
+    {
+        if (currentIndex < 0 || currentIndex >= rects.Count) return -1;
+        var current = rects[currentIndex];
+        if (current.Width <= 0 || current.Height <= 0) return -1;
+
+        int best = -1;
+        double bestScore = double.PositiveInfinity;
+        for (int i = 0; i < rects.Count; i++)
+        {
+            if (i == currentIndex) continue;
+            var candidate = rects[i];
+            if (candidate.Width <= 0 || candidate.Height <= 0) continue;
+
+            if (!TryGetDirectionalScore(current, candidate, direction, out double score)) continue;
+            if (score < bestScore)
+            {
+                bestScore = score;
+                best = i;
+            }
+        }
+
+        return best;
+    }
+
+    private static bool TryGetDirectionalScore(
+        Rect current,
+        Rect candidate,
+        FocusNavigationDirection direction,
+        out double score)
+    {
+        double cx = CenterX(current);
+        double cy = CenterY(current);
+        double tx = CenterX(candidate);
+        double ty = CenterY(candidate);
+
+        double primary;
+        double secondary;
+        double overlapPenalty;
+        switch (direction)
+        {
+            case FocusNavigationDirection.Left:
+                primary = cx - tx;
+                secondary = Math.Abs(cy - ty);
+                overlapPenalty = RangesOverlap(current.Top, current.Bottom, candidate.Top, candidate.Bottom) ? 0 : 1_000_000;
+                break;
+            case FocusNavigationDirection.Right:
+                primary = tx - cx;
+                secondary = Math.Abs(cy - ty);
+                overlapPenalty = RangesOverlap(current.Top, current.Bottom, candidate.Top, candidate.Bottom) ? 0 : 1_000_000;
+                break;
+            case FocusNavigationDirection.Up:
+                primary = cy - ty;
+                secondary = Math.Abs(cx - tx);
+                overlapPenalty = RangesOverlap(current.Left, current.Right, candidate.Left, candidate.Right) ? 0 : 1_000_000;
+                break;
+            case FocusNavigationDirection.Down:
+                primary = ty - cy;
+                secondary = Math.Abs(cx - tx);
+                overlapPenalty = RangesOverlap(current.Left, current.Right, candidate.Left, candidate.Right) ? 0 : 1_000_000;
+                break;
+            default:
+                score = double.PositiveInfinity;
+                return false;
+        }
+
+        if (primary <= 0.5)
+        {
+            score = double.PositiveInfinity;
+            return false;
+        }
+
+        score = overlapPenalty + primary * 1_000 + secondary;
+        return true;
+    }
+
+    private static double CenterX(Rect rect) => rect.X + rect.Width / 2.0;
+    private static double CenterY(Rect rect) => rect.Y + rect.Height / 2.0;
+
+    private static bool RangesOverlap(double aStart, double aEnd, double bStart, double bEnd) =>
+        aStart <= bEnd && bStart <= aEnd;
+}

--- a/MarkdownRenderer/MarkdownRenderer/Layout/FocusableItem.cs
+++ b/MarkdownRenderer/MarkdownRenderer/Layout/FocusableItem.cs
@@ -1,12 +1,26 @@
 namespace MarkdownRenderer.Layout;
 
-/// <summary>Represents a keyboard-focusable element (link or inline embed) in the document.</summary>
+/// <summary>The kind of keyboard-focusable element represented by <see cref="FocusableItem"/>.</summary>
+public enum FocusableItemKind
+{
+    Link,
+    InlineEmbed,
+    BlockEmbed,
+}
+
+/// <summary>Represents a keyboard-focusable element in the document.</summary>
 public readonly struct FocusableItem
 {
     public FocusableItem(int blockIndex, int inlineIndex, bool isLink) =>
-        (BlockIndex, InlineIndex, IsLink) = (blockIndex, inlineIndex, isLink);
+        (BlockIndex, InlineIndex, Kind) = (blockIndex, inlineIndex, isLink ? FocusableItemKind.Link : FocusableItemKind.InlineEmbed);
+
+    public FocusableItem(int blockIndex, int inlineIndex, FocusableItemKind kind) =>
+        (BlockIndex, InlineIndex, Kind) = (blockIndex, inlineIndex, kind);
+
     public int BlockIndex { get; }
     public int InlineIndex { get; }
-    /// <summary>True for <see cref="Boxes.LinkRun"/>, false for <see cref="Boxes.InlineEmbedRun"/>.</summary>
-    public bool IsLink { get; }
+    public FocusableItemKind Kind { get; }
+    public bool IsLink => Kind == FocusableItemKind.Link;
+    public bool IsInlineEmbed => Kind == FocusableItemKind.InlineEmbed;
+    public bool IsBlockEmbed => Kind == FocusableItemKind.BlockEmbed;
 }

--- a/MarkdownRenderer/MarkdownRenderer/Layout/InlineRun.cs
+++ b/MarkdownRenderer/MarkdownRenderer/Layout/InlineRun.cs
@@ -98,6 +98,24 @@ public sealed class LinkRun : InlineRun
     public override string Text => _text;
 }
 
+public sealed class InlineImageRun : InlineRun
+{
+    private readonly string _text;
+    public string Url { get; }
+    public string? Title { get; }
+    public string AltText => _text;
+
+    public InlineImageRun(string altText, string url, string? title = null)
+    {
+        _text = altText ?? string.Empty;
+        Url = url ?? string.Empty;
+        Title = title;
+        RenderedLength = _text.Length;
+    }
+
+    public override string Text => _text;
+}
+
 public sealed class LineBreakRun : InlineRun
 {
     public LineBreakRun() { RenderedLength = 1; }

--- a/MarkdownRenderer/MarkdownRenderer/Layout/LayoutBuilder.cs
+++ b/MarkdownRenderer/MarkdownRenderer/Layout/LayoutBuilder.cs
@@ -149,7 +149,10 @@ public sealed class LayoutBuilder
 
     private InlineContainerBox BuildCodeBlock(LeafBlock block, string text)
     {
-        var box = new InlineContainerBox(_context, MarkdownElementKeys.CodeBlock);
+        var box = new InlineContainerBox(_context, MarkdownElementKeys.CodeBlock)
+        {
+            CodeLanguage = NormalizeCodeLanguage(block)
+        };
         box.BlockIndex = _context.NextBlockIndex();
         // No ElementKey on the run — it inherits the container's CodeBlock style.
         // Setting ElementKey = CodeBlock would cause DrawDecorations to draw a
@@ -160,6 +163,15 @@ public sealed class LayoutBuilder
         };
         box.Add(run);
         return box;
+    }
+
+    private static string? NormalizeCodeLanguage(LeafBlock block)
+    {
+        if (block is not FencedCodeBlock fenced) return null;
+        var text = fenced.Info?.ToString().Trim() ?? string.Empty;
+        if (text.Length == 0) return null;
+        var firstSpace = text.IndexOfAny(new[] { ' ', '\t', '\r', '\n' });
+        return firstSpace > 0 ? text.Substring(0, firstSpace) : text;
     }
 
     private StackBox BuildQuote(QuoteBlock qb)
@@ -183,7 +195,10 @@ public sealed class LayoutBuilder
 
     private StackBox BuildList(ListBlock list)
     {
-        var stack = new StackBox();
+        var stack = new StackBox
+        {
+            FlowDirection = _context.FlowDirection,
+        };
         stack.BlockIndex = _context.NextBlockIndex();
         // Honour the ordered-list start number from the source (e.g. `5.`).
         // Markdig stores this as a string on ListBlock.OrderedStart.
@@ -224,7 +239,10 @@ public sealed class LayoutBuilder
         });
 
         // Content area — all child blocks of the list item.
-        var content = new StackBox();
+        var content = new StackBox
+        {
+            FlowDirection = _context.FlowDirection,
+        };
         content.BlockIndex = _context.NextBlockIndex();
         foreach (var child in li)
         {
@@ -241,7 +259,10 @@ public sealed class LayoutBuilder
 
     private StackBox BuildGenericContainer(ContainerBlock cb)
     {
-        var stack = new StackBox();
+        var stack = new StackBox
+        {
+            FlowDirection = _context.FlowDirection,
+        };
         stack.BlockIndex = _context.NextBlockIndex();
         foreach (var child in cb)
         {
@@ -332,11 +353,16 @@ public sealed class LayoutBuilder
     {
         if (link.IsImage)
         {
-            // Images are not yet natively rendered; show alt text as plain text.
+            // Inline images are painted as their alt text for now, but keep a
+            // distinct run type so UIA can expose image semantics instead of
+            // flattening them into anonymous paragraph text.
             var alt = new System.Text.StringBuilder();
             FlattenContainer(link, alt);
             string altText = alt.Length > 0 ? alt.ToString() : "image";
-            return new TextRun(altText) { SourceSpan = new SourceSpan(link.Span.Start, link.Span.Length) };
+            return new InlineImageRun(altText, link.Url ?? string.Empty, link.Title)
+            {
+                SourceSpan = new SourceSpan(link.Span.Start, link.Span.Length)
+            };
         }
         var sb = new System.Text.StringBuilder();
         FlattenContainer(link, sb);

--- a/MarkdownRenderer/MarkdownRenderer/Layout/LayoutSnapshot.cs
+++ b/MarkdownRenderer/MarkdownRenderer/Layout/LayoutSnapshot.cs
@@ -61,6 +61,20 @@ public sealed class LayoutSnapshot : System.IDisposable
         }
     }
 
+    public void PaintSelectionForeground(CanvasDrawingSession ds, DocumentRange range, Windows.UI.Color color, Rect viewport)
+    {
+        foreach (var b in Blocks)
+        {
+            if (b.Bounds.Bottom < viewport.Top || b.Bounds.Top > viewport.Bottom) continue;
+            PaintSelectionForeground(b, ds, range, color, viewport);
+        }
+    }
+
+    private static void PaintSelectionForeground(BlockBox box, CanvasDrawingSession ds, DocumentRange range, Windows.UI.Color color, Rect viewport)
+    {
+        box.PaintSelectionForeground(ds, range, color, viewport);
+    }
+
     public bool HitTest(Point point, out DocumentPosition position)
     {
         foreach (var b in Blocks)
@@ -97,10 +111,13 @@ public sealed class LayoutSnapshot : System.IDisposable
                 foreach (var run in icb.Runs)
                 {
                     if (run is LinkRun)
-                        list.Add(new FocusableItem(icb.BlockIndex, run.InlineIndex, isLink: true));
+                        list.Add(new FocusableItem(icb.BlockIndex, run.InlineIndex, FocusableItemKind.Link));
                     else if (run is InlineEmbedRun)
-                        list.Add(new FocusableItem(icb.BlockIndex, run.InlineIndex, isLink: false));
+                        list.Add(new FocusableItem(icb.BlockIndex, run.InlineIndex, FocusableItemKind.InlineEmbed));
                 }
+                break;
+            case EmbedBox eb:
+                list.Add(new FocusableItem(eb.BlockIndex, 0, FocusableItemKind.BlockEmbed));
                 break;
             case ListItemBox lib:
                 WalkForFocusable(lib.Marker, list);

--- a/MarkdownRenderer/MarkdownRenderer/Layout/TextBoundaryHelper.cs
+++ b/MarkdownRenderer/MarkdownRenderer/Layout/TextBoundaryHelper.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Globalization;
 
 namespace MarkdownRenderer.Layout;
 
@@ -12,43 +13,124 @@ public static class TextBoundaryHelper
     /// <summary>
     /// Returns the [start, end) char offsets of the word that contains (or is nearest to)
     /// the given <paramref name="charIndex"/> in <paramref name="buffer"/>.
-    /// A "word" is a maximal sequence of non-whitespace characters.
+    /// A "word" is a maximal sequence of Unicode word characters. Punctuation
+    /// and whitespace are treated as boundaries, while combining marks stay
+    /// attached to their base character through text-element segmentation.
     /// </summary>
     public static (int Start, int End) FindWordBoundaries(string buffer, int charIndex)
     {
         if (string.IsNullOrEmpty(buffer)) return (0, 0);
-        int idx = Math.Clamp(charIndex, 0, Math.Max(0, buffer.Length - 1));
+        var starts = StringInfo.ParseCombiningCharacters(buffer);
+        int idx = TextElementStartAtOrBefore(starts, Math.Clamp(charIndex, 0, Math.Max(0, buffer.Length - 1)));
 
-        // If the cursor landed on whitespace, snap left or right to a word.
-        if (idx < buffer.Length && char.IsWhiteSpace(buffer[idx]))
+        // If the cursor landed on a boundary character, snap left or right to a word.
+        if (!IsWordTextElement(buffer, idx))
         {
-            if (idx > 0 && !char.IsWhiteSpace(buffer[idx - 1]))
-                idx--;  // prefer the word just to the left
+            int previous = PreviousTextElementStart(starts, idx);
+            if (previous >= 0 && IsWordTextElement(buffer, previous))
+            {
+                idx = previous;
+            }
             else
             {
-                int fwd = idx;
-                while (fwd < buffer.Length && char.IsWhiteSpace(buffer[fwd]))
-                    fwd++;
+                int fwd = Math.Min(buffer.Length, NextTextElementStart(starts, idx));
+                while (fwd < buffer.Length && !IsWordTextElement(buffer, fwd))
+                    fwd = Math.Min(buffer.Length, NextTextElementStart(starts, fwd));
+
                 if (fwd < buffer.Length)
-                    idx = fwd; // there is a word to the right — snap to it
+                    idx = fwd;
                 else
-                    return (idx, idx); // entire buffer is whitespace — empty range at clamped position
+                    return (idx, idx);
             }
         }
 
         // Walk left to the start of the word.
         int start = idx;
-        while (start > 0 && !char.IsWhiteSpace(buffer[start - 1]))
-            start--;
+        while (true)
+        {
+            int previous = PreviousTextElementStart(starts, start);
+            if (previous < 0 || !IsWordTextElement(buffer, previous)) break;
+            start = previous;
+        }
 
         // Walk right to the end of the word.
-        int end = idx;
-        while (end < buffer.Length && !char.IsWhiteSpace(buffer[end]))
-            end++;
-
-        // Surrogate pairs are naturally kept intact: neither high nor low surrogates
-        // are whitespace, so the while-loops above always include both chars together.
+        int end = Math.Min(buffer.Length, NextTextElementStart(starts, idx));
+        while (end < buffer.Length && IsWordTextElement(buffer, end))
+            end = Math.Min(buffer.Length, NextTextElementStart(starts, end));
 
         return (start, end);
+    }
+
+    public static int FindNextWordStart(string buffer, int charIndex)
+    {
+        if (string.IsNullOrEmpty(buffer)) return 0;
+        var starts = StringInfo.ParseCombiningCharacters(buffer);
+        int idx = Math.Clamp(charIndex, 0, buffer.Length);
+        if (idx >= buffer.Length) return buffer.Length;
+
+        idx = TextElementStartAtOrBefore(starts, idx);
+        if (IsWordTextElement(buffer, idx))
+            idx = FindWordBoundaries(buffer, idx).End;
+
+        while (idx < buffer.Length && !IsWordTextElement(buffer, idx))
+            idx = Math.Min(buffer.Length, NextTextElementStart(starts, idx));
+
+        return Math.Min(idx, buffer.Length);
+    }
+
+    public static int FindPreviousWordStart(string buffer, int charIndex)
+    {
+        if (string.IsNullOrEmpty(buffer)) return 0;
+        var starts = StringInfo.ParseCombiningCharacters(buffer);
+        int idx = Math.Clamp(charIndex, 0, buffer.Length);
+        if (idx <= 0) return 0;
+
+        idx = PreviousTextElementStart(starts, idx);
+        while (idx >= 0 && !IsWordTextElement(buffer, idx))
+            idx = PreviousTextElementStart(starts, idx);
+
+        return idx < 0 ? 0 : FindWordBoundaries(buffer, idx).Start;
+    }
+
+    private static bool IsWordTextElement(string buffer, int start)
+    {
+        if (start < 0 || start >= buffer.Length) return false;
+        return CharUnicodeInfo.GetUnicodeCategory(buffer, start) switch
+        {
+            UnicodeCategory.UppercaseLetter or
+            UnicodeCategory.LowercaseLetter or
+            UnicodeCategory.TitlecaseLetter or
+            UnicodeCategory.ModifierLetter or
+            UnicodeCategory.OtherLetter or
+            UnicodeCategory.DecimalDigitNumber or
+            UnicodeCategory.LetterNumber or
+            UnicodeCategory.OtherNumber or
+            UnicodeCategory.NonSpacingMark or
+            UnicodeCategory.SpacingCombiningMark or
+            UnicodeCategory.ConnectorPunctuation => true,
+            _ => false,
+        };
+    }
+
+    private static int TextElementStartAtOrBefore(int[] starts, int charIndex)
+    {
+        int index = Array.BinarySearch(starts, charIndex);
+        if (index >= 0) return starts[index];
+        index = ~index - 1;
+        return starts[Math.Clamp(index, 0, starts.Length - 1)];
+    }
+
+    private static int NextTextElementStart(int[] starts, int currentStart)
+    {
+        int index = Array.BinarySearch(starts, currentStart);
+        if (index < 0) index = ~index - 1;
+        return index + 1 < starts.Length ? starts[index + 1] : int.MaxValue;
+    }
+
+    private static int PreviousTextElementStart(int[] starts, int currentStart)
+    {
+        int index = Array.BinarySearch(starts, currentStart);
+        if (index < 0) index = ~index - 1;
+        return index > 0 ? starts[index - 1] : -1;
     }
 }

--- a/MarkdownRenderer/MarkdownRenderer/Properties/AssemblyInfo.cs
+++ b/MarkdownRenderer/MarkdownRenderer/Properties/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("MarkdownRenderer.Sample")]

--- a/MarkdownRenderer/MarkdownRenderer/Properties/Resources.resx
+++ b/MarkdownRenderer/MarkdownRenderer/Properties/Resources.resx
@@ -1,0 +1,90 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="MarkdownDocumentName" xml:space="preserve">
+    <value>Markdown document</value>
+  </data>
+  <data name="ImageName" xml:space="preserve">
+    <value>Image</value>
+  </data>
+  <data name="TableName" xml:space="preserve">
+    <value>Table</value>
+  </data>
+  <data name="ListName" xml:space="preserve">
+    <value>List</value>
+  </data>
+  <data name="EmbeddedContentName" xml:space="preserve">
+    <value>Embedded content</value>
+  </data>
+  <data name="CodeLanguageHelpFormat" xml:space="preserve">
+    <value>Language: {0}</value>
+  </data>
+  <data name="StyleBody" xml:space="preserve">
+    <value>Body</value>
+  </data>
+  <data name="StyleHeading1" xml:space="preserve">
+    <value>Heading 1</value>
+  </data>
+  <data name="StyleHeading2" xml:space="preserve">
+    <value>Heading 2</value>
+  </data>
+  <data name="StyleHeading3" xml:space="preserve">
+    <value>Heading 3</value>
+  </data>
+  <data name="StyleHeading4" xml:space="preserve">
+    <value>Heading 4</value>
+  </data>
+  <data name="StyleHeading5" xml:space="preserve">
+    <value>Heading 5</value>
+  </data>
+  <data name="StyleHeading6" xml:space="preserve">
+    <value>Heading 6</value>
+  </data>
+  <data name="StyleCodeBlock" xml:space="preserve">
+    <value>Code block</value>
+  </data>
+  <data name="StyleInlineCode" xml:space="preserve">
+    <value>Inline code</value>
+  </data>
+  <data name="StyleQuote" xml:space="preserve">
+    <value>Quote</value>
+  </data>
+  <data name="StyleLink" xml:space="preserve">
+    <value>Link</value>
+  </data>
+  <data name="StyleStrong" xml:space="preserve">
+    <value>Strong</value>
+  </data>
+  <data name="StyleEmphasis" xml:space="preserve">
+    <value>Emphasis</value>
+  </data>
+  <data name="StyleStrikethrough" xml:space="preserve">
+    <value>Strikethrough</value>
+  </data>
+  <data name="StyleListMarker" xml:space="preserve">
+    <value>List marker</value>
+  </data>
+  <data name="StyleTableHeader" xml:space="preserve">
+    <value>Table header</value>
+  </data>
+  <data name="StyleTableCell" xml:space="preserve">
+    <value>Table cell</value>
+  </data>
+  <data name="ContextMenuCopy" xml:space="preserve">
+    <value>Copy</value>
+  </data>
+  <data name="ContextMenuSelectAll" xml:space="preserve">
+    <value>Select All</value>
+  </data>
+</root>

--- a/MarkdownRenderer/MarkdownRenderer/Selection/MarkdownSelectionCoordinator.cs
+++ b/MarkdownRenderer/MarkdownRenderer/Selection/MarkdownSelectionCoordinator.cs
@@ -1,0 +1,64 @@
+using System;
+using System.Collections.Generic;
+using MarkdownRenderer.Controls;
+
+namespace MarkdownRenderer.Selection;
+
+internal static class MarkdownSelectionCoordinator
+{
+    private static readonly object Gate = new();
+    private static readonly List<WeakReference<MarkdownRendererControl>> Controls = new();
+
+    public static void Register(MarkdownRendererControl control)
+    {
+        lock (Gate)
+        {
+            PruneLocked();
+            foreach (var weak in Controls)
+            {
+                if (weak.TryGetTarget(out var existing) && ReferenceEquals(existing, control))
+                    return;
+            }
+
+            Controls.Add(new WeakReference<MarkdownRendererControl>(control));
+        }
+    }
+
+    public static void Unregister(MarkdownRendererControl control)
+    {
+        lock (Gate)
+        {
+            Controls.RemoveAll(weak =>
+                !weak.TryGetTarget(out var existing) ||
+                ReferenceEquals(existing, control));
+        }
+    }
+
+    public static void ClearSelectionsExcept(MarkdownRendererControl? owner)
+    {
+        MarkdownRendererControl[] snapshot;
+        lock (Gate)
+        {
+            PruneLocked();
+            var live = new List<MarkdownRendererControl>(Controls.Count);
+            foreach (var weak in Controls)
+            {
+                if (weak.TryGetTarget(out var control) &&
+                    !ReferenceEquals(control, owner))
+                {
+                    live.Add(control);
+                }
+            }
+
+            snapshot = live.ToArray();
+        }
+
+        foreach (var control in snapshot)
+            control.ClearSelectionFromCoordinator();
+    }
+
+    private static void PruneLocked()
+    {
+        Controls.RemoveAll(static weak => !weak.TryGetTarget(out _));
+    }
+}

--- a/MarkdownRenderer/MarkdownRenderer/Selection/SelectionController.cs
+++ b/MarkdownRenderer/MarkdownRenderer/Selection/SelectionController.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using Microsoft.Graphics.Canvas;
 using Windows.Foundation;
 using Windows.UI;
+using MarkdownRenderer.Diagnostics;
 using MarkdownRenderer.Document;
 using MarkdownRenderer.Layout;
 using MarkdownRenderer.Layout.Boxes;
@@ -23,17 +24,19 @@ public sealed class SelectionController
     public void SetAnchor(DocumentPosition anchor)
     {
         Range = new DocumentRange(anchor, anchor);
-        MarkdownRenderer.Diagnostics.ShakeLogger.Log("sel-anchor",
-            $"blk={anchor.BlockIndex} inl={anchor.InlineIndex} c={anchor.CharacterOffset}");
+        if (ShakeLogger.IsEnabled)
+            ShakeLogger.Log("sel-anchor",
+                $"blk={anchor.BlockIndex} inl={anchor.InlineIndex} c={anchor.CharacterOffset}");
         Changed?.Invoke(this, System.EventArgs.Empty);
     }
 
     public void ExtendTo(DocumentPosition position)
     {
         Range = new DocumentRange(Range.Start, position);
-        MarkdownRenderer.Diagnostics.ShakeLogger.Log("sel-extend",
-            $"start=blk{Range.Start.BlockIndex}/c{Range.Start.CharacterOffset} " +
-            $"end=blk{position.BlockIndex}/c{position.CharacterOffset}");
+        if (ShakeLogger.IsEnabled)
+            ShakeLogger.Log("sel-extend",
+                $"start=blk{Range.Start.BlockIndex}/c{Range.Start.CharacterOffset} " +
+                $"end=blk{position.BlockIndex}/c{position.CharacterOffset}");
         Changed?.Invoke(this, System.EventArgs.Empty);
     }
 
@@ -97,8 +100,9 @@ public sealed class SelectionController
             var snapped = new Rect(x, y, w, h);
             if (first)
             {
-                MarkdownRenderer.Diagnostics.ShakeLogger.LogPaint(
-                    "sel-rect-first", -1, snapped.X, snapped.Y, snapped.Width, snapped.Height);
+                if (ShakeLogger.IsEnabled)
+                    ShakeLogger.LogPaint(
+                        "sel-rect-first", -1, snapped.X, snapped.Y, snapped.Width, snapped.Height);
                 first = false;
             }
             ds.FillRectangle(snapped, color);

--- a/MarkdownRenderer/MarkdownRenderer/Theming/MarkdownHighContrastDefaults.cs
+++ b/MarkdownRenderer/MarkdownRenderer/Theming/MarkdownHighContrastDefaults.cs
@@ -1,0 +1,58 @@
+namespace MarkdownRenderer.Theming;
+
+internal enum MarkdownHighContrastColorRole
+{
+    WindowText,
+    Window,
+    Hotlight,
+    Highlight,
+    HighlightText,
+}
+
+internal readonly record struct MarkdownHighContrastStyleRoles(
+    MarkdownHighContrastColorRole Foreground,
+    MarkdownHighContrastColorRole? Background = null,
+    MarkdownHighContrastColorRole? AccentBar = null,
+    bool Underline = false,
+    bool Strikethrough = false);
+
+internal static class MarkdownHighContrastDefaults
+{
+    public static MarkdownHighContrastStyleRoles Resolve(string elementKey) => elementKey switch
+    {
+        "Link" => new(
+            MarkdownHighContrastColorRole.Hotlight,
+            Underline: true),
+
+        "CodeBlock" => new(
+            MarkdownHighContrastColorRole.WindowText,
+            MarkdownHighContrastColorRole.Window,
+            MarkdownHighContrastColorRole.WindowText),
+
+        "CodeInline" => new(
+            MarkdownHighContrastColorRole.WindowText,
+            MarkdownHighContrastColorRole.Window),
+
+        "Quote" => new(
+            MarkdownHighContrastColorRole.WindowText,
+            AccentBar: MarkdownHighContrastColorRole.WindowText),
+
+        "Strikethrough" => new(
+            MarkdownHighContrastColorRole.WindowText,
+            Strikethrough: true),
+
+        "TableHeader" => new(
+            MarkdownHighContrastColorRole.HighlightText,
+            MarkdownHighContrastColorRole.Highlight),
+
+        "Body" or "TableCell" => new(
+            MarkdownHighContrastColorRole.WindowText,
+            MarkdownHighContrastColorRole.Window),
+
+        "AlertNote" or "AlertTip" or "AlertImportant" or "AlertWarning" or "AlertCaution" => new(
+            MarkdownHighContrastColorRole.WindowText,
+            AccentBar: MarkdownHighContrastColorRole.Hotlight),
+
+        _ => new(MarkdownHighContrastColorRole.WindowText),
+    };
+}

--- a/MarkdownRenderer/MarkdownRenderer/Theming/MarkdownSystemThemeProvider.cs
+++ b/MarkdownRenderer/MarkdownRenderer/Theming/MarkdownSystemThemeProvider.cs
@@ -1,0 +1,126 @@
+using System;
+using Microsoft.UI.System;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Media;
+using Windows.UI;
+using Windows.UI.ViewManagement;
+
+namespace MarkdownRenderer.Theming;
+
+internal interface IMarkdownSystemThemeProvider
+{
+    bool IsHighContrast { get; }
+    Color WindowTextColor { get; }
+    Color WindowColor { get; }
+    Color HotlightColor { get; }
+    Color HighlightColor { get; }
+    Color HighlightTextColor { get; }
+}
+
+internal sealed class MarkdownSystemThemeProvider : IMarkdownSystemThemeProvider
+{
+    private readonly FrameworkElement _host;
+    private readonly ThemeSettings? _themeSettings;
+
+    public MarkdownSystemThemeProvider(FrameworkElement host)
+    {
+        _host = host ?? throw new ArgumentNullException(nameof(host));
+        try { _themeSettings = CreateThemeSettings(host); }
+        catch { }
+    }
+
+    public bool IsHighContrast
+    {
+        get
+        {
+            try { return _themeSettings?.HighContrast == true; }
+            catch { return false; }
+        }
+    }
+
+    public Color WindowTextColor => ResolveSystemColor("SystemColorWindowTextColor", "SystemColorWindowTextBrush", UIColorType.Foreground);
+    public Color WindowColor => ResolveSystemColor("SystemColorWindowColor", "SystemColorWindowBrush", UIColorType.Background);
+    public Color HotlightColor => ResolveSystemColor("SystemColorHotlightColor", "SystemColorHotlightBrush", UIColorType.Accent);
+    public Color HighlightColor => ResolveSystemColor("SystemColorHighlightColor", "SystemColorHighlightBrush", UIColorType.Accent);
+    public Color HighlightTextColor => ResolveSystemColor("SystemColorHighlightTextColor", "SystemColorHighlightTextBrush", UIColorType.Background);
+
+    private Color ResolveSystemColor(string colorKey, string brushKey, UIColorType fallbackType)
+    {
+        if (TryResolveResourceColor(colorKey, out var color) ||
+            TryResolveResourceColor(brushKey, out color))
+        {
+            return color;
+        }
+
+        try { return new UISettings().GetColorValue(fallbackType); }
+        catch { return fallbackType == UIColorType.Background ? Color.FromArgb(0xFF, 0, 0, 0) : Color.FromArgb(0xFF, 0xFF, 0xFF, 0xFF); }
+    }
+
+    private static ThemeSettings? CreateThemeSettings(FrameworkElement host)
+    {
+        var xamlRoot = host.XamlRoot;
+        if (xamlRoot?.ContentIslandEnvironment is null) return null;
+        return ThemeSettings.CreateForWindowId(xamlRoot.ContentIslandEnvironment.AppWindowId);
+    }
+
+    private bool TryResolveResourceColor(string key, out Color color)
+    {
+        try
+        {
+            if (_host.Resources?.TryGetValue(key, out var hostValue) == true &&
+                TryExtractColor(hostValue, out color))
+            {
+                return true;
+            }
+
+            if (Application.Current?.Resources?.TryGetValue(key, out var appValue) == true &&
+                TryExtractColor(appValue, out color))
+            {
+                return true;
+            }
+
+            if (Application.Current?.Resources?.ThemeDictionaries != null)
+            {
+                foreach (var dictionary in Application.Current.Resources.ThemeDictionaries.Values)
+                {
+                    if (dictionary is ResourceDictionary rd &&
+                        rd.TryGetValue(key, out var themeValue) &&
+                        TryExtractColor(themeValue, out color))
+                    {
+                        return true;
+                    }
+                }
+            }
+        }
+        catch { }
+
+        color = default;
+        return false;
+    }
+
+    private static bool TryExtractColor(object value, out Color color)
+    {
+        switch (value)
+        {
+            case Color c:
+                color = c;
+                return true;
+            case SolidColorBrush brush:
+                color = brush.Color;
+                return true;
+            default:
+                color = default;
+                return false;
+        }
+    }
+}
+
+internal sealed class ForcedMarkdownSystemThemeProvider : IMarkdownSystemThemeProvider
+{
+    public bool IsHighContrast { get; init; }
+    public Color WindowTextColor { get; init; } = Color.FromArgb(0xFF, 0xFF, 0xFF, 0xFF);
+    public Color WindowColor { get; init; } = Color.FromArgb(0xFF, 0, 0, 0);
+    public Color HotlightColor { get; init; } = Color.FromArgb(0xFF, 0x00, 0xFF, 0xFF);
+    public Color HighlightColor { get; init; } = Color.FromArgb(0xFF, 0xFF, 0xFF, 0x00);
+    public Color HighlightTextColor { get; init; } = Color.FromArgb(0xFF, 0, 0, 0);
+}

--- a/MarkdownRenderer/MarkdownRenderer/Theming/ThemeResolver.cs
+++ b/MarkdownRenderer/MarkdownRenderer/Theming/ThemeResolver.cs
@@ -7,6 +7,7 @@ using Microsoft.UI.Xaml.Markup;
 using Microsoft.UI.Xaml.Media;
 using Windows.UI;
 using Windows.UI.Text;
+using MarkdownRenderer.Diagnostics;
 
 namespace MarkdownRenderer.Theming;
 
@@ -19,11 +20,15 @@ public sealed class ThemeResolver
 {
     private readonly FrameworkElement _host;
     private readonly MarkdownTheme _theme;
+    private readonly IMarkdownSystemThemeProvider _systemTheme;
+
+    internal static IMarkdownSystemThemeProvider? SystemThemeProviderOverride { get; set; }
 
     public ThemeResolver(FrameworkElement host, MarkdownTheme theme)
     {
         _host = host ?? throw new ArgumentNullException(nameof(host));
         _theme = theme ?? throw new ArgumentNullException(nameof(theme));
+        _systemTheme = SystemThemeProviderOverride ?? new MarkdownSystemThemeProvider(_host);
     }
 
     public ElementStyle GetEffectiveStyle(string elementKey)
@@ -79,20 +84,28 @@ public sealed class ThemeResolver
         var dict = new Dictionary<string, ElementStyle>(allKeys.Length);
         foreach (var k in allKeys)
             dict[k] = GetEffectiveStyle(k);
-        return new ThemeSnapshot(dict);
+        return new ThemeSnapshot(
+            dict,
+            ResolveSurfaceColor(),
+            ResolveSelectionHighlightColor(),
+            ResolveSelectionForegroundColor(),
+            ResolveFocusVisualColor(),
+            _systemTheme.IsHighContrast);
     }
 
     private ElementStyle GetDefault(string key)
     {
+        if (_systemTheme.IsHighContrast)
+            return GetHighContrastDefault(key);
+
         bool isDark = _host.ActualTheme == ElementTheme.Dark;
 
         // Hardcoded Win11 design token equivalents — bypasses the XAML resource system
         // which only works reliably for the app-level theme, not per-element themes.
-        var fg         = isDark ? Color.FromArgb(0xFF, 0xFF, 0xFF, 0xFF) : Color.FromArgb(0xFF, 0x1A, 0x1A, 0x1A);
-        var fgSecondary = isDark ? Color.FromArgb(0xFF, 0x9D, 0x9D, 0x9D) : Color.FromArgb(0xFF, 0x7A, 0x7A, 0x7A);
+        var fg = ResolvePrimaryTextColor(isDark);
+        var fgSecondary = ResolveSecondaryTextColor(isDark);
         // Accent: try to get the user's accent color, fall back to Win11 blue.
-        var accent      = _theme.AccentColor ?? ResolveBrush("AccentTextFillColorPrimaryBrush",
-            isDark ? Color.FromArgb(0xFF, 0x60, 0xCD, 0xFF) : Color.FromArgb(0xFF, 0x00, 0x5F, 0xB8));
+        var accent      = _theme.AccentColor ?? ResolveAccentTextColor(isDark);
         var codeBg      = isDark ? Color.FromArgb(0x1A, 0xFF, 0xFF, 0xFF) : Color.FromArgb(0x0F, 0x00, 0x00, 0x00);
         var quoteBar    = isDark ? Color.FromArgb(0x50, 0xFF, 0xFF, 0xFF) : Color.FromArgb(0x50, 0x00, 0x00, 0x00);
 
@@ -133,6 +146,249 @@ public sealed class ThemeResolver
         };
     }
 
+    private ElementStyle GetHighContrastDefault(string key)
+    {
+        var roles = MarkdownHighContrastDefaults.Resolve(key);
+        var fg = ResolveHighContrastRole(roles.Foreground);
+        var bg = roles.Background is { } backgroundRole ? ResolveHighContrastRole(backgroundRole) : (Color?)null;
+        var accentBar = roles.AccentBar is { } accentRole ? ResolveHighContrastRole(accentRole) : (Color?)null;
+
+        const string font = "Segoe UI Variable";
+        const string mono = "Consolas";
+
+        return key switch
+        {
+            MarkdownElementKeys.Heading1 => new ElementStyle { FontFamily = font, FontSize = 32, FontWeight = FontWeights.SemiBold, Foreground = fg, Margin = new Thickness(0, 16, 0, 8) },
+            MarkdownElementKeys.Heading2 => new ElementStyle { FontFamily = font, FontSize = 26, FontWeight = FontWeights.SemiBold, Foreground = fg, Margin = new Thickness(0, 14, 0, 6) },
+            MarkdownElementKeys.Heading3 => new ElementStyle { FontFamily = font, FontSize = 22, FontWeight = FontWeights.SemiBold, Foreground = fg, Margin = new Thickness(0, 12, 0, 4) },
+            MarkdownElementKeys.Heading4 => new ElementStyle { FontFamily = font, FontSize = 18, FontWeight = FontWeights.SemiBold, Foreground = fg, Margin = new Thickness(0, 10, 0, 4) },
+            MarkdownElementKeys.Heading5 => new ElementStyle { FontFamily = font, FontSize = 15, FontWeight = FontWeights.SemiBold, Foreground = fg, Margin = new Thickness(0, 8, 0, 2) },
+            MarkdownElementKeys.Heading6 => new ElementStyle { FontFamily = font, FontSize = 14, FontWeight = FontWeights.SemiBold, Foreground = fg, Margin = new Thickness(0, 6, 0, 2) },
+            MarkdownElementKeys.Body => new ElementStyle { FontFamily = font, FontSize = 14, Foreground = fg, Background = bg, Margin = new Thickness(0, 0, 0, 8) },
+            MarkdownElementKeys.CodeBlock => new ElementStyle { FontFamily = mono, FontSize = 13, Foreground = fg, Background = bg, AccentBar = accentBar, Margin = new Thickness(0, 4, 0, 8), Padding = new Thickness(12, 8, 12, 8) },
+            MarkdownElementKeys.CodeInline => new ElementStyle { FontFamily = mono, FontSize = 12, Foreground = fg, Background = bg, Padding = new Thickness(2, 0, 2, 0) },
+            MarkdownElementKeys.Quote => new ElementStyle { FontFamily = font, FontSize = 14, Foreground = fg, AccentBar = accentBar, Margin = new Thickness(0, 4, 0, 4), Padding = new Thickness(12, 2, 8, 2) },
+            MarkdownElementKeys.Link => new ElementStyle { FontFamily = font, FontSize = 14, Foreground = fg, Underline = roles.Underline },
+            MarkdownElementKeys.Strong => new ElementStyle { FontFamily = font, FontSize = 14, FontWeight = FontWeights.SemiBold, Foreground = fg },
+            MarkdownElementKeys.Emphasis => new ElementStyle { FontFamily = font, FontSize = 14, FontStyle = FontStyle.Italic, Foreground = fg },
+            MarkdownElementKeys.Strikethrough => new ElementStyle { FontFamily = font, FontSize = 14, Strikethrough = roles.Strikethrough, Foreground = fg },
+            MarkdownElementKeys.ListMarker => new ElementStyle { FontFamily = font, FontSize = 14, Foreground = fg },
+            MarkdownElementKeys.ThematicBreak => new ElementStyle { FontFamily = font, Foreground = fg, Margin = new Thickness(0, 12, 0, 12) },
+            MarkdownElementKeys.ImageCaption => new ElementStyle { FontFamily = font, FontSize = 12, FontStyle = FontStyle.Italic, Foreground = fg, Margin = new Thickness(0, 2, 0, 8) },
+            MarkdownElementKeys.TableHeader => new ElementStyle { FontFamily = font, FontSize = 14, FontWeight = FontWeights.SemiBold, Foreground = fg, Background = bg },
+            MarkdownElementKeys.TableCell => new ElementStyle { FontFamily = font, FontSize = 14, Foreground = fg, Background = bg },
+            MarkdownElementKeys.AlertNote or MarkdownElementKeys.AlertTip or MarkdownElementKeys.AlertImportant or
+            MarkdownElementKeys.AlertWarning or MarkdownElementKeys.AlertCaution => new ElementStyle { FontFamily = font, FontSize = 14, Foreground = fg, AccentBar = accentBar, Padding = new Thickness(12, 2, 8, 2), Margin = new Thickness(0, 4, 0, 8) },
+            _ => new ElementStyle { FontFamily = font, FontSize = 14, Foreground = fg, Background = bg, Margin = new Thickness(0, 0, 0, 4) }
+        };
+    }
+
+    private Color ResolveHighContrastRole(MarkdownHighContrastColorRole role) => role switch
+    {
+        MarkdownHighContrastColorRole.WindowText => _systemTheme.WindowTextColor,
+        MarkdownHighContrastColorRole.Window => _systemTheme.WindowColor,
+        MarkdownHighContrastColorRole.Hotlight => _systemTheme.HotlightColor,
+        MarkdownHighContrastColorRole.Highlight => _systemTheme.HighlightColor,
+        MarkdownHighContrastColorRole.HighlightText => _systemTheme.HighlightTextColor,
+        _ => _systemTheme.WindowTextColor,
+    };
+
+    private Color ResolveSelectionHighlightColor()
+    {
+        var nativeSelection = ResolveNativeSelectionHighlightColor();
+        if (_systemTheme.IsHighContrast)
+            return WithAlpha(nativeSelection, 0xFF);
+
+        // TextBox paints the selection highlight over a clean text-control
+        // surface after replacing the selected glyph foreground. Our canvas has
+        // already painted the unselected glyphs underneath, so use the same
+        // native resource but pre-composite translucent brushes over the
+        // markdown surface. The resulting opaque color matches the native
+        // visual while preventing old dark glyphs from bleeding through.
+        return CompositeOver(nativeSelection, ResolveSurfaceColor());
+    }
+
+    private Color ResolveNativeSelectionHighlightColor()
+    {
+        if (TryResolveResourceColor("TextControlSelectionHighlightColor", out var color) ||
+            TryResolveResourceColor("AccentFillColorSelectedTextBackgroundBrush", out color) ||
+            TryResolveResourceColor("SystemControlHighlightAccentBrush", out color) ||
+            TryResolveResourceColor("SystemColorHighlightColorBrush", out color) ||
+            TryResolveResourceColor("SystemColorHighlightColor", out color))
+        {
+            return color;
+        }
+
+        return _systemTheme.IsHighContrast
+            ? _systemTheme.HighlightColor
+            : ResolveBrush("AccentFillColorDefaultBrush",
+                ResolveBrush("AccentTextFillColorPrimaryBrush", Color.FromArgb(0xFF, 0x00, 0x78, 0xD4)));
+    }
+
+    private Color ResolveSelectionForegroundColor()
+    {
+        if (_systemTheme.IsHighContrast)
+            return _systemTheme.HighlightTextColor;
+
+        if (TryResolveResourceColor("TextOnAccentFillColorSelectedTextBrush", out var color) ||
+            TryResolveResourceColor("TextOnAccentFillColorSelectedText", out color) ||
+            TryResolveResourceColor("SystemColorHighlightTextColorBrush", out color) ||
+            TryResolveResourceColor("SystemColorHighlightTextColor", out color))
+        {
+            return Color.FromArgb(0xFF, color.R, color.G, color.B);
+        }
+
+        return Color.FromArgb(0xFF, 0xFF, 0xFF, 0xFF);
+    }
+
+    private Color ResolveFocusVisualColor()
+    {
+        if (_systemTheme.IsHighContrast)
+            return _systemTheme.HighlightColor;
+
+        return ResolveBrush("SystemControlFocusVisualPrimaryBrush",
+            ResolveBrush("FocusVisualPrimaryBrush",
+                ResolveBrush("AccentTextFillColorPrimaryBrush", Color.FromArgb(0xFF, 0x00, 0x78, 0xD4))));
+    }
+
+    private static Color WithAlpha(Color color, byte alpha) =>
+        Color.FromArgb(alpha, color.R, color.G, color.B);
+
+    private static Color CompositeOver(Color top, Color bottom)
+    {
+        double topA = top.A / 255.0;
+        double bottomA = bottom.A / 255.0;
+        double outA = topA + bottomA * (1.0 - topA);
+        if (outA <= 0.0)
+            return Color.FromArgb(0, 0, 0, 0);
+
+        byte a = (byte)Math.Clamp((int)Math.Round(outA * 255.0), 0, 255);
+        byte r = CompositeChannel(top.R, topA, bottom.R, bottomA, outA);
+        byte g = CompositeChannel(top.G, topA, bottom.G, bottomA, outA);
+        byte b = CompositeChannel(top.B, topA, bottom.B, bottomA, outA);
+        return Color.FromArgb(a, r, g, b);
+    }
+
+    private static byte CompositeChannel(byte top, double topA, byte bottom, double bottomA, double outA)
+    {
+        var value = (top * topA + bottom * bottomA * (1.0 - topA)) / outA;
+        return (byte)Math.Clamp((int)Math.Round(value), 0, 255);
+    }
+
+    private bool TryResolveResourceColor(string resourceKey, out Color color)
+    {
+        try
+        {
+            if (_host.Resources?.TryGetValue(resourceKey, out var hostValue) == true &&
+                TryExtractColor(hostValue, out color))
+            {
+                return true;
+            }
+
+            var themeKey = _host.ActualTheme == ElementTheme.Dark ? "Dark" : "Light";
+            if (Application.Current?.Resources?.ThemeDictionaries != null &&
+                Application.Current.Resources.ThemeDictionaries.TryGetValue(themeKey, out var td) &&
+                td is ResourceDictionary themeDict &&
+                themeDict.TryGetValue(resourceKey, out var themeValue) &&
+                TryExtractColor(themeValue, out color))
+            {
+                return true;
+            }
+
+            if (Application.Current?.Resources?.TryGetValue(resourceKey, out var appValue) == true &&
+                TryExtractColor(appValue, out color))
+            {
+                return true;
+            }
+        }
+        catch (Exception ex) { MarkdownDiagnostics.WriteLine($"[ThemeResolver] TryResolveResourceColor failed for '{resourceKey}': {ex.Message}"); }
+
+        color = default;
+        return false;
+    }
+
+    private static bool TryExtractColor(object value, out Color color)
+    {
+        switch (value)
+        {
+            case Color c:
+                color = c;
+                return true;
+            case SolidColorBrush brush:
+                var alpha = (byte)Math.Clamp((int)Math.Round(brush.Color.A * brush.Opacity), 0, 255);
+                color = Color.FromArgb(alpha, brush.Color.R, brush.Color.G, brush.Color.B);
+                return true;
+            default:
+                color = default;
+                return false;
+        }
+    }
+
+    private Color ResolveSurfaceColor()
+    {
+        if (_systemTheme.IsHighContrast)
+            return _systemTheme.WindowColor;
+
+        if (TryResolveResourceColor("TextControlBackgroundFocused", out var color) ||
+            TryResolveResourceColor("TextControlBackground", out color) ||
+            TryResolveResourceColor("LayerFillColorDefaultBrush", out color) ||
+            TryResolveResourceColor("SolidBackgroundFillColorBaseBrush", out color) ||
+            TryResolveResourceColor("ApplicationPageBackgroundThemeBrush", out color))
+        {
+            return CompositeOver(color, _host.ActualTheme == ElementTheme.Dark
+                ? Color.FromArgb(0xFF, 0x20, 0x20, 0x20)
+                : Color.FromArgb(0xFF, 0xFF, 0xFF, 0xFF));
+        }
+
+        return _host.ActualTheme == ElementTheme.Dark
+            ? Color.FromArgb(0xFF, 0x20, 0x20, 0x20)
+            : Color.FromArgb(0xFF, 0xFF, 0xFF, 0xFF);
+    }
+
+    private Color ResolvePrimaryTextColor(bool isDark)
+    {
+        if (TryResolveResourceColor("TextControlForegroundFocused", out var color) ||
+            TryResolveResourceColor("TextControlForeground", out color) ||
+            TryResolveResourceColor("TextFillColorPrimaryBrush", out color) ||
+            TryResolveResourceColor("TextFillColorPrimary", out color))
+        {
+            return color;
+        }
+
+        return isDark
+            ? Color.FromArgb(0xFF, 0xFF, 0xFF, 0xFF)
+            : Color.FromArgb(0xFF, 0x1A, 0x1A, 0x1A);
+    }
+
+    private Color ResolveSecondaryTextColor(bool isDark)
+    {
+        if (TryResolveResourceColor("TextFillColorSecondaryBrush", out var color) ||
+            TryResolveResourceColor("TextFillColorSecondary", out color) ||
+            TryResolveResourceColor("TextControlPlaceholderForeground", out color))
+        {
+            return color;
+        }
+
+        return isDark
+            ? Color.FromArgb(0xFF, 0x9D, 0x9D, 0x9D)
+            : Color.FromArgb(0xFF, 0x7A, 0x7A, 0x7A);
+    }
+
+    private Color ResolveAccentTextColor(bool isDark)
+    {
+        if (TryResolveResourceColor("AccentTextFillColorPrimaryBrush", out var color) ||
+            TryResolveResourceColor("AccentTextFillColorPrimary", out color) ||
+            TryResolveResourceColor("SystemControlForegroundAccentBrush", out color) ||
+            TryResolveResourceColor("AccentFillColorDefaultBrush", out color))
+        {
+            return color;
+        }
+
+        return isDark
+            ? Color.FromArgb(0xFF, 0x60, 0xCD, 0xFF)
+            : Color.FromArgb(0xFF, 0x00, 0x5F, 0xB8);
+    }
+
     private Color ResolveBrush(string resourceKey, Color fallback)
     {
         try
@@ -152,7 +408,7 @@ public sealed class ThemeResolver
             if (_host.Resources?.TryGetValue(resourceKey, out var r2) == true && r2 is SolidColorBrush b2)
                 return b2.Color;
         }
-        catch (Exception ex) { System.Diagnostics.Debug.WriteLine($"[ThemeResolver] ResolveBrush failed for '{resourceKey}': {ex.Message}"); }
+        catch (Exception ex) { MarkdownDiagnostics.WriteLine($"[ThemeResolver] ResolveBrush failed for '{resourceKey}': {ex.Message}"); }
         return fallback;
     }
 }

--- a/MarkdownRenderer/MarkdownRenderer/Theming/ThemeSnapshot.cs
+++ b/MarkdownRenderer/MarkdownRenderer/Theming/ThemeSnapshot.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using Windows.UI;
 
 namespace MarkdownRenderer.Theming;
 
@@ -12,10 +13,27 @@ public sealed class ThemeSnapshot
 {
     private readonly IReadOnlyDictionary<string, ElementStyle> _styles;
 
-    internal ThemeSnapshot(IReadOnlyDictionary<string, ElementStyle> styles)
+    internal ThemeSnapshot(
+        IReadOnlyDictionary<string, ElementStyle> styles,
+        Color surfaceColor,
+        Color selectionHighlightColor,
+        Color selectionForegroundColor,
+        Color focusVisualColor,
+        bool isHighContrast)
     {
         _styles = styles ?? throw new ArgumentNullException(nameof(styles));
+        SurfaceColor = surfaceColor;
+        SelectionHighlightColor = selectionHighlightColor;
+        SelectionForegroundColor = selectionForegroundColor;
+        FocusVisualColor = focusVisualColor;
+        IsHighContrast = isHighContrast;
     }
+
+    public Color SurfaceColor { get; }
+    public Color SelectionHighlightColor { get; }
+    public Color SelectionForegroundColor { get; }
+    public Color FocusVisualColor { get; }
+    public bool IsHighContrast { get; }
 
     public ElementStyle GetStyle(string elementKey)
     {

--- a/MarkdownRenderer/TODO.md
+++ b/MarkdownRenderer/TODO.md
@@ -10,30 +10,48 @@ Legend: 🔴 blocks release · 🟠 must fix before 1.0 · 🟡 v1.1 candidate
 
 ## Accessibility
 
-> The biggest gap — currently ~60% complete. Screen reader support is non-negotiable
-> for a production control.
+> The foundational UIA surface is now implemented. Remaining accessibility work
+> is deeper OS/Narrator smoke coverage, keyboard edge cases, and broader real
+> Windows contrast-theme / system-language validation.
 
-- 🔴 **Implement `ITextProvider` / `ITextRangeProvider`**
+- ✅ **Implement `ITextProvider` / `ITextRangeProvider`**
   Narrator and other AT cannot query text by character offset, expand selection
   by word/line/paragraph, or drive Ctrl+F search. Add the UIA Text pattern to
   `MarkdownAutomationPeer`. (`Accessibility/MarkdownAutomationPeer.cs`)
 
-- 🔴 **Expose heading levels in `MarkdownBlockPeer`**
+- ✅ **Implement `ITextProvider.RangeFromChild`**
+  Child peers now map back to text ranges through WinUI peer/provider identity,
+  with deterministic UI automation coverage for hyperlinks, images, and hosted
+  WinUI embedded controls.
+
+- ✅ **Expose core `ITextRangeProvider` text attributes**
+  Ranges now expose read-only/hidden/active/culture/flow attributes plus
+  font family, font size, font weight, foreground/background color, underline,
+  strikethrough, style id/name, and superscript. UI automation verifies link,
+  code, body, and high-contrast color attributes.
+
+- ✅ **Expose heading levels in `MarkdownBlockPeer`**
   Override `GetHeadingLevelCore()` so Narrator announces "Heading 2" instead of
   treating H1–H6 identically to paragraphs. (`Accessibility/MarkdownBlockPeer.cs`)
 
-- 🔴 **Implement `ITableProvider` / `ITableItemProvider` for tables**
+- ✅ **Implement `ITableProvider` / `ITableItemProvider` for tables**
   Table cells have no UIA table role. Screen readers cannot navigate rows/columns
   or understand header relationships. Add table peers with row/column/header
   associations. (`Accessibility/`)
 
-- 🟠 **Add List / ListItem UIA control types**
+- ✅ **Add List / ListItem UIA control types**
   List blocks are plain text to UIA. Narrator cannot announce "list with N items".
   Add UIA `List` and `ListItem` control types to the list/list-item block peers.
 
-- 🟡 **Expose code block language hint in UIA**
+- ✅ **Expose code block language hint in UIA**
   The fenced code info string (e.g. `typescript`) is available from Markdig but
   discarded at render time. Expose it as a UIA `HelpText` or custom property.
+
+- 🟠 **Manual Narrator + real Windows theme smoke**
+  CI now covers forced RTL and forced high-contrast palettes deterministically,
+  but a release-quality pass still needs manual/optional smoke across Narrator,
+  every built-in Windows contrast theme, a customized contrast theme, and real
+  system language changes.
 
 ---
 

--- a/docs/markdown-renderer/accessibility.md
+++ b/docs/markdown-renderer/accessibility.md
@@ -8,91 +8,73 @@ accessibility. This is a major requirement for production maturity.
 Implemented:
 
 - `MarkdownAutomationPeer` exposes the control as `AutomationControlType.Document`;
-- document text is aggregated into the root peer name with a length cap;
+- the root peer implements `ITextProvider` and exposes `ITextRangeProvider`
+  ranges for document text, visible ranges, selection, range-from-point,
+  text search, word/line/paragraph movement, bounding rectangles, children, and
+  scroll-into-view;
+- `ITextProvider.RangeFromChild` maps UIA child providers back to semantic text
+  ranges for links, images, table/list nodes, and hosted WinUI embeds;
+- `ITextRangeProvider.GetAttributeValue` and `FindAttribute` expose common
+  native text attributes: read-only/hidden/active/culture/flow direction, font
+  family/size/weight, foreground/background color, underline, strikethrough,
+  style id/name, and superscript;
+- document text is built from a semantic model over the committed layout
+  snapshot and is also aggregated into the root peer name with a length cap;
 - `MarkdownBlockPeer` exposes inline-container blocks such as paragraphs,
   headings, code blocks, list content, and table cell text;
+- headings expose `GetHeadingLevelCore`;
 - `MarkdownLinkPeer` implements `IInvokeProvider` for links;
 - link activation through UIA raises the same control path as pointer activation;
-- image alt text and SVG title/description are included in aggregated text;
-- keyboard focus ring supports link/embed navigation;
+- link peers report tight text-run bounds rather than the whole renderer;
+- list and list-item peers expose native UIA `List` / `ListItem` control types;
+- table and cell peers expose `Table`, `Grid`, `TableItem`, and `GridItem`
+  patterns with row/column/header metadata;
+- image peers expose alt text / SVG title as name and SVG description as help text;
+- fenced code block language info is exposed as help text;
+- keyboard focus ordering coordinates painted links and hosted WinUI embeds;
 - hosted WinUI embeds expose their normal XAML UIA peers through the visual tree.
 
 ## Current peer model
 
 ```text
 MarkdownAutomationPeer (Document)
-  MarkdownBlockPeer (paragraph/heading/list marker/table cell/etc.)
+  MarkdownBlockPeer (paragraph/heading/code)
     MarkdownLinkPeer (Invoke)
-  Hosted WinUI element peers through XAML visual tree
+  MarkdownNodePeer (List)
+    MarkdownNodePeer (ListItem)
+      MarkdownBlockPeer (...)
+  MarkdownNodePeer (Table: Grid + Table)
+    MarkdownNodePeer (TableCell: GridItem + TableItem)
+      MarkdownBlockPeer (...)
+  MarkdownNodePeer (Image)
+  Hosted WinUI element peers through XAML visual tree and TextRange children
 ```
 
-The root peer walks the committed `LayoutSnapshot` and creates stable block peers
-using weak-table caching. Link peers are also cached by `LinkRun` identity.
+The root peer builds a semantic accessibility model from the committed
+`LayoutSnapshot`. Block peers are cached by `InlineContainerBox` identity and
+link peers by `LinkRun` identity; semantic node peers are cached for the current
+snapshot.
 
-## Screen-reader limitations
+## Remaining gaps
 
-The current accessibility layer is useful but incomplete:
+The foundational UIA surface is now in place. Remaining work is depth and
+real-world validation:
 
-- no `ITextProvider`;
-- no `ITextRangeProvider`;
-- no selection pattern;
-- heading levels are not fully exposed through `GetHeadingLevelCore`;
-- lists are not represented as List/ListItem control types;
-- tables do not implement `ITableProvider` / `ITableItemProvider`;
-- code block language information is not exposed;
-- image and caption semantics are flattened into text;
-- hosted WinUI embeds and painted markdown are not yet bridged into one coherent
-  semantic tree.
-
-## Required maturity work
-
-### Text pattern
-
-Implementing `ITextProvider` and `ITextRangeProvider` is the largest accessibility
-task. It should allow assistive technology to:
-
-- retrieve text ranges;
-- move by character, word, line, paragraph, and document;
-- find text;
-- retrieve bounding rectangles;
-- query selection;
-- map from screen point to text range.
-
-The existing `DocumentPosition`, `DocumentRange`, `MarkdownSourceMap`, and
-selection rectangle code provide useful foundations, but UIA requires a more
-complete range abstraction.
-
-### Heading levels
-
-Heading blocks should expose the correct heading level. This likely requires
-storing heading level metadata on `InlineContainerBox` or introducing a dedicated
-heading box/semantic role.
-
-### Tables
-
-Tables need peers that preserve row/column/header relationships. A mature table
-implementation should expose:
-
-- row count;
-- column count;
-- row and column index per cell;
-- header association;
-- cell text ranges.
-
-### Lists
-
-List and list item semantics should be explicit. Markers should not be the only
-way for assistive technology to infer list structure.
+- manual Narrator smoke across Windows contrast themes and system languages;
+- deeper `ITextRangeProvider` attribute coverage for advanced attributes not
+  represented in the markdown style model, such as annotation objects, tabs,
+  margins, and paragraph spacing;
+- arrow-key spatial navigation and pointer-resume semantics that match native
+  controls in more edge cases;
+- richer row-header modeling for future table syntaxes that support row headers;
+- broader verification around virtualized embeds and offscreen text ranges.
 
 ## Accessibility testing
 
-Current automation checks verify tree shape, discoverability, keyboard traversal,
-focus behavior, and selection effects. Future accessibility tests should include:
-
-- Narrator/manual smoke checklist;
-- UIA Text pattern compliance tests;
-- table navigation tests;
-- heading navigation tests;
-- mixed RTL/LTR document tests;
-- hosted embed focus order tests.
+Current automation checks verify tree shape, TextPattern document text/ranges/
+bounds/selection, `RangeFromChild`, text attributes, heading/list/table/image/link
+roles, table dimensions, hosted button focus order, keyboard traversal, focus
+dismissal, deterministic forced high contrast, and selection reliability. Manual
+smoke should still cover Narrator phrasing and all built-in/custom Windows
+contrast themes because those are OS-environment dependent.
 

--- a/docs/markdown-renderer/selection-and-clipboard.md
+++ b/docs/markdown-renderer/selection-and-clipboard.md
@@ -61,7 +61,16 @@ Implemented:
 - selection across text blocks;
 - word and block expansion;
 - source-accurate copy;
-- overlay highlight rectangles;
+- selection adorner fill rectangles derived from WinUI's native
+  `TextControlSelectionHighlightColor` resource, pre-composited over the
+  renderer surface when the native brush is translucent so previously painted
+  glyphs do not show through;
+- selected glyph foreground overpainted from WinUI's native selected-text
+  foreground resource on the same single viewport-sized Win2D adorner surface;
+- no per-drag XAML child creation/resizing and no document-canvas invalidation
+  while dragging selection;
+- app-wide dismissal: pointer/focus movement outside the renderer clears the
+  selection, and active selections are coordinated across renderer instances;
 - selection automation that verifies real `sel-anchor`, `sel-extend`, and
   `sel-rect-phys` diagnostics;
 - no canvas repaint during selection drag on Embeds sample.

--- a/docs/markdown-renderer/testing-and-diagnostics.md
+++ b/docs/markdown-renderer/testing-and-diagnostics.md
@@ -7,7 +7,7 @@ diagnostic logging for paint/selection regressions.
 
 | Project | Purpose |
 | --- | --- |
-| `MarkdownRenderer.Tests` | Unit tests for parsing, layout, theming, selection, SVG helpers, and regressions. |
+| `MarkdownRenderer.Tests` | Pure-logic unit tests for parsing, source maps, text boundaries, focus item semantics, SVG helpers, image loading, and regressions. |
 | `MarkdownRenderer.Sample` | Manual WinUI test host with feature pages. |
 | `MarkdownRenderer.Sample.Automation` | FlaUI UI automation against the sample app. |
 | `MarkdownRenderer.PixelTests` | SVG fixture and pixel-comparison infrastructure. |
@@ -37,6 +37,19 @@ dotnet test MarkdownRenderer\MarkdownRenderer.Tests\MarkdownRenderer.Tests.cspro
 Current automation checks include:
 
 - automation tree shape;
+- Accessibility Lab TextPattern text/ranges/bounds;
+- Accessibility Lab `RangeFromChild` for hyperlinks, images, and hosted WinUI
+  embedded controls;
+- Accessibility Lab UIA text attributes for links, code, read-only text, and
+  flow/color attributes;
+- Accessibility Lab semantic roles for headings, links, lists, tables, cells,
+  images, hosted buttons, and task checkboxes;
+- deterministic forced high-contrast palette resolution through the sample's
+  `ForcedHighContrastToggle`;
+- Accessibility Lab keyboard order from painted links into hosted WinUI controls;
+- pointer-dismiss resume within the markdown focus order;
+- selection dismissal when clicking another app control or a hosted WinUI
+  control inside the markdown surface;
 - RTL flow toggle;
 - sample button discoverability;
 - embed virtualization bounded realization;
@@ -53,7 +66,12 @@ Current automation checks include:
 - Embeds-page selection text-shake regression.
 
 Selection automation validates actual selection diagnostics instead of relying on
-guessed coordinates. A selection probe must produce events such as:
+guessed coordinates. The current probes derive target points from UIA
+TextPattern bounding rectangles, validate that the point produces a `sel-anchor`
+event, and only then perform the target double-click, triple-click, or drag
+gesture. This also covers short documents whose rendered canvas content is
+vertically centered inside the control. A selection probe must produce events
+such as:
 
 - `sel-anchor`;
 - `ptr-move-drag`;
@@ -65,8 +83,11 @@ occur during the measured selection drag.
 
 ## ShakeLogger
 
-`MarkdownRenderer.Diagnostics.ShakeLogger` writes diagnostic events to
-`text_shaking2.log` at the repository root during sample runs.
+`MarkdownRenderer.Diagnostics.ShakeLogger` is off by default. Enable it only
+when collecting paint/selection diagnostics by setting either
+`MARKDOWN_RENDERER_DIAGNOSTICS=1` or `MARKDOWN_RENDERER_SHAKE_LOG=1`, or by
+launching the sample with `--markdown-renderer-diagnostics`. When enabled it
+writes diagnostic events to `text_shaking2.log` at the repository root.
 
 Important markers:
 
@@ -75,18 +96,20 @@ Important markers:
 - `sel-anchor`: selection anchor was set;
 - `ptr-move-drag`: pointer moved during a captured selection drag;
 - `sel-extend`: selection range changed;
-- `sel-rect-phys`: selection overlay rectangle was updated.
+- `sel-rect-phys`: selection adorner rectangle was updated.
+- `sel-adorner-draw`: selection adorner rendered at least one selected frame.
 
-This log is used to catch regressions where selection/hover accidentally repaint
-text and cause visible shake.
+The UI automation harness enables diagnostics for the probes that read this log.
+Normal sample and app runs stay quiet so paint and pointer paths do not pay the
+logging cost.
 
 ## Test gaps
 
 Needed before maturity:
 
-- UIA Text pattern compliance once implemented;
-- table and list accessibility tests;
-- mixed RTL/LTR documents;
+- more exhaustive mixed RTL/LTR documents;
+- real Narrator smoke across built-in and customized Windows contrast themes;
+- optional system language / MRT layout-direction smoke;
 - 10K-line and 100K-word stress documents;
 - rapid theme switching;
 - concurrent scroll + selection + theme changes;

--- a/docs/markdown-renderer/theming-and-customization.md
+++ b/docs/markdown-renderer/theming-and-customization.md
@@ -2,7 +2,7 @@
 
 The renderer uses a native object model for styling rather than CSS. Consumers
 provide a `MarkdownTheme`, and the renderer resolves it against Windows 11
-defaults and the current WinUI `ActualTheme`.
+defaults, the current WinUI `ActualTheme`, and Windows high contrast settings.
 
 ## Main types
 
@@ -11,8 +11,8 @@ defaults and the current WinUI `ActualTheme`.
 | `MarkdownTheme` | Consumer-owned theme object with `AccentColor`, `Overrides`, `Revision`, and `Changed`. |
 | `ElementStyle` | Fully resolved immutable-ish style used by layout and paint. |
 | `ElementStyleOverride` | Nullable partial style override supplied by consumers. |
-| `ThemeResolver` | Merges Win11 defaults, current light/dark theme, accent color, and overrides. |
-| `ThemeSnapshot` | Resolved style set captured for a layout pass. |
+| `ThemeResolver` | Merges Win11 defaults, current light/dark theme, high contrast system colors, accent color, and overrides. |
+| `ThemeSnapshot` | Resolved style set and surface color captured for a layout pass. |
 | `MarkdownElementKeys` | Built-in style keys for markdown element categories. |
 
 ## Built-in element keys
@@ -94,9 +94,24 @@ The control listens to `ActualThemeChanged`. If a `MarkdownTheme` is assigned,
 the control calls `theme.Invalidate()`, which raises `Theme.Changed` and triggers
 a rebuild. If no custom theme is assigned, it rebuilds directly.
 
-Current behavior is correct but coarse: theme changes re-run parse and layout.
+The control also listens to `Microsoft.UI.System.ThemeSettings.Changed` for the
+current window. When Windows enters or leaves a contrast theme, the renderer
+rebuilds against system colors such as Window, WindowText, Hotlight, Highlight,
+and HighlightText. The canvas clear color comes from `ThemeSnapshot.SurfaceColor`
+so high contrast does not leave a light/dark hardcoded background behind.
+
+High contrast defaults avoid scheme-name-specific palettes. The role mapping
+lives in `MarkdownHighContrastDefaults` and is unit-tested with deterministic
+roles; the sample automation also forces a fake high-contrast palette and checks
+the resulting UIA text attributes. Consumer `MarkdownTheme` overrides are still
+honored as explicit overrides, so app authors remain responsible for ensuring
+custom colors meet contrast requirements.
+
+Current behavior is intentionally coarse: theme changes re-run parse and layout.
 Future work should add a restyle-only path that reuses the parsed AST and only
-rebuilds text metrics and colors.
+rebuilds text metrics and colors. Real Windows contrast-theme smoke still needs
+to cover every built-in theme plus customized palettes because those OS settings
+are intrusive and environment-dependent.
 
 ## Important current limitation
 

--- a/global.json
+++ b/global.json
@@ -1,7 +1,7 @@
 {
   "sdk": {
     "version": "10.0.202",
-    "rollForward": "latestPatch",
+    "rollForward": "latestFeature",
     "allowPrerelease": false
   }
 }


### PR DESCRIPTION
## Summary

This PR brings the WinUI markdown renderer much closer to native-control accessibility behavior and hardens the selection/clipboard path that shook out during manual testing.

## What Changed

- Added a semantic accessibility model and richer UIA peer tree for headings, paragraphs, links, images, lists, tables/cells, code blocks, and hosted embeds.
- Implemented TextPattern support with document/visible ranges, movement, selection, bounding rectangles, range-from-point behavior, scroll-into-view, and word-sized Narrator rectangles.
- Added high contrast/system theme integration, system FlowDirection helper support, localized automation/context strings, and native-looking focus/keyboard coordination across painted links and hosted WinUI controls.
- Reworked text selection rendering onto a single stable Win2D adorner so selection uses native colors without repainting/shaking document text.
- Fixed selection edge cases for thematic breaks, cross-page persistence, multi-control dismissal, table row-border hit-testing, and Ctrl+C after pointer selection.
- Expanded sample automation and unit coverage, and updated markdown renderer docs/TODOs.

## Root Causes Fixed

- Narrator only saw a custom/root-like surface because text ranges and semantic peers were too flat.
- Selection color/shake regressions came from painting selection in the document text layer or covering text without repainting selected foreground.
- Table drag flicker came from table-gap hit testing returning the table container block index instead of a nearby real cell caret.
- Ctrl+C after drag could miss the renderer because WinUI focus routing may remain on a stale element after pointer selection.

## Validation

- `dotnet build MarkdownRenderer\MarkdownRenderer.Sample\MarkdownRenderer.Sample.csproj -p:Platform=x64 --no-restore`
- `dotnet build MarkdownRenderer\MarkdownRenderer.Sample.Automation\MarkdownRenderer.Sample.Automation.csproj -p:Platform=x64 --no-restore`
- `dotnet test MarkdownRenderer\MarkdownRenderer.Tests\MarkdownRenderer.Tests.csproj -p:Platform=x64 --no-restore` -> 218 passed
- Full sample automation run -> 26 passed, 0 failed
- `git diff --cached --check`

## Notes

Narrator screenshot artifacts generated during manual smoke testing are intentionally not included in this PR.
