### PR TITLE
Fix Store CLI upload timeout regression

### DIFF
--- a/.github/workflows/jithub-store-release.yml
+++ b/.github/workflows/jithub-store-release.yml
@@ -47,6 +47,10 @@ jobs:
       APP_DISPLAY_NAME: ${{ vars.STORE_APP_DISPLAY_NAME }}
       BUNDLE_PLATFORMS: ${{ vars.JITHUB_STORE_BUNDLE_PLATFORMS }}
       PUBLISHER_DISPLAY_NAME: ${{ vars.STORE_PUBLISHER_DISPLAY_NAME }}
+      STORE_CLI_VERSION: v0.4.1
+      # v0.4.1 resolves an omitted --uploadTimeout to zero (microsoft/msstore-cli#162).
+      # Keep an explicit value until a release containing the upstream fix is validated.
+      STORE_UPLOAD_TIMEOUT_SECONDS: 900
       TARGET_PLATFORM_VERSION: 10.0.26100.0
       STORE_CLIENT_ID: ${{ secrets.STORE_CLIENT_ID }}
       STORE_CLIENT_SECRET: ${{ secrets.STORE_CLIENT_SECRET }}
@@ -70,11 +74,26 @@ jobs:
           global-json-file: ./global.json
 
       - name: Set up Microsoft Store CLI
-        uses: microsoft/microsoft-store-apppublisher@v1.3
+        uses: microsoft/microsoft-store-apppublisher@v1.4
+        with:
+          # v0.4.1 is the first release with the Native AOT upload progress fix.
+          # Keep this pinned until a newer CLI release is validated here.
+          version: ${{ env.STORE_CLI_VERSION }}
 
       - name: Verify Microsoft Store CLI
         shell: pwsh
-        run: msstore --help
+        run: |
+          $ErrorActionPreference = 'Stop'
+
+          & msstore --version
+          if ($LASTEXITCODE -ne 0) {
+            throw "msstore --version failed with exit code $LASTEXITCODE."
+          }
+
+          & msstore --help
+          if ($LASTEXITCODE -ne 0) {
+            throw "msstore --help failed with exit code $LASTEXITCODE."
+          }
 
       - name: Patch Store manifest values
         shell: pwsh
@@ -183,6 +202,11 @@ jobs:
           $submissionMode = '${{ inputs.store_submission_mode }}'
           $flightId = '${{ inputs.store_flight_id }}'
           $rolloutPercentage = '${{ inputs.package_rollout_percentage }}'
+          $uploadTimeoutSeconds = 0L
+
+          if (-not [long]::TryParse($env:STORE_UPLOAD_TIMEOUT_SECONDS, [ref]$uploadTimeoutSeconds) -or $uploadTimeoutSeconds -lt 100) {
+            throw 'STORE_UPLOAD_TIMEOUT_SECONDS must be an integer of at least 100 seconds.'
+          }
 
           if ($submissionMode -eq 'flight' -and [string]::IsNullOrWhiteSpace($flightId)) {
             throw 'store_flight_id is required when store_submission_mode is flight.'
@@ -197,7 +221,9 @@ jobs:
             'publish',
             $uploadPackage,
             '--appId',
-            "$env:STORE_PRODUCT_ID"
+            "$env:STORE_PRODUCT_ID",
+            '--uploadTimeout',
+            $uploadTimeoutSeconds.ToString([System.Globalization.CultureInfo]::InvariantCulture)
           )
 
           if ($submissionMode -in @('draft', 'public')) {
@@ -220,8 +246,9 @@ jobs:
           }
 
           & msstore @publishArgs
