### PR TITLE
[codex] Fix repo manage crash

### DIFF
--- a/JitHub.WinUI.Tests/XamlBindingPatternTests.cs
+++ b/JitHub.WinUI.Tests/XamlBindingPatternTests.cs
@@ -77,6 +77,41 @@ public sealed class XamlBindingPatternTests
             string.Join(Environment.NewLine, violations));
     }
 
+    [Fact]
+    public void ContainerStyleIsOnlyAppliedToBorders()
+    {
+        string winuiRoot = FindWinUIProjectRoot();
+        List<string> violations = [];
+
+        foreach (string path in Directory.EnumerateFiles(winuiRoot, "*.xaml", SearchOption.AllDirectories).Order())
+        {
+            string relativePath = Path.GetRelativePath(winuiRoot, path);
+            string text = File.ReadAllText(path);
+
+            foreach (Match match in Regex.Matches(
+                text,
+                "<(?<element>[\\w:]+)\\b(?<attrs>[^>]*\\bStyle\\s*=\\s*\"\\{(?:ThemeResource|StaticResource)\\s+Container\\}\"[^>]*)>",
+                RegexOptions.Singleline))
+            {
+                string element = match.Groups["element"].Value;
+                if (string.Equals(element, "Border", StringComparison.Ordinal) ||
+                    element.EndsWith(":Border", StringComparison.Ordinal))
+                {
+                    continue;
+                }
+
+                int line = GetLineNumber(text, match.Index);
+                violations.Add($"{relativePath}:{line}: {element}");
+            }
+        }
+
+        Assert.True(
+            violations.Count == 0,
+            "The shared Container style targets Border and crashes XAML parsing when applied to another element:" +
+            Environment.NewLine +
+            string.Join(Environment.NewLine, violations));
+    }
+
     private static bool IsWholeObjectOrFrameworkBinding(string expression)
     {
         if (string.IsNullOrWhiteSpace(expression))

--- a/JitHub.WinUI/ViewModels/Pages/RepoManagePageViewModel.cs
+++ b/JitHub.WinUI/ViewModels/Pages/RepoManagePageViewModel.cs
@@ -7,9 +7,11 @@ using System.Threading.Tasks;
 using CommunityToolkit.Mvvm.ComponentModel;
 using JitHub.Models.GitHub;
 using JitHub.Services;
+using Microsoft.UI.Xaml.Data;
 
 namespace JitHub.WinUI.ViewModels.Pages;
 
+[Bindable]
 public sealed partial class RepoManagePageViewModel : ViewModelBase
 {
     private readonly IAuthService _authService;
@@ -29,6 +31,12 @@ public sealed partial class RepoManagePageViewModel : ViewModelBase
     }
 
     public ObservableCollection<GitHubRepositorySelectionItem> Repositories { get; } = [];
+
+    public string PageTitle => GetString("RepoManage.PageTitle", "Manage repositories");
+
+    public string PageDescription => GetString(
+        "RepoManage.PageDescription",
+        "Review and delete repositories from your GitHub account.");
 
     public string DeleteSelectedButtonText => GetString("RepoManage.DeleteSelectedButton", "Delete selected");
 
@@ -65,6 +73,9 @@ public sealed partial class RepoManagePageViewModel : ViewModelBase
     public partial bool IsDeletionProgressVisible { get; set; }
 
     [ObservableProperty]
+    public partial bool IsLoadingRepositories { get; set; }
+
+    [ObservableProperty]
     public partial double DeletionProgressValue { get; set; }
 
     [ObservableProperty]
@@ -82,6 +93,7 @@ public sealed partial class RepoManagePageViewModel : ViewModelBase
 
         try
         {
+            IsLoadingRepositories = true;
             StatusText = GetString("RepoManage.LoadingRepositories", "Loading repositories...");
             Repositories.Clear();
             AreRepositoriesVisible = false;
@@ -134,6 +146,19 @@ public sealed partial class RepoManagePageViewModel : ViewModelBase
             StatusText = GetString(
                 "Dashboard.RepositoriesNetworkError",
                 "JitHub could not reach GitHub to load your repositories.");
+        }
+        catch (Exception ex)
+        {
+            AreRepositoriesVisible = false;
+            IsEmptyStateVisible = true;
+            StatusText = FormatString(
+                "RepoManage.LoadFailureStatus",
+                "JitHub could not load repositories: {0}",
+                ex.Message);
+        }
+        finally
+        {
+            IsLoadingRepositories = false;
         }
     }
 
