### PR TITLE
[codex] Fix packaged markdown text selection

### DIFF
--- a/JitHub.WinUI/Views/Controls/CodeViewer/FilePreviewHost.xaml.cs
+++ b/JitHub.WinUI/Views/Controls/CodeViewer/FilePreviewHost.xaml.cs
@@ -11,6 +11,7 @@ namespace JitHub.WinUI.Views.Controls.CodeViewer;
 public sealed partial class FilePreviewHost : UserControl
 {
     private RepoFilePreviewViewModel? _viewModel;
+    private RepoFilePreviewKind? _currentRendererKind;
 
     public FilePreviewHost()
     {
@@ -54,7 +55,7 @@ public sealed partial class FilePreviewHost : UserControl
             EmptyState.Visibility = Visibility.Visible;
             LoadingState.Visibility = Visibility.Collapsed;
             ErrorState.Visibility = Visibility.Collapsed;
-            RendererHost.Content = null;
+            ClearRenderer();
             return;
         }
 
@@ -73,7 +74,7 @@ public sealed partial class FilePreviewHost : UserControl
             EmptyState.Visibility = Visibility.Collapsed;
             ErrorMessageText.Text = vm.ErrorMessage;
             ErrorState.Visibility = Visibility.Visible;
-            RendererHost.Content = null;
+            ClearRenderer();
             return;
         }
 
@@ -82,17 +83,44 @@ public sealed partial class FilePreviewHost : UserControl
         if (vm.CurrentFile is null)
         {
             EmptyState.Visibility = Visibility.Visible;
-            RendererHost.Content = null;
+            ClearRenderer();
             return;
         }
 
         EmptyState.Visibility = Visibility.Collapsed;
-        RendererHost.Content = CreateRenderer(vm);
+        EnsureRenderer(vm);
     }
 
-    private static FrameworkElement CreateRenderer(RepoFilePreviewViewModel vm)
+    private void EnsureRenderer(RepoFilePreviewViewModel vm)
     {
-        FrameworkElement renderer = vm.Kind switch
+        // Keep the renderer instance stable while the preview kind is unchanged.
+        // Markdown selection owns pointer capture; replacing the control during a
+        // queued preview refresh drops that capture in packaged builds.
+        if (RendererHost.Content is FrameworkElement existing &&
+            _currentRendererKind == vm.Kind)
+        {
+            if (!ReferenceEquals(existing.DataContext, vm))
+                existing.DataContext = vm;
+            return;
+        }
+
+        var renderer = CreateRenderer(vm.Kind);
+        renderer.HorizontalAlignment = HorizontalAlignment.Stretch;
+        renderer.VerticalAlignment = VerticalAlignment.Stretch;
+        renderer.DataContext = vm;
+        RendererHost.Content = renderer;
+        _currentRendererKind = vm.Kind;
+    }
+
+    private void ClearRenderer()
+    {
+        RendererHost.Content = null;
+        _currentRendererKind = null;
+    }
+
+    private static FrameworkElement CreateRenderer(RepoFilePreviewKind kind)
+    {
+        return kind switch
         {
             RepoFilePreviewKind.Code => new CodePreview(),
             RepoFilePreviewKind.Markdown => new MarkdownPreview(),
@@ -107,9 +135,5 @@ public sealed partial class FilePreviewHost : UserControl
             RepoFilePreviewKind.TooLarge => new UnsupportedPreview(),
             _ => new UnsupportedPreview(),
         };
-        renderer.HorizontalAlignment = HorizontalAlignment.Stretch;
-        renderer.VerticalAlignment = VerticalAlignment.Stretch;
-        renderer.DataContext = vm;
-        return renderer;
     }
 }

--- a/MarkdownRenderer/MarkdownRenderer/Controls/MarkdownRendererControl.cs
+++ b/MarkdownRenderer/MarkdownRenderer/Controls/MarkdownRendererControl.cs
@@ -1017,10 +1017,12 @@ public sealed partial class MarkdownRendererControl : UserControl
         };
         _root.Children.Add(_canvas);
         _root.Children.Add(_overlay);