-          if ($LASTEXITCODE -ne 0) {
-            throw 'msstore publish failed.'
+          $publishExitCode = $LASTEXITCODE
+          if ($publishExitCode -ne 0) {
+            throw "msstore publish failed with exit code $publishExitCode."
           }
 
           if ($submissionMode -ne 'flight') {

--- a/JitHub.WinUI.Tests/Services/NativeAotSourceContractTests.cs
+++ b/JitHub.WinUI.Tests/Services/NativeAotSourceContractTests.cs
@@ -253,6 +253,12 @@ public sealed class NativeAotSourceContractTests
         Assert.DoesNotContain("Require matching hardware validation", storeWorkflow, StringComparison.Ordinal);
         Assert.DoesNotContain("actions: read", storeWorkflow, StringComparison.Ordinal);
         Assert.Contains("'x86|x64|ARM64'", storeWorkflow, StringComparison.Ordinal);
+        Assert.Contains("microsoft/microsoft-store-apppublisher@v1.4", storeWorkflow, StringComparison.Ordinal);
+        Assert.Contains("STORE_CLI_VERSION: v0.4.1", storeWorkflow, StringComparison.Ordinal);
+        Assert.Contains("version: ${{ env.STORE_CLI_VERSION }}", storeWorkflow, StringComparison.Ordinal);
+        Assert.Contains("STORE_UPLOAD_TIMEOUT_SECONDS: 900", storeWorkflow, StringComparison.Ordinal);
+        Assert.Contains("'--uploadTimeout'", storeWorkflow, StringComparison.Ordinal);
+        Assert.DoesNotContain("msstore --verbose", storeWorkflow, StringComparison.Ordinal);
     }
 
     [Fact]

--- a/docs/windows-cli-workflow.md
+++ b/docs/windows-cli-workflow.md
@@ -117,7 +117,7 @@ The Store release workflow is `.github/workflows/jithub-store-release.yml`.
 
 It now uses the Microsoft Store Developer CLI as the release control plane:
 
-- `microsoft/microsoft-store-apppublisher@v1.3` installs `msstore` on the runner.
+- `microsoft/microsoft-store-apppublisher@v1.4` installs the pinned `msstore` version on the runner. The workflow passes an explicit upload timeout because `msstore` v0.4.1 otherwise resolves the omitted option to zero; keep the version pin and timeout until a newer CLI release is deliberately validated.
 - `msstore reconfigure` authenticates with the protected `microsoft-store` GitHub environment secrets.
 - `msstore publish` receives the exact `.appxupload` or `.msixupload` file produced by `eng/Build-JitHubWinUIStorePackage.ps1` as the publish command's positional input.
 - `use_signing_certificate` is optional. Leave it `false` to match the existing UWP Store-upload flow where Partner Center accepts and re-signs the submitted package; enable it only when `STORE_PACKAGE_CERTIFICATE_BASE64` and `STORE_PACKAGE_CERTIFICATE_PASSWORD` are configured.


### PR DESCRIPTION
## Summary
- pin Microsoft Store App Publisher v1.4 and Store CLI v0.4.1
- pass an explicit 900-second Store blob upload timeout to work around microsoft/msstore-cli#162
- log the installed CLI version and preserve secret-safe non-verbose output
- lock the behavior with the Native AOT release contract test and update release docs

## Failure analysis
Run 33364350524 built and verified the Store package, authenticated successfully, and then failed at Azure blob upload 0% after about 25 seconds. Store CLI v0.4.1 resolves an omitted --uploadTimeout to zero, causing every request to be cancelled immediately. The upstream fix merged after v0.4.1 but has not been released.

## Verification
- dotnet restore JitHub.WinUI.Tests/JitHub.WinUI.Tests.csproj --locked-mode -p:Configuration=Release
- dotnet test JitHub.WinUI.Tests/JitHub.WinUI.Tests.csproj -c Release --no-restore --filter Category=ReleaseSecurity (72 passed)
- downloaded Store CLI v0.4.1 and verified version 0.4.1.3+6098cd1eb7

Closes the release failure in https://github.com/JitHubApp/JitHubV2/actions/runs/33364350524
Upstream: https://github.com/microsoft/msstore-cli/issues/162