### PR TITLE
Validate Microsoft Store package versions before build

### DIFF
--- a/.github/workflows/jithub-store-release.yml
+++ b/.github/workflows/jithub-store-release.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       release_version:
-        description: Four-part Store package version (for example 1.6.5.0)
+        description: Four-part Store package version ending in .0 (for example 3.0.2.0). Increment Major, Minor, or Build; Revision is reserved by Microsoft Store.
         required: true
         type: string
       use_signing_certificate:
@@ -48,6 +48,7 @@ jobs:
       BUNDLE_PLATFORMS: ${{ vars.JITHUB_STORE_BUNDLE_PLATFORMS }}
       PUBLISHER_DISPLAY_NAME: ${{ vars.STORE_PUBLISHER_DISPLAY_NAME }}
       STORE_CLI_VERSION: v0.4.1
+      STORE_RELEASE_VERSION: ${{ inputs.release_version }}
       # v0.4.1 resolves an omitted --uploadTimeout to zero (microsoft/msstore-cli#162).
       # Keep an explicit value until a release containing the upstream fix is validated.
       STORE_UPLOAD_TIMEOUT_SECONDS: 900
@@ -67,6 +68,10 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+
+      - name: Validate Store package version
+        shell: pwsh
+        run: .\eng\Assert-JitHubStorePackageVersion.ps1 -Version "$env:STORE_RELEASE_VERSION"
 
       - name: Set up .NET SDK
         uses: actions/setup-dotnet@v4
@@ -100,7 +105,7 @@ jobs:
         run: >
           .\eng\Prepare-JitHubStoreRelease.ps1
           -ManifestPath "${{ env.MANIFEST_PATH }}"
-          -Version "${{ inputs.release_version }}"
+          -Version "$env:STORE_RELEASE_VERSION"
           -PackageIdentityName "$env:STORE_PACKAGE_IDENTITY_NAME"
           -PackagePublisher "$env:STORE_PACKAGE_PUBLISHER"
           -PublisherDisplayName "$env:PUBLISHER_DISPLAY_NAME"

--- a/.github/workflows/native-aot.yml
+++ b/.github/workflows/native-aot.yml
@@ -15,6 +15,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Test Store package version policy
+        shell: pwsh
+        run: .\eng\Test-JitHubStorePackageVersion.ps1
+
       - uses: actions/setup-dotnet@v4
         with:
           global-json-file: ./global.json

--- a/JitHub.WinUI.Tests/Services/CodeSymbolExtractorTests.cs
+++ b/JitHub.WinUI.Tests/Services/CodeSymbolExtractorTests.cs
@@ -45,15 +45,17 @@ public sealed class CodeSymbolExtractorTests
     }
 
     [Fact]
-    public async System.Threading.Tasks.Task UiWorkBudgetRequestsYieldWithinFiftyMilliseconds()
+    public void UiWorkBudget_YieldsAtConfiguredTimestampBoundary()
     {
-        UiWorkBudget budget = new(TimeSpan.FromMilliseconds(2));
-        Stopwatch stopwatch = Stopwatch.StartNew();
-        while (!budget.ShouldYield())
-        {
-            await System.Threading.Tasks.Task.Yield();
-        }
+        TimeSpan slice = TimeSpan.FromMilliseconds(2);
+        long sliceTicks = Math.Max(1, (long)(slice.TotalSeconds * Stopwatch.Frequency));
+        const long started = 10_000;
+        UiWorkBudget budget = new(slice, started);
 
-        Assert.True(stopwatch.Elapsed < TimeSpan.FromMilliseconds(50));
+        Assert.False(budget.ShouldYield(started));
+        Assert.False(budget.ShouldYield(started + sliceTicks - 1));
+        Assert.True(budget.ShouldYield(started + sliceTicks));
+        Assert.False(budget.ShouldYield(started + sliceTicks));
+        Assert.True(budget.ShouldYield(started + (2 * sliceTicks)));
     }
 }

--- a/JitHub.WinUI.Tests/Services/SecurityReleaseGateTests.cs
+++ b/JitHub.WinUI.Tests/Services/SecurityReleaseGateTests.cs
@@ -1,6 +1,7 @@
 using JitHub.Models;
 using JitHub.Services;
 using JitHub.Services.Markdown;