+        _overlay.Children.Add(CreateSelectionAdorner());
+        _overlay.Children.Add(CreateSelectionDragShield());
         _scroll.Content = _root;
 
         _canvas.RegionsInvalidated += OnRegionsInvalidated;
-        _canvas.CreateResources += (_, _) => RequestRebuild(); // rebuild layouts after GPU device loss/recreation
+        _canvas.CreateResources += OnCanvasCreateResources;
         _canvas.PointerPressed += OnPointerPressed;
         _canvas.PointerMoved += OnPointerMoved;
         _canvas.PointerReleased += OnPointerReleased;
@@ -1585,7 +1587,7 @@ public sealed partial class MarkdownRendererControl : UserControl
 
         _selection.Clear();
         _selectionAdornerRects.Clear();
-        try { _selectionAdorner?.Invalidate(); } catch { }
+        InvalidateSelectionAdorner();
     }
 
     private async Task RebuildAsync(CancellationToken ct, RebuildReason reason)
@@ -1818,6 +1820,7 @@ public sealed partial class MarkdownRendererControl : UserControl
         _lastFiredRealizedCount = -1;
         _selectionAdornerRects.Clear();
         EnsureSelectionAdorner();
+        EnsureSelectionDragShield();
         _selection.Clear();             // stale selection no longer valid after re-layout
         _focusedItemIndex = -1;         // selection/focus stale after re-layout
         _focusResumeItemIndex = -1;
@@ -1873,7 +1876,7 @@ public sealed partial class MarkdownRendererControl : UserControl
     {
         EnsureLazyLayoutForViewport();
         UpdateSelectionAdornerViewport();
-        _selectionAdorner?.Invalidate();
+        InvalidateSelectionAdorner();
         // Run a final realisation pass after intermediate-view bursts settle
         // so we don't thrash during fling/inertia. ViewChanged with
         // IsIntermediate=false fires at the end of inertia; we also realise on
@@ -2577,19 +2580,47 @@ public sealed partial class MarkdownRendererControl : UserControl
                 _canvasDeviceRecoveryQueued = false;
                 RequestRebuild();
                 try { _canvas?.Invalidate(); } catch (Exception ex) when (GraphicsDeviceErrors.IsDeviceLost(ex)) { }
-                try { _selectionAdorner?.Invalidate(); } catch (Exception ex) when (GraphicsDeviceErrors.IsDeviceLost(ex)) { }
+                InvalidateSelectionAdorner();
             });
         });
     }
 
+    private void OnCanvasCreateResources(
+        CanvasVirtualControl sender,
+        Microsoft.Graphics.Canvas.UI.CanvasCreateResourcesEventArgs args)
+    {
+        // Initial resource creation can be deferred until the first input frame in
+        // packaged WinUI. Rebuilding there resets pointer capture and selection
+        // state, which makes the first click/drag flash and get swallowed. Layout
+        // uses CanvasDevice.GetSharedDevice(), so initial creation needs no rebuild.
+        // Later resource creation means device/DPI changed, so rebuild layouts.
+        if (args.Reason != Microsoft.Graphics.Canvas.UI.CanvasCreateResourcesReason.FirstTime)
+            RequestRebuild();
+    }
+
     // ---- Input ----