@@ -203,6 +228,10 @@ public sealed partial class RepoManagePageViewModel : ViewModelBase
                 {
                     failures.Add($"{repositoryItem.Repository.FullName}: {GetString("RepoManage.DeleteFailureNetworkErrorShort", "network error")}");
                 }
+                catch (Exception ex)
+                {
+                    failures.Add($"{repositoryItem.Repository.FullName}: {ex.Message}");
+                }
             }
 
             await LoadRepositoriesAsync();
@@ -231,9 +260,32 @@ public sealed partial class RepoManagePageViewModel : ViewModelBase
             selectedRepositoryCount);
     }
 
+    public void ShowUnexpectedError(Exception exception)
+    {
+        AreRepositoriesVisible = Repositories.Count > 0;
+        IsEmptyStateVisible = Repositories.Count == 0;
+        StatusText = FormatString(
+            "RepoManage.UnexpectedErrorStatus",
+            "JitHub could not manage repositories: {0}",
+            exception.Message);
+        IsInteractionEnabled = true;
+        IsDeletionProgressVisible = false;
+        IsLoadingRepositories = false;
+    }
+
     private bool TryGetActiveToken(out string token)
     {
-        token = GetActiveToken() ?? string.Empty;
+        try
+        {
+            token = GetActiveToken() ?? string.Empty;
+        }
+        catch (Exception ex)
+        {
+            token = string.Empty;
+            ShowUnexpectedError(ex);
+            return false;
+        }
+
         if (!string.IsNullOrWhiteSpace(token))
         {
             return true;

--- a/JitHub.WinUI/Views/DataTemplates/Repository/ForkRepo.xaml
+++ b/JitHub.WinUI/Views/DataTemplates/Repository/ForkRepo.xaml
@@ -58,7 +58,7 @@
         </Button>
     </DataTemplate>
     <DataTemplate x:Key="SelectableForkRepo">
-        <Grid Style="{ThemeResource Container}">
+        <Border Style="{ThemeResource Container}">
             <CheckBox IsChecked="{Binding Selected, Mode=TwoWay}">
                 <Grid Margin="16,0,0,0">
                     <Grid.ColumnDefinitions>
@@ -85,7 +85,7 @@
                     </StackPanel>
                 </Grid>
             </CheckBox>
-        </Grid>
+        </Border>
     </DataTemplate>
 </ResourceDictionary>
 

--- a/JitHub.WinUI/Views/DataTemplates/Repository/PrivateRepo.xaml
+++ b/JitHub.WinUI/Views/DataTemplates/Repository/PrivateRepo.xaml
@@ -58,7 +58,7 @@
         </Button>
     </DataTemplate>
     <DataTemplate x:Key="SelectablePrivateRepo">
-        <Grid Style="{ThemeResource Container}">
+        <Border Style="{ThemeResource Container}">
             <CheckBox IsChecked="{Binding Selected, Mode=TwoWay}">
                 <Grid Margin="16,0,0,0">
                     <Grid.ColumnDefinitions>
@@ -85,7 +85,7 @@
                     </StackPanel>
                 </Grid>
             </CheckBox>
-        </Grid>
+        </Border>
     </DataTemplate>
 </ResourceDictionary>
 

--- a/JitHub.WinUI/Views/DataTemplates/Repository/PublicRepo.xaml
+++ b/JitHub.WinUI/Views/DataTemplates/Repository/PublicRepo.xaml
@@ -62,7 +62,7 @@
         </Button>
     </DataTemplate>
     <DataTemplate x:Key="SelectablePublicRepo">
-        <Grid Style="{ThemeResource Container}">
+        <Border Style="{ThemeResource Container}">
             <CheckBox IsChecked="{Binding Selected, Mode=TwoWay}">
                 <Grid Margin="16,0,0,0">
                     <Grid.ColumnDefinitions>
@@ -89,7 +89,7 @@
                     </StackPanel>
                 </Grid>
             </CheckBox>
-        </Grid>
+        </Border>
     </DataTemplate>
 </ResourceDictionary>
 

--- a/JitHub.WinUI/Views/Pages/RepoManagePage.xaml
+++ b/JitHub.WinUI/Views/Pages/RepoManagePage.xaml
@@ -1,87 +1,141 @@
 <Page
     x:Class="JitHub.WinUI.Views.Pages.RepoManagePage"
+    x:Name="Root"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:local="using:JitHub.WinUI.Views.Pages"
+    xmlns:appcontrols="using:JitHub.WinUI.Views.Controls.App"
+    xmlns:common="using:JitHub.WinUI.Views.Controls.Common"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
-    xmlns:repositoryviewmodels="using:JitHub.WinUI.ViewModels.RepositoryViewModels"
-    xmlns:helpers="using:JitHub.WinUI.Helpers"
-    mc:Ignorable="d"
+    xmlns:models="using:JitHub.Models.GitHub"
+    xmlns:viewmodels="using:JitHub.WinUI.ViewModels.Pages"
+    x:DataType="viewmodels:RepoManagePageViewModel"
     Background="Transparent"
-    Loaded="Page_Loaded">
-    <Page.DataContext>
-        <repositoryviewmodels:RepoManageViewModel x:Name="ViewModel"/>
-    </Page.DataContext>
-    <Page.Resources>
-        <helpers:RepoIconTemplateSelector
-            x:Key="RepoTemplate"
-            PublicTemplate="{StaticResource SelectablePublicRepo}"
-            PrivateTemplate="{StaticResource SelectablePrivateRepo}"
-            ForkTemplate="{StaticResource SelectableForkRepo}"/>
-    </Page.Resources>
-    <Grid
-        Padding="16 16 0 16">
+    Loaded="Page_Loaded"
+    mc:Ignorable="d">
+    <Grid Padding="{ThemeResource AppPagePadding}" RowSpacing="16">
         <Grid.RowDefinitions>
-            <RowDefinition Height="auto"/>
-            <RowDefinition Height="*"/>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="*" />
+            <RowDefinition Height="Auto" />
         </Grid.RowDefinitions>
-        <muxc:ProgressRing
-            Height="32"
-            Width="32"
-            HorizontalAlignment="Center"
-            VerticalAlignment="Center"
-            IsActive="True"
-            Visibility="{x:Bind ViewModel.Loading, Mode=OneWay}"/>
-        <muxc:ProgressBar
+
+        <appcontrols:AppSectionHeader
+            Title="{x:Bind ViewModel.PageTitle, Mode=OneWay}"
+            Description="{x:Bind ViewModel.PageDescription, Mode=OneWay}">
+            <appcontrols:AppSectionHeader.ActionContent>
+                <StackPanel Orientation="Horizontal" Spacing="8">
+                    <Button
+                        AutomationProperties.Name="{x:Bind ViewModel.DeleteSelectedButtonText, Mode=OneWay}"
+                        Click="DeleteSelectedButton_Click"
+                        IsEnabled="{x:Bind ViewModel.IsInteractionEnabled, Mode=OneWay}"
+                        Style="{StaticResource AppDangerOutlineButtonStyle}"
+                        ToolTipService.ToolTip="{x:Bind ViewModel.DeleteSelectedButtonText, Mode=OneWay}">
+                        <FontIcon FontFamily="{StaticResource SegoeFluentIcons}" Glyph="&#xE74D;" />
+                    </Button>
+                    <Button
+                        AutomationProperties.Name="{x:Bind ViewModel.ClearSelectionButtonText, Mode=OneWay}"
+                        Click="ClearSelectionButton_Click"
+                        IsEnabled="{x:Bind ViewModel.IsInteractionEnabled, Mode=OneWay}"
+                        Style="{StaticResource AppToolbarButtonStyle}"
+                        ToolTipService.ToolTip="{x:Bind ViewModel.ClearSelectionButtonText, Mode=OneWay}">
+                        <FontIcon FontFamily="{StaticResource SegoeFluentIcons}" Glyph="&#xE711;" />
+                    </Button>
+                    <Button
+                        AutomationProperties.Name="{x:Bind ViewModel.ReloadButtonText, Mode=OneWay}"
+                        Click="ReloadButton_Click"
+                        IsEnabled="{x:Bind ViewModel.IsInteractionEnabled, Mode=OneWay}"
+                        Style="{StaticResource AppToolbarButtonStyle}"
+                        ToolTipService.ToolTip="{x:Bind ViewModel.ReloadButtonText, Mode=OneWay}">
+                        <FontIcon FontFamily="{StaticResource SegoeFluentIcons}" Glyph="&#xE72C;" />
+                    </Button>
+                </StackPanel>
+            </appcontrols:AppSectionHeader.ActionContent>
+        </appcontrols:AppSectionHeader>
+
+        <Grid Grid.Row="1" RowSpacing="8">
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="Auto" />
+            </Grid.RowDefinitions>
+            <ProgressBar
+                HorizontalAlignment="Stretch"
+                IsIndeterminate="True"
+                Visibility="{x:Bind ViewModel.IsLoadingRepositories, Converter={StaticResource BoolToVisibilityConverter}, Mode=OneWay}" />
+            <TextBlock
+                Grid.Row="1"
+                Style="{StaticResource SectionSecondaryTextBlockStyle}"
+                Text="{x:Bind ViewModel.StatusText, Mode=OneWay}"
+                TextWrapping="Wrap" />
+        </Grid>
+
+        <Grid Grid.Row="2">
+            <ListView
+                IsEnabled="{x:Bind ViewModel.IsInteractionEnabled, Mode=OneWay}"
+                ItemsSource="{x:Bind ViewModel.Repositories, Mode=OneWay}"
+                SelectionMode="None"
+                Visibility="{x:Bind ViewModel.AreRepositoriesVisible, Converter={StaticResource BoolToVisibilityConverter}, Mode=OneWay}">
+                <ListView.ItemContainerStyle>
+                    <Style TargetType="ListViewItem">
+                        <Setter Property="Padding" Value="0" />
+                        <Setter Property="Margin" Value="0,0,0,8" />
+                        <Setter Property="HorizontalContentAlignment" Value="Stretch" />
+                    </Style>
+                </ListView.ItemContainerStyle>
+                <ListView.ItemTemplate>
+                    <DataTemplate x:DataType="models:GitHubRepositorySelectionItem">
+                        <Border Style="{ThemeResource Container}">
+                            <CheckBox
+                                HorizontalContentAlignment="Stretch"
+                                IsChecked="{x:Bind Selected, Mode=TwoWay}">
+                                <Grid Margin="14,0,0,0" RowSpacing="4">
+                                    <Grid.RowDefinitions>
+                                        <RowDefinition Height="Auto" />
+                                        <RowDefinition Height="Auto" />
+                                        <RowDefinition Height="Auto" />
+                                    </Grid.RowDefinitions>
+                                    <TextBlock
+                                        Style="{StaticResource ListItemTitleTextBlockStyle}"
+                                        Text="{x:Bind Repository.FullName, Mode=OneWay}"
+                                        TextTrimming="CharacterEllipsis" />
+                                    <TextBlock
+                                        Grid.Row="1"
+                                        Style="{StaticResource SectionSecondaryTextBlockStyle}"
+                                        Text="{x:Bind Repository.Description, Mode=OneWay}"
+                                        TextWrapping="Wrap" />
+                                    <StackPanel
+                                        Grid.Row="2"
+                                        Orientation="Horizontal"
+                                        Spacing="4">
+                                        <appcontrols:AppIcon
+                                            VerticalAlignment="Center"
+                                            IconBrush="{ThemeResource AppWarmAccentBrush}"
+                                            IconKind="Star"
+                                            IconSize="14" />
+                                        <TextBlock
+                                            VerticalAlignment="Center"
+                                            Style="{StaticResource SectionSecondaryTextBlockStyle}"
+                                            Text="{x:Bind Repository.StargazersCount, Mode=OneWay}" />
+                                    </StackPanel>
+                                </Grid>
+                            </CheckBox>
+                        </Border>
+                    </DataTemplate>
+                </ListView.ItemTemplate>
+            </ListView>
+
+            <common:EmptyStateView
+                Title="{x:Bind ViewModel.EmptyStateTitle, Mode=OneWay}"
+                Description="{x:Bind ViewModel.EmptyStateDescription, Mode=OneWay}"
+                Visibility="{x:Bind ViewModel.IsEmptyStateVisible, Converter={StaticResource BoolToVisibilityConverter}, Mode=OneWay}" />
+        </Grid>
+
+        <ProgressBar
+            Grid.Row="3"
             HorizontalAlignment="Stretch"
-            VerticalAlignment="Top"
-            Maximum="{x:Bind ViewModel.TotalRepoToDelete, Mode=OneWay}"
-            Value="{x:Bind ViewModel.Progress, Mode=OneWay}"
-            Visibility="{x:Bind ViewModel.Deleting, Mode=OneWay}"/>
-        <StackPanel
-            Grid.Row="0"
-            Orientation="Horizontal"
-            Padding="16 8"
-            Spacing="8"
-            HorizontalAlignment="Right">
-            <Button
-                x:Name="DeleteButton"
-                Style="{StaticResource AppDangerOutlineButtonStyle}"
-                Command="{x:Bind ViewModel.DeleteCommand, Mode=OneWay}">
-                <FontIcon
-                    FontFamily="{StaticResource SegoeFluentIcons}"
-                    Glyph="&#xE74D;"/>
-            </Button>
-            <Button
-                x:Name="CancelButton"
-                Style="{StaticResource AppToolbarButtonStyle}"
-                Click="{x:Bind ViewModel.DeselectAll, Mode=OneWay}">
-                <FontIcon
-                    FontFamily="{StaticResource SegoeFluentIcons}"
-                    Glyph="&#xE711;"/>
-            </Button>
-            <Button
-                x:Name="RefreshButton"
-                Style="{StaticResource AppToolbarButtonStyle}"
-                Command="{x:Bind ViewModel.LoadCommand, Mode=OneWay}">
-                <FontIcon
-                    FontFamily="{StaticResource SegoeFluentIcons}"
-                    Glyph="&#xE72C;"/>
-            </Button>
-        </StackPanel>
-        <ScrollViewer
-            Grid.Row="1"
-            Padding="0 0 16 0">
-            <muxc:ItemsRepeater
-                ItemsSource="{x:Bind ViewModel.Repos, Mode=OneWay}"
-                ItemTemplate="{StaticResource RepoTemplate}">
-                <muxc:ItemsRepeater.Layout>
-                    <muxc:StackLayout Spacing="8"/>
-                </muxc:ItemsRepeater.Layout>
-            </muxc:ItemsRepeater>
-        </ScrollViewer>
+            Maximum="{x:Bind ViewModel.DeletionProgressMaximum, Mode=OneWay}"
+            Value="{x:Bind ViewModel.DeletionProgressValue, Mode=OneWay}"
+            Visibility="{x:Bind ViewModel.IsDeletionProgressVisible, Converter={StaticResource BoolToVisibilityConverter}, Mode=OneWay}" />
     </Grid>
 </Page>
-

--- a/JitHub.WinUI/Views/Pages/RepoManagePage.xaml.cs
+++ b/JitHub.WinUI/Views/Pages/RepoManagePage.xaml.cs
@@ -1,47 +1,125 @@
 using System;
 using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Runtime.InteropServices.WindowsRuntime;
-using Windows.Foundation;
-using Windows.Foundation.Collections;
+using System.Threading.Tasks;
+using JitHub.Models.GitHub;
+using JitHub.WinUI.ViewModels.Pages;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
-using Microsoft.UI.Xaml.Controls.Primitives;
-using Microsoft.UI.Xaml.Data;
-using Microsoft.UI.Xaml.Input;
-using Microsoft.UI.Xaml.Media;
-using Microsoft.UI.Xaml.Navigation;
 
-// The Blank Page item template is documented at https://go.microsoft.com/fwlink/?LinkId=234238
+namespace JitHub.WinUI.Views.Pages;
 
-namespace JitHub.WinUI.Views.Pages
+public sealed partial class RepoManagePage : Page
 {
-    /// <summary>
-    /// An empty page that can be used on its own or navigated to within a Frame.
-    /// </summary>
-    public sealed partial class RepoManagePage : Page
-    {
-        private bool _initialized;
+    private bool _initialized;
 
-        public RepoManagePage()
+    public RepoManagePageViewModel ViewModel { get; }
+
+    public RepoManagePage()
+    {
+        ViewModel = ((App)Application.Current).GetService<RepoManagePageViewModel>();
+        InitializeComponent();
+        DataContext = ViewModel;
+    }
+
+    private async void Page_Loaded(object sender, RoutedEventArgs e)
+    {
+        if (_initialized)
         {
-            this.InitializeComponent();
+            return;
         }
 
-        private void Page_Loaded(object sender, RoutedEventArgs e)
+        _initialized = true;
+        await LoadRepositoriesSafelyAsync();
+    }
+
+    private async void ReloadButton_Click(object sender, RoutedEventArgs e)
+    {
+        await LoadRepositoriesSafelyAsync();
+    }
+
+    private void ClearSelectionButton_Click(object sender, RoutedEventArgs e)
+    {
+        ViewModel.ClearSelection();
+    }
+
+    private async void DeleteSelectedButton_Click(object sender, RoutedEventArgs e)
+    {
+        try
         {
-            if (_initialized)
+            IReadOnlyList<GitHubRepositorySelectionItem> selectedRepositories = ViewModel.GetSelectedRepositories();
+            if (selectedRepositories.Count == 0)
             {
                 return;
             }
 
-            _initialized = true;
-            if (ViewModel.LoadCommand.CanExecute(null))
+            ContentDialogResult dialogResult = await ShowDeleteConfirmationAsync(selectedRepositories.Count);
+            if (dialogResult != ContentDialogResult.Primary)
             {
-                ViewModel.LoadCommand.Execute(null);
+                return;
+            }
+
+            RepositoryDeletionResult? deletionResult = await ViewModel.DeleteSelectedAsync(selectedRepositories);
+            if (deletionResult?.HasFailures == true)
+            {
+                await ShowDeleteFailuresAsync(deletionResult.Failures);
             }
         }
+        catch (Exception ex)
+        {
+            ViewModel.ShowUnexpectedError(ex);
+        }
+    }
+
+    private async Task LoadRepositoriesSafelyAsync()
+    {
+        try
+        {
+            await ViewModel.LoadRepositoriesAsync();
+        }
+        catch (Exception ex)
+        {
+            ViewModel.ShowUnexpectedError(ex);
+        }
+    }
+
+    private async Task<ContentDialogResult> ShowDeleteConfirmationAsync(int selectedRepositoryCount)
+    {
+        ContentDialog dialog = new()
+        {
+            XamlRoot = XamlRoot,
+            Title = ViewModel.DeleteDialogTitle,
+            Content = new TextBlock
+            {
+                Text = ViewModel.FormatDeleteDialogContent(selectedRepositoryCount),
+                TextWrapping = TextWrapping.Wrap
+            },
+            PrimaryButtonText = ViewModel.DeleteDialogConfirmButtonText,
+            CloseButtonText = ViewModel.DeleteDialogCloseButtonText,
+            DefaultButton = ContentDialogButton.Close
+        };
+
+        return await dialog.ShowAsync();
+    }
+
+    private async Task ShowDeleteFailuresAsync(IReadOnlyList<string> failures)
+    {
+        ContentDialog dialog = new()
+        {
+            XamlRoot = XamlRoot,
+            Title = ViewModel.DeleteFailureDialogTitle,
+            Content = new ScrollViewer
+            {
+                MaxHeight = 320,
+                Content = new TextBlock
+                {
+                    Text = string.Join(Environment.NewLine, failures),
+                    TextWrapping = TextWrapping.Wrap
+                }
+            },
+            CloseButtonText = ViewModel.CloseButtonText,
+            DefaultButton = ContentDialogButton.Close
+        };
+
+        await dialog.ShowAsync();
     }
 }
-


### PR DESCRIPTION
## Summary

Fixes the Manage Repository crash reported during Microsoft Store certification.

## Root cause

The Manage Repository page materialized selectable repository templates that applied the shared `Container` style to `Grid` elements. That style targets `Border`, so WinUI threw a XAML parse exception when the template loaded after clicking the gear button. In the Store crash report this surfaced as a `0xc000027b` fail-fast in `Microsoft.UI.Xaml.dll`.

## Changes

- Use `Border` for selectable repository templates that apply the `Container` style.
- Move `RepoManagePage` to the newer DI-backed `RepoManagePageViewModel` flow.
- Add guarded load/delete handlers so GitHub/auth/API failures become page status instead of escaping through XAML events.
- Add a regression test that prevents applying the `Container` style to non-`Border` elements.

## Validation

- `dotnet build .\JitHub.WinUI\JitHub.WinUI.csproj -c Release -p:PublishAot=false -p:PublishTrimmed=false`
- UI smoke: launched the release app with `--page=home`, invoked `RepoSideBarManage`, verified “Manage repositories” appeared and the process stayed alive.
- `dotnet test .\JitHub.WinUI.Tests\JitHub.WinUI.Tests.csproj -c Release` passed: 99 tests.
- `powershell -NoProfile -ExecutionPolicy Bypass -File .\eng\Build-JitHubWinUIStorePackage.ps1 -ProjectPath .\JitHub.WinUI\JitHub.WinUI.csproj -OutputDirectory .\artifacts\store-smoke -BundlePlatforms x64` completed and produced the bundled `.msixupload`.