+using System.Xml.Linq;
 using Xunit;
 
 namespace JitHub.WinUI.Tests.Services;
@@ -32,6 +33,21 @@ public sealed class SecurityReleaseGateTests
         Assert.Contains("--include-transitive", script, StringComparison.Ordinal);
         Assert.Contains("allowedPrereleasePackages", script, StringComparison.Ordinal);
         Assert.Contains("UriSchemeHttps", script, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    [Trait("Category", "ReleaseSecurity")]
+    public void PackageRestore_UsesOnlyReviewedPublicSources()
+    {
+        string root = FindRepositoryRoot();
+        XDocument configuration = XDocument.Load(Path.Combine(root, "NuGet.config"));
+        XElement source = Assert.Single(configuration.Root!
+            .Element("packageSources")!
+            .Elements("add"));
+
+        Assert.Equal("nuget.org", source.Attribute("key")?.Value);
+        Assert.Equal("https://api.nuget.org/v3/index.json", source.Attribute("value")?.Value);
+        Assert.Equal("3", source.Attribute("protocolVersion")?.Value);
     }
 
     [Fact]

--- a/JitHub.WinUI.Tests/Services/SecurityReleaseGateTests.cs
+++ b/JitHub.WinUI.Tests/Services/SecurityReleaseGateTests.cs
@@ -58,6 +58,31 @@ public sealed class SecurityReleaseGateTests
             "The Store package script must verify the canonical Release test lock file.");
     }
 
+    [Fact]
+    [Trait("Category", "ReleaseSecurity")]
+    public void StoreRelease_ValidatesPackageVersionBeforeToolchainSetup()
+    {
+        string root = FindRepositoryRoot();
+        string storeWorkflow = File.ReadAllText(Path.Combine(root, ".github", "workflows", "jithub-store-release.yml"));
+        string nativeAotWorkflow = File.ReadAllText(Path.Combine(root, ".github", "workflows", "native-aot.yml"));
+        string prepareScript = File.ReadAllText(Path.Combine(root, "eng", "Prepare-JitHubStoreRelease.ps1"));
+        string validatorScript = File.ReadAllText(Path.Combine(root, "eng", "Assert-JitHubStorePackageVersion.ps1"));
+        string validatorTests = File.ReadAllText(Path.Combine(root, "eng", "Test-JitHubStorePackageVersion.ps1"));
+
+        int validationIndex = storeWorkflow.IndexOf("- name: Validate Store package version", StringComparison.Ordinal);
+        int toolchainIndex = storeWorkflow.IndexOf("- name: Set up .NET SDK", StringComparison.Ordinal);
+
+        Assert.True(validationIndex >= 0 && toolchainIndex > validationIndex, "Store versions must be rejected before toolchain setup and packaging.");
+        Assert.Contains("STORE_RELEASE_VERSION: ${{ inputs.release_version }}", storeWorkflow, StringComparison.Ordinal);
+        Assert.Contains("Assert-JitHubStorePackageVersion.ps1 -Version \"$env:STORE_RELEASE_VERSION\"", storeWorkflow, StringComparison.Ordinal);
+        Assert.DoesNotContain("-Version \"${{ inputs.release_version }}\"", storeWorkflow, StringComparison.Ordinal);
+        Assert.Contains("Assert-JitHubStorePackageVersion.ps1", prepareScript, StringComparison.Ordinal);
+        Assert.Contains("must end in '.0'", validatorScript, StringComparison.Ordinal);
+        Assert.Contains("65535", validatorScript, StringComparison.Ordinal);
+        Assert.Contains("'3.0.0.2'", validatorTests, StringComparison.Ordinal);
+        Assert.Contains("Test-JitHubStorePackageVersion.ps1", nativeAotWorkflow, StringComparison.Ordinal);
+    }
+
     [Theory]
     [Trait("Category", "ReleaseSecurity")]
     [InlineData("javascript:alert(1)")]

--- a/JitHub.WinUI/Services/CodeViewer/UiWorkBudget.cs
+++ b/JitHub.WinUI/Services/CodeViewer/UiWorkBudget.cs
@@ -11,17 +11,23 @@ public sealed class UiWorkBudget
     private long _sliceStarted;
 
     public UiWorkBudget(TimeSpan? maximumSlice = null)