+
+    private static bool IsPrecisePointer(PointerRoutedEventArgs e)
+    {
+        var type = e.Pointer.PointerDeviceType;
+        return type == Microsoft.UI.Input.PointerDeviceType.Mouse ||
+               type == Microsoft.UI.Input.PointerDeviceType.Pen;
+    }
+
+    private bool IsActivePointerSessionEvent(PointerRoutedEventArgs e)
+        => _pointerSession.IsActive && _pointerSession.PointerId == e.Pointer.PointerId;
 
     private void OnPointerPressed(object sender, PointerRoutedEventArgs e)
     {
-        if (_snapshot is null || _canvas is null) return;
+        if (_snapshot is null || _canvas is null)
+            return;
+        if (!IsPrecisePointer(e))
+            return;
+
         // Only process left (primary) button presses; right-clicks are handled by
         // OnRightTapped and must not affect the multi-click counter or selection anchor.
-        if (!e.GetCurrentPoint(_canvas).Properties.IsLeftButtonPressed) return;
+        if (!e.GetCurrentPoint(_canvas).Properties.IsLeftButtonPressed)
+            return;
         var pt = e.GetCurrentPoint(_canvas).Position;
         RememberFocusResumePoint(pt);
 
@@ -2764,6 +2795,9 @@ public sealed partial class MarkdownRendererControl : UserControl
         // Drag-select.
         if (_selectionAnchor is not null)
         {
+            if (!IsActivePointerSessionEvent(e))
+                return;
+
             HideAbbreviationTooltip();
             var dragPoint = PrepareSelectionDragPoint(pt);
             // Atomic embed inclusion: when the pointer is inside an inline
@@ -2836,6 +2870,16 @@ public sealed partial class MarkdownRendererControl : UserControl
             // hovered-run identity flips.  Suppressing the toggle here
             // costs nothing because the IBeam cursor and link-hover color
             // aren't relevant while the user is mid-drag selecting.
+            return;
+        }
+
+        // Touch contacts should pan the containing ScrollViewer. Treating touch
+        // like a mouse press can capture the pointer, start text selection, and
+        // drive the Win2D selection overlay at touch-scroll frequency.
+        if (!IsPrecisePointer(e))
+        {
+            HideAbbreviationTooltip();
+            SetCursorShape(null);
             return;
         }
 
@@ -3119,8 +3163,18 @@ public sealed partial class MarkdownRendererControl : UserControl
         if (_overlay is null)
             return;
 
-        EnsureSelectionAdorner();
+        if (_selectionAdorner is null && !HasInteractiveTextAdornerContent())
+            return;
+
+        if (!EnsureSelectionAdorner())
+            return;
+
         UpdateSelectionAdornerViewport();
+        InvalidateSelectionAdorner();
+    }
+
+    private void InvalidateSelectionAdorner()
+    {
         try
         {
             _selectionAdorner?.Invalidate();
@@ -3128,6 +3182,10 @@ public sealed partial class MarkdownRendererControl : UserControl
         catch (Exception ex) when (GraphicsDeviceErrors.IsDeviceLost(ex))
         {
             HandleCanvasDeviceLost(ex);
+        }
+        catch (System.Runtime.InteropServices.COMException ex)
+        {
+            MarkdownDiagnostics.WriteLine($"[MarkdownRendererControl] selection adorner invalidate failed: {ex.Message}");
         }
     }
 
@@ -3347,7 +3405,7 @@ public sealed partial class MarkdownRendererControl : UserControl
         if (snapshot is null || !_selection.IsActive)
         {
             _selectionAdornerRects.Clear();
-            _selectionAdorner?.Invalidate();
+            InvalidateSelectionAdorner();
             return;
         }
 
@@ -3386,29 +3444,51 @@ public sealed partial class MarkdownRendererControl : UserControl
             }
         }
 
-        EnsureSelectionAdorner();
-        UpdateSelectionAdornerViewport();
-        _selectionAdorner?.Invalidate();
-    }
-
-    private void EnsureSelectionAdorner()
-    {
-        if (_overlay is null)
+        if (!EnsureSelectionAdorner())
             return;
 
-        if (_selectionAdorner is null)
+        UpdateSelectionAdornerViewport();
+        InvalidateSelectionAdorner();
+    }
+
+    private bool HasInteractiveTextAdornerContent()
+        => (_selection.IsActive && _selectionAdornerRects.Count > 0) ||
+           (_lastHoveredRun is LinkRun && _lastHoveredBox is not null) ||
+           TryGetFocusedLink(out _, out _);
+
+    private CanvasControl CreateSelectionAdorner()
+    {
+        var adorner = new CanvasControl
         {
-            _selectionAdorner = new CanvasControl
-            {
-                IsHitTestVisible = false,
-                UseLayoutRounding = true,
-            };
-            _selectionAdorner.Draw += OnSelectionAdornerDraw;
-            Canvas.SetZIndex(_selectionAdorner, 0);
+            IsHitTestVisible = false,
+            UseLayoutRounding = true,
+        };
+        adorner.Draw += OnSelectionAdornerDraw;
+        Canvas.SetZIndex(adorner, 0);
+        _selectionAdorner = adorner;
+        return adorner;
+    }
+
+    private bool EnsureSelectionAdorner()
+    {
+        if (_overlay is null)
+            return false;
+
+        if (_selectionAdorner is null)
+            CreateSelectionAdorner();
+
+        try
+        {
+            if (VisualTreeHelper.GetParent(_selectionAdorner) is null)
+                _overlay.Children.Add(_selectionAdorner);
+        }
+        catch (System.Runtime.InteropServices.COMException ex)
+        {
+            MarkdownDiagnostics.WriteLine($"[MarkdownRendererControl] selection adorner attach failed: {ex.Message}");
+            return false;
         }
 
-        if (VisualTreeHelper.GetParent(_selectionAdorner) is null)
-            _overlay.Children.Add(_selectionAdorner);
+        return true;
     }
 
     private void SetSelectionDragShieldActive(bool active)
@@ -3423,27 +3503,65 @@ public sealed partial class MarkdownRendererControl : UserControl
             return;
         }
 
-        if (_selectionDragShield is null)
+        if (!EnsureSelectionDragShield())
+            return;
+
+        _selectionDragShield!.Width = GetSelectionOverlayWidth();
+        _selectionDragShield.Height = GetSelectionOverlayHeight();
+        _selectionDragShield.Visibility = Visibility.Visible;
+    }
+
+    private Border CreateSelectionDragShield()
+    {
+        var shield = new Border
         {
-            _selectionDragShield = new Border
-            {
-                Background = new SolidColorBrush(Color.FromArgb(1, 0, 0, 0)),
-                IsHitTestVisible = true,
-            };
-            _selectionDragShield.PointerMoved += OnPointerMoved;
-            _selectionDragShield.PointerReleased += OnPointerReleased;
-            _selectionDragShield.PointerCanceled += OnPointerCanceledOrCaptureLost;
-            _selectionDragShield.PointerCaptureLost += OnPointerCanceledOrCaptureLost;
-            Canvas.SetLeft(_selectionDragShield, 0);
-            Canvas.SetTop(_selectionDragShield, 0);
-            Canvas.SetZIndex(_selectionDragShield, 4);
+            Background = new SolidColorBrush(Color.FromArgb(0, 0, 0, 0)),
+            IsHitTestVisible = true,
+            Visibility = Visibility.Collapsed,
+        };
+        shield.PointerMoved += OnPointerMoved;
+        shield.PointerReleased += OnPointerReleased;
+        shield.PointerCanceled += OnPointerCanceledOrCaptureLost;
+        shield.PointerCaptureLost += OnPointerCanceledOrCaptureLost;
+        Canvas.SetLeft(shield, 0);
+        Canvas.SetTop(shield, 0);
+        Canvas.SetZIndex(shield, 4);
+        _selectionDragShield = shield;
+        return shield;
+    }
+
+    private bool EnsureSelectionDragShield()
+    {
+        if (_overlay is null)
+            return false;
+
+        if (_selectionDragShield is null)
+            CreateSelectionDragShield();
+
+        try
+        {
+            if (VisualTreeHelper.GetParent(_selectionDragShield) is null)
+                _overlay.Children.Add(_selectionDragShield);
+        }
+        catch (System.Runtime.InteropServices.COMException ex)
+        {
+            MarkdownDiagnostics.WriteLine($"[MarkdownRendererControl] selection drag shield attach failed: {ex.Message}");
+            return false;
         }
 
-        _selectionDragShield.Width = Math.Max(1, _overlay.Width);
-        _selectionDragShield.Height = Math.Max(1, _overlay.Height);
-        if (VisualTreeHelper.GetParent(_selectionDragShield) is null)
-            _overlay.Children.Add(_selectionDragShield);
-        _selectionDragShield.Visibility = Visibility.Visible;
+        return true;
+    }
+
+    private double GetSelectionOverlayWidth()
+    {
+        double width = _scroll?.ViewportWidth > 0 ? _scroll.ViewportWidth : ActualWidth;
+        return double.IsFinite(width) && width > 0 ? width : 1.0;
+    }
+
+    private double GetSelectionOverlayHeight()
+    {
+        double height = _scroll?.ViewportHeight > 0 ? _scroll.ViewportHeight : ActualHeight;
+        return double.IsFinite(height) && height > 0 ? height : 1.0;
     }
 
     private void UpdateSelectionAdornerViewport()