+        : this(maximumSlice, Stopwatch.GetTimestamp())
+    {
+    }
+
+    internal UiWorkBudget(TimeSpan? maximumSlice, long sliceStarted)
     {
         TimeSpan slice = maximumSlice ?? DefaultSlice;
         if (slice <= TimeSpan.Zero) throw new ArgumentOutOfRangeException(nameof(maximumSlice));
 
         _maximumTicks = Math.Max(1, (long)(slice.TotalSeconds * Stopwatch.Frequency));
-        _sliceStarted = Stopwatch.GetTimestamp();
+        _sliceStarted = sliceStarted;
     }
 
-    public bool ShouldYield()
+    public bool ShouldYield() => ShouldYield(Stopwatch.GetTimestamp());
+
+    internal bool ShouldYield(long now)
     {
-        long now = Stopwatch.GetTimestamp();
         if (now - _sliceStarted < _maximumTicks) return false;
         _sliceStarted = now;
         return true;

--- a/NuGet.config
+++ b/NuGet.config
@@ -3,6 +3,5 @@
   <packageSources>
     <clear />
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
-    <add key="CommunityToolkit-Labs" value="https://pkgs.dev.azure.com/dotnet/CommunityToolkit/_packaging/CommunityToolkit-Labs/nuget/v3/index.json" />
   </packageSources>
 </configuration>

--- a/docs/windows-cli-workflow.md
+++ b/docs/windows-cli-workflow.md
@@ -115,6 +115,8 @@ Never put Partner Center credentials in plain text files, checked-in scripts, or
 
 The Store release workflow is `.github/workflows/jithub-store-release.yml`.
 
+Store package versions use `Major.Minor.Build.0`. Microsoft reserves the fourth component for Store use, so release operators must increment Major, Minor, or Build and leave Revision at `0`. The workflow validates the version immediately after checkout, before restoring or building the Native AOT package.
+
 It now uses the Microsoft Store Developer CLI as the release control plane:
 
 - `microsoft/microsoft-store-apppublisher@v1.4` installs the pinned `msstore` version on the runner. The workflow passes an explicit upload timeout because `msstore` v0.4.1 otherwise resolves the omitted option to zero; keep the version pin and timeout until a newer CLI release is deliberately validated.
@@ -166,3 +168,4 @@ Do not use `store` as a publishing tool. It is a client-side Store surface, not 
 - Windows App CLI reference: https://learn.microsoft.com/en-us/windows/apps/dev-tools/winapp-cli/usage
 - Microsoft Store Developer CLI: https://learn.microsoft.com/en-us/windows/apps/publish/msstore-dev-cli/commands
 - Store publishing with GitHub Actions: https://learn.microsoft.com/en-us/windows/apps/publish/msstore-dev-cli/github-actions
+- Microsoft Store MSIX package and version requirements: https://learn.microsoft.com/en-us/windows/apps/publish/publish-your-app/msix/app-package-requirements

--- a/eng/Assert-JitHubStorePackageVersion.ps1
+++ b/eng/Assert-JitHubStorePackageVersion.ps1
@@ -1,0 +1,44 @@
+param(
+    [Parameter(Mandatory = $true)]
+    [AllowEmptyString()]
+    [string]$Version
+)
+
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+
+if ([string]::IsNullOrWhiteSpace($Version)) {
+    throw 'Store package version must not be empty.'
+}
+
+if ($Version -notmatch '^\d+\.\d+\.\d+\.\d+$') {
+    throw "Store package version '$Version' must use the four-part format Major.Minor.Build.Revision."
+}
+
+$components = $Version.Split('.')
+$parsedComponents = @()
+
+for ($index = 0; $index -lt $components.Count; $index++) {
+    $componentValue = 0
+    $parsed = [int]::TryParse(
+        $components[$index],
+        [System.Globalization.NumberStyles]::None,
+        [System.Globalization.CultureInfo]::InvariantCulture,
+        [ref]$componentValue)
+
+    if (-not $parsed -or $componentValue -gt 65535) {
+        throw "Store package version '$Version' has a component outside the supported range of 0 through 65535."
+    }
+
+    $parsedComponents += $componentValue
+}
+
+if ($parsedComponents[0] -eq 0) {
+    throw "Store package version '$Version' must have a Major component from 1 through 65535."
+}
+
+if ($parsedComponents[3] -ne 0) {
+    throw "Store package version '$Version' must end in '.0'. Microsoft Store reserves the Revision component; increment Major, Minor, or Build instead."
+}
+
+Write-Host "Validated Microsoft Store package version $Version."

--- a/eng/Prepare-JitHubStoreRelease.ps1
+++ b/eng/Prepare-JitHubStoreRelease.ps1
@@ -19,16 +19,10 @@ param(
 
 $ErrorActionPreference = 'Stop'
 
+& (Join-Path $PSScriptRoot 'Assert-JitHubStorePackageVersion.ps1') -Version $Version
+
 if (-not (Test-Path -LiteralPath $ManifestPath)) {
     throw "Manifest not found: $ManifestPath"
-}
-
-if ([string]::IsNullOrWhiteSpace($Version)) {
-    throw 'Version must not be empty.'
-}
-
-if ($Version -notmatch '^\d+\.\d+\.\d+\.\d+$') {
-    throw "Version '$Version' must use the four-part format Major.Minor.Build.Revision."
 }
 
 if ([string]::IsNullOrWhiteSpace($PackageIdentityName)) {

--- a/eng/Test-JitHubStorePackageVersion.ps1
+++ b/eng/Test-JitHubStorePackageVersion.ps1
@@ -1,0 +1,45 @@
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+
+$validatorPath = Join-Path $PSScriptRoot 'Assert-JitHubStorePackageVersion.ps1'
+
+$validVersions = @(
+    '1.0.0.0',
+    '3.0.2.0',
+    '65535.65535.65535.0'
+)
+
+foreach ($version in $validVersions) {
+    & $validatorPath -Version $version | Out-Null
+}
+
+$invalidVersions = @(
+    @{ Version = ''; Expected = 'must not be empty' },
+    @{ Version = '1.2.3'; Expected = 'four-part format' },
+    @{ Version = '1.2.invalid.0'; Expected = 'four-part format' },
+    @{ Version = '0.1.0.0'; Expected = 'Major component' },
+    @{ Version = '65536.0.0.0'; Expected = 'supported range' },
+    @{ Version = '1.65536.0.0'; Expected = 'supported range' },
+    @{ Version = '1.0.65536.0'; Expected = 'supported range' },
+    @{ Version = '3.0.0.2'; Expected = "must end in '.0'" }
+)
+
+foreach ($testCase in $invalidVersions) {
+    $rejected = $false
+
+    try {
+        & $validatorPath -Version $testCase.Version | Out-Null
+    }
+    catch {
+        $rejected = $true
+        if ($_.Exception.Message -notlike "*$($testCase.Expected)*") {
+            throw "Version '$($testCase.Version)' failed with an unexpected message: $($_.Exception.Message)"
+        }
+    }
+
+    if (-not $rejected) {
+        throw "Version '$($testCase.Version)' should have been rejected."
+    }
+}
+
+Write-Host "Validated $($validVersions.Count) accepted and $($invalidVersions.Count) rejected Store package version cases."


### PR DESCRIPTION
## Summary
- reject Store package versions whose revision is nonzero or whose components exceed Store limits
- run validation immediately after checkout, before toolchain setup and the Native AOT package build
- reuse the same validator from manifest preparation
- route workflow input through an environment variable instead of interpolating it into PowerShell
- exercise valid and invalid version cases in PR CI and document the Store versioning contract

## Failure analysis
Run 33406944776 confirms the previous upload fix worked: the package uploaded successfully and the submission reached Partner Center validation. Partner Center then rejected 3.0.0.2 because Microsoft Store reserves the fourth package-version component and requires it to be zero.

## Verification
- eng/Test-JitHubStorePackageVersion.ps1: 3 accepted and 8 rejected cases pass
- Prepare-JitHubStoreRelease.ps1 accepts 3.0.2.0 and rejects the exact failed 3.0.0.2 input
- ReleaseSecurity tests: 73 passed
- git diff --cached --check

Failed run: https://github.com/JitHubApp/JitHubV2/actions/runs/33406944776
Microsoft requirements: https://learn.microsoft.com/en-us/windows/apps/publish/publish-your-app/msix/app-package-requirements