@@ -3451,8 +3569,8 @@ public sealed partial class MarkdownRendererControl : UserControl
         if (_selectionAdorner is null)
             return;
 
-        double width = Math.Max(1.0, _scroll?.ViewportWidth > 0 ? _scroll.ViewportWidth : ActualWidth);
-        double height = Math.Max(1.0, _scroll?.ViewportHeight > 0 ? _scroll.ViewportHeight : ActualHeight);
+        double width = GetSelectionOverlayWidth();
+        double height = GetSelectionOverlayHeight();
         double top = _scroll?.VerticalOffset ?? 0.0;
 
         if (double.IsNaN(_selectionAdorner.Width) || Math.Abs(_selectionAdorner.Width - width) > 0.5)
@@ -3516,17 +3634,11 @@ public sealed partial class MarkdownRendererControl : UserControl
                 args.DrawingSession.FillRectangle(rect, selectedBackground);
             }
 
-            foreach (var rect in _selectionAdornerRects)
-            {
-                if (rect.Right < viewport.Left || rect.Left > viewport.Right ||
-                    rect.Bottom < viewport.Top || rect.Top > viewport.Bottom)
-                {
-                    continue;
-                }
-
-                using var layer = args.DrawingSession.CreateLayer(1.0f, rect);
-                snapshot.PaintSelectionForeground(args.DrawingSession, range, selectedForeground, rect);
-            }
+            // Selected text uses a masked foreground layout, so it can be drawn
+            // once for the visible viewport after the opaque highlight fill.
+            // This preserves the native text-selection look without creating a
+            // clipped Win2D layer for every selection stripe during drag/scroll.
+            snapshot.PaintSelectionForeground(args.DrawingSession, range, selectedForeground, viewport);
         }
 
         PaintLinkStateOverlay(args.DrawingSession, viewport);
@@ -3556,6 +3668,9 @@ public sealed partial class MarkdownRendererControl : UserControl
 
     private void OnPointerCanceledOrCaptureLost(object sender, PointerRoutedEventArgs e)
     {
+        if (!IsActivePointerSessionEvent(e))
+            return;
+
         // True interruption (system-level cancel or capture taken by another element):
         // tear down drag state so a phantom anchor doesn't survive into the next gesture.
         // We deliberately do NOT do this on plain PointerExited — with capture, the
@@ -3567,6 +3682,8 @@ public sealed partial class MarkdownRendererControl : UserControl
         _selectionAnchor = null;
         _clickMode = ClickMode.Single;
         SetSelectionDragShieldActive(false);
+        if (!_selection.Range.Normalized().IsEmpty)
+            InvalidateSelectionAdorner();
         OnPointerExited(sender, e);
     }
 
@@ -3640,6 +3757,8 @@ public sealed partial class MarkdownRendererControl : UserControl
     private void OnPointerReleased(object sender, PointerRoutedEventArgs e)
     {
         if (_canvas is null) return;
+        if (!IsActivePointerSessionEvent(e))
+            return;
 
         // Snapshot BEFORE releasing capture: ReleasePointerCapture can dispatch
         // PointerCaptureLost synchronously, so read and clear the pointer session first.
@@ -3655,7 +3774,7 @@ public sealed partial class MarkdownRendererControl : UserControl
         if (!_selection.Range.Normalized().IsEmpty)
         {
             UpdateSelectionAdornerViewport();
-            _selectionAdorner?.Invalidate();
+            InvalidateSelectionAdorner();
         }
 
         // Click handling for links: if no real selection occurred, raise LinkClick

--- a/MarkdownRenderer/MarkdownRenderer/Layout/Boxes/InlineContainerBox.cs
+++ b/MarkdownRenderer/MarkdownRenderer/Layout/Boxes/InlineContainerBox.cs
@@ -26,6 +26,8 @@ internal sealed class InlineContainerBox : BlockBox
     private CanvasTextLayout? _selectionLayout;
     private Color _selectionLayoutColor;
     private float _selectionLayoutWidth;
+    private int _selectionLayoutStart = -1;
+    private int _selectionLayoutLength = -1;
     private string _buffer = string.Empty;
     private bool _bufferDirty;
     private float _lastWidth;
@@ -517,8 +519,15 @@ internal sealed class InlineContainerBox : BlockBox
     {
         if (_layout is null) return;
 
+        var normalized = range.Normalized();
+        EnsureBuffer();
+        int from = ToBufferIndex(normalized.Start);
+        int to = ToBufferIndex(normalized.End);
+        if (to <= from)
+            return;
+
         bool intersectsSelection = false;
-        foreach (var rect in GetRangeRects(range))
+        foreach (var rect in GetRangeRects(normalized))
         {
             if (rect.Right < viewport.Left || rect.Left > viewport.Right ||
                 rect.Bottom < viewport.Top || rect.Top > viewport.Bottom)
@@ -534,10 +543,10 @@ internal sealed class InlineContainerBox : BlockBox
 
         var style = GetContainerStyle();
         var (sx, sy) = GetSnappedOrigin(style);
-        var layout = EnsureSelectionLayout(color, style);
+        var layout = EnsureSelectionLayout(color, style, from, to - from);
         ds.DrawTextLayout(layout, sx, sy, color);
-        DrawDecorations(ds, sx, sy, color);
-        DrawSelectedInlineImages(ds, sx, sy, viewport, range.Normalized(), color);
+        DrawSelectedDecorations(ds, sx, sy, color, from, to - from);
+        DrawSelectedInlineImages(ds, sx, sy, viewport, normalized, color);
     }
 
     public void PaintLinkStateForeground(CanvasDrawingSession ds, LinkRun link, bool focused, Rect viewport)
@@ -947,12 +956,16 @@ internal sealed class InlineContainerBox : BlockBox
         }
     }
 
-    private CanvasTextLayout EnsureSelectionLayout(Color color, ElementStyle style)
+    private CanvasTextLayout EnsureSelectionLayout(Color color, ElementStyle style, int selectedStart, int selectedLength)
     {
         EnsureBuffer();
+        selectedStart = Math.Clamp(selectedStart, 0, _buffer.Length);
+        selectedLength = Math.Clamp(selectedLength, 0, _buffer.Length - selectedStart);
         if (_selectionLayout is not null &&
             _selectionLayoutColor == color &&
-            Math.Abs(_selectionLayoutWidth - _lastWidth) <= 0.5f)
+            Math.Abs(_selectionLayoutWidth - _lastWidth) <= 0.5f &&
+            _selectionLayoutStart == selectedStart &&
+            _selectionLayoutLength == selectedLength)
         {
             return _selectionLayout;
         }
@@ -984,10 +997,16 @@ internal sealed class InlineContainerBox : BlockBox
         _selectionLayout.Options = CanvasDrawTextOptions.EnableColorFont;
         ApplyRunStyles(_selectionLayout, applyColors: false);
         if (_buffer.Length > 0)
-            _selectionLayout.SetColor(0, _buffer.Length, color);
+        {
+            _selectionLayout.SetColor(0, _buffer.Length, Color.FromArgb(0, 0, 0, 0));
+            if (selectedLength > 0)
+                _selectionLayout.SetColor(selectedStart, selectedLength, color);
+        }
         ApplyEmbedSpacing(_selectionLayout);
         _selectionLayoutColor = color;
         _selectionLayoutWidth = _lastWidth;
+        _selectionLayoutStart = selectedStart;
+        _selectionLayoutLength = selectedLength;
         return _selectionLayout;
     }
 
@@ -1167,6 +1186,53 @@ internal sealed class InlineContainerBox : BlockBox
                 }
             }
             cumulative += len;
+        }
+    }
+
+    private void DrawSelectedDecorations(CanvasDrawingSession ds, float baseX, float baseY, Color color, int selectedStart, int selectedLength)
+    {
+        if (_layout is null || selectedLength <= 0)
+            return;
+
+        int selectedEnd = selectedStart + selectedLength;
+        int cumulative = 0;
+        CanvasLineMetrics[]? lineMetrics = null;
+        bool lineMetricsAttempted = false;
+        foreach (var run in _runs)
+        {
+            int len = run.Text.Length;
+            if (len == 0)
+                continue;
+
+            int runStart = cumulative;
+            int runEnd = cumulative + len;
+            cumulative = runEnd;
+
+            if (runEnd <= selectedStart || runStart >= selectedEnd)
+                continue;
+            if (run is InlineEmbedRun or InlineImageRun)
+                continue;
+            if (run is LinkRun { IsSuperscript: true })
+                continue;
+
+            var rs = GetRunStyle(run);
+            if (!rs.Underline && !rs.Strikethrough)
+                continue;
+
+            if (!lineMetricsAttempted)
+            {
+                lineMetrics = TryGetLineMetrics();
+                lineMetricsAttempted = true;
+            }
+
+            int segmentStart = Math.Max(runStart, selectedStart);
+            int segmentLength = Math.Min(runEnd, selectedEnd) - segmentStart;
+            var regions = _layout.GetCharacterRegions(segmentStart, segmentLength);
+            if (regions is null)
+                continue;
+
+            foreach (var r in regions)
+                DrawRunDecorations(ds, baseX, baseY, lineMetrics, r, run, rs, color);
         }
     }
 

--- a/MarkdownRenderer/MarkdownRenderer/Selection/SelectionController.cs
+++ b/MarkdownRenderer/MarkdownRenderer/Selection/SelectionController.cs
@@ -23,11 +23,13 @@ internal sealed class SelectionController
 
     public void SetAnchor(DocumentPosition anchor)
     {
+        bool hadSelection = !Range.IsEmpty;
         Range = new DocumentRange(anchor, anchor);
         if (ShakeLogger.IsEnabled)
             ShakeLogger.Log("sel-anchor",
                 $"blk={anchor.BlockIndex} inl={anchor.InlineIndex} c={anchor.CharacterOffset}");
-        Changed?.Invoke(this, System.EventArgs.Empty);
+        if (hadSelection)
+            Changed?.Invoke(this, System.EventArgs.Empty);
     }
 
     public void ExtendTo(DocumentPosition position)


### PR DESCRIPTION
## Summary

Fixes the packaged-build markdown/code-viewer selection crash and first-drag flash by keeping the preview renderer stable during queued view-model refreshes and hardening the markdown selection overlay lifecycle.

## Root Cause

In packaged x86 builds, the first pointer interaction could trigger a queued preview refresh that replaced the markdown renderer while it owned pointer capture. That dropped capture mid-drag and, in the crash path, caused overlay children to be added during WinUI measure/arrange.

## Changes

- Reuse the existing file preview renderer when the preview kind is unchanged.
- Pre-create and safely reattach the markdown selection adorner and drag shield.
- Ignore touch contacts in markdown selection/hover handling so touch scroll remains owned by the containing ScrollViewer.
- Require selection move/release/cancel events to match the active captured pointer.
- Draw selected glyph foreground with a masked text layout pass instead of per-selection-rect clipped layers.

## Validation

- `dotnet test MarkdownRenderer\MarkdownRenderer.Tests\MarkdownRenderer.Tests.csproj -c Release -p:Platform=x64 --no-restore`
- `dotnet test JitHub.WinUI.Tests\JitHub.WinUI.Tests.csproj -c Release -p:Platform=x64`
- `dotnet build JitHub.WinUI\JitHub.WinUI.csproj -c Release -p:Platform=x86 -p:GenerateAppxPackageOnBuild=false --no-restore`
- Registered and launched the x86 packaged-style build locally; user confirmed the crash/first-drag issue is fixed.
