### PR TITLE
Restore production website startup

### DIFF
--- a/.github/workflows/main_jithubweb.yml
+++ b/.github/workflows/main_jithubweb.yml
@@ -54,6 +54,40 @@ jobs:
       - name: Publish website
         run: dotnet publish ./${{ env.WEBSITE_PROJECT }} --configuration Release --no-restore --output ./publish --property:TreatWarningsAsErrors=true
 
+      - name: Smoke test production startup
+        shell: bash
+        run: |
+          log_file="${RUNNER_TEMP}/jithub-web-production.log"
+          ASPNETCORE_ENVIRONMENT=Production \
+          WEBSITE_HOSTNAME=jithub-web-prod.azurewebsites.net \
+          ASPNETCORE_URLS=http://127.0.0.1:5088 \
+            dotnet ./publish/JitHub.Web.dll >"${log_file}" 2>&1 &
+          web_pid=$!
+          cleanup() {
+            if kill -0 "${web_pid}" 2>/dev/null; then
+              kill "${web_pid}"
+              wait "${web_pid}" || true
+            fi
+          }
+          trap cleanup EXIT
+
+          for attempt in {1..30}; do
+            if ! kill -0 "${web_pid}" 2>/dev/null; then
+              cat "${log_file}"
+              exit 1
+            fi
+
+            if [ "$(curl --silent --show-error --fail --max-time 2 http://127.0.0.1:5088/healthz || true)" = "ok" ]; then
+              exit 0
+            fi
+
+            sleep 1
+          done
+
+          cat "${log_file}"
+          echo "Production startup health check timed out."
+          exit 1
+
       - name: Upload published website
         uses: actions/upload-artifact@v4
         with:
@@ -95,3 +129,21 @@ jobs:
           app-name: ${{ env.AZURE_WEBAPP_NAME }}
           package: ./publish
           publish-profile: ${{ secrets.JITHUB_WEBAPP_PUBLISH_PROFILE }}
+
+      - name: Verify deployed website health
+        shell: bash
+        env:
+          JITHUB_WEBAPP_HEALTH_URL: ${{ vars.JITHUB_WEBAPP_HEALTH_URL }}
+        run: |
+          health_url="${JITHUB_WEBAPP_HEALTH_URL:-https://${AZURE_WEBAPP_NAME}.azurewebsites.net/healthz}"
+          for attempt in {1..30}; do
+            if [ "$(curl --silent --show-error --fail --max-time 10 "${health_url}" || true)" = "ok" ]; then
+              echo "Production website is healthy at ${health_url}."
+              exit 0
+            fi
+
+            sleep 10
+          done
+
+          echo "Production website did not become healthy at ${health_url}."
+          exit 1

--- a/JitHub.Web.Tests/OAuthHandoffBackendRegistrationTests.cs
+++ b/JitHub.Web.Tests/OAuthHandoffBackendRegistrationTests.cs
@@ -1,0 +1,96 @@
+using JitHub.Web.Services;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace JitHub.Web.Tests;
+
+public sealed class OAuthHandoffBackendRegistrationTests
+{
+    [Fact]
+    public void ProductionWithoutRedisUsesBoundedProcessLocalBackend()
+    {
+        ServiceCollection services = new();
+        IConfiguration configuration = BuildConfiguration(new Dictionary<string, string?>());
+
+        OAuthHandoffBackendSelection selection = OAuthHandoffBackendRegistration.Configure(
+            services,
+            configuration,
+            isDevelopment: false);
+
+        Assert.False(selection.UsesRedis);
+        Assert.Contains("absent or incomplete", selection.FallbackReason, StringComparison.Ordinal);
+        ServiceDescriptor backend = Assert.Single(
+            services,
+            descriptor => descriptor.ServiceType == typeof(IOAuthHandoffBackend));
+        Assert.Equal(typeof(InMemoryOAuthHandoffBackend), backend.ImplementationType);
+    }
+
+    [Fact]
+    public void DevelopmentWithoutRedisUsesProcessLocalBackendWithoutWarning()
+    {
+        ServiceCollection services = new();
+
+        OAuthHandoffBackendSelection selection = OAuthHandoffBackendRegistration.Configure(
+            services,
+            BuildConfiguration(new Dictionary<string, string?>()),
+            isDevelopment: true);
+
+        Assert.False(selection.UsesRedis);
+        Assert.Null(selection.FallbackReason);
+    }
+
+    [Theory]
+    [InlineData("not-base64")]
+    [InlineData("c2hvcnQ=")]
+    public void InvalidEncryptionKeyFallsBackWithoutCrashingStartup(string encryptionKey)
+    {
+        ServiceCollection services = new();
+        IConfiguration configuration = BuildConfiguration(
+            new Dictionary<string, string?>
+            {
+                [$"ConnectionStrings:{OAuthHandoffBackendRegistration.RedisConnectionStringName}"] =
+                    "localhost:6379",
+                [OAuthHandoffBackendRegistration.EncryptionKeySetting] = encryptionKey
+            });
+
+        OAuthHandoffBackendSelection selection = OAuthHandoffBackendRegistration.Configure(
+            services,
+            configuration,
+            isDevelopment: false);
+
+        Assert.False(selection.UsesRedis);
+        Assert.Contains("encryption key", selection.FallbackReason, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void CompleteRedisConfigurationSelectsDistributedBackend()
+    {
+        ServiceCollection services = new();
+        IConfiguration configuration = BuildConfiguration(
+            new Dictionary<string, string?>
+            {
+                [$"ConnectionStrings:{OAuthHandoffBackendRegistration.RedisConnectionStringName}"] =
+                    "localhost:6379",
+                [OAuthHandoffBackendRegistration.EncryptionKeySetting] =
+                    Convert.ToBase64String(new byte[32])
+            });
+
+        OAuthHandoffBackendSelection selection = OAuthHandoffBackendRegistration.Configure(
+            services,
+            configuration,
+            isDevelopment: false);
+
+        Assert.True(selection.UsesRedis);
+        Assert.Null(selection.FallbackReason);
+        Assert.Single(
+            services,
+            descriptor => descriptor.ServiceType == typeof(IOAuthHandoffBackend));
+    }
+
+    private static IConfiguration BuildConfiguration(
+        IReadOnlyDictionary<string, string?> values) =>
+        new ConfigurationBuilder()
+            .AddInMemoryCollection(values)
+            .Build();
+}

--- a/JitHub.Web.Tests/OAuthRedirectUriPolicyTests.cs
+++ b/JitHub.Web.Tests/OAuthRedirectUriPolicyTests.cs
@@ -36,10 +36,67 @@ public sealed class OAuthRedirectUriPolicyTests
     }
 
     [Fact]
-    public void ProductionRequiresConfiguredCallbackIdentity()
+    public void ProductionWithoutCallbackFailsClosedWithoutCrashingStartup()
     {
+        OAuthRedirectUriPolicy policy = LoadPolicy(
+            Environments.Production,
+            new Dictionary<string, string?>());
+
+        Assert.Empty(policy.AllowedRedirectUris);
+        Assert.NotNull(policy.ConfigurationError);
         Assert.Throws<InvalidOperationException>(() =>
-            LoadPolicy(Environments.Production, new Dictionary<string, string?>()));
+            policy.RequireAllowed("https://jithub-web-prod.azurewebsites.net/authorize"));
+    }
+
+    [Fact]
+    public void ProductionUsesAzureAppServiceReadOnlyHostnameWhenCallbackIsNotExplicit()
+    {
+        OAuthRedirectUriPolicy policy = LoadPolicy(
+            Environments.Production,
+            new Dictionary<string, string?>
+            {
+                [OAuthRedirectUriPolicy.AzureWebsiteHostnameSetting] =
+                    "jithub-web-prod.azurewebsites.net"
+            });
+
+        Assert.Equal(
+            "https://jithub-web-prod.azurewebsites.net/authorize",
+            policy.RequireAllowed("https://jithub-web-prod.azurewebsites.net/authorize"));
+        Assert.Throws<InvalidOperationException>(() =>
+            policy.RequireAllowed("https://attacker.example/authorize"));
+    }
+
+    [Theory]
+    [InlineData("attacker.example")]
+    [InlineData("jithub-web-prod.azurewebsites.net.attacker.example")]
+    [InlineData("jithub-web-prod.azurewebsites.net/attacker")]
+    [InlineData("user@jithub-web-prod.azurewebsites.net")]
+    public void ProductionRejectsUntrustedAzureHostnameFallback(string hostname)
+    {
+        OAuthRedirectUriPolicy policy = LoadPolicy(
+            Environments.Production,
+            new Dictionary<string, string?>
+            {
+                [OAuthRedirectUriPolicy.AzureWebsiteHostnameSetting] = hostname
+            });
+
+        Assert.Empty(policy.AllowedRedirectUris);
+        Assert.NotNull(policy.ConfigurationError);
+    }
+
+    [Fact]
+    public void ProductionInvalidExplicitCallbackFailsClosedWithoutCrashingStartup()
+    {
+        OAuthRedirectUriPolicy policy = LoadPolicy(
+            Environments.Production,
+            new Dictionary<string, string?>
+            {
+                [OAuthRedirectUriPolicy.CallbackUrlSetting] =
+                    "https://jithub-web-prod.azurewebsites.net/authorize?attacker=true"
+            });
+
+        Assert.Empty(policy.AllowedRedirectUris);
+        Assert.Contains("absolute callback URL", policy.ConfigurationError, StringComparison.Ordinal);
     }
 
     [Theory]

--- a/JitHub.Web.Tests/WebsiteDeploymentContractTests.cs
+++ b/JitHub.Web.Tests/WebsiteDeploymentContractTests.cs
@@ -1,0 +1,51 @@
+using System.Text.Json;
+using Xunit;
+
+namespace JitHub.Web.Tests;
+
+public sealed class WebsiteDeploymentContractTests
+{
+    [Fact]
+    public void DeploymentRunsProductionStartupAndLiveHealthChecks()
+    {
+        string root = FindRepositoryRoot();
+        string workflow = File.ReadAllText(
+            Path.Combine(root, ".github", "workflows", "main_jithubweb.yml"));
+
+        Assert.Contains("Smoke test production startup", workflow, StringComparison.Ordinal);
+        Assert.Contains("ASPNETCORE_ENVIRONMENT=Production", workflow, StringComparison.Ordinal);
+        Assert.Contains("WEBSITE_HOSTNAME=jithub-web-prod.azurewebsites.net", workflow, StringComparison.Ordinal);
+        Assert.Contains("Verify deployed website health", workflow, StringComparison.Ordinal);
+        Assert.Contains("/healthz", workflow, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void PackagedAppUsesTheDeployedProductionCallback()
+    {
+        string root = FindRepositoryRoot();
+        using JsonDocument settings = JsonDocument.Parse(
+            File.ReadAllText(Path.Combine(root, "JitHub.WinUI", "appsettings.json")));
+        string? callback = settings.RootElement
+            .GetProperty("Credential")
+            .GetProperty("AuthorizationCallbackUrl")
+            .GetString();
+
+        Assert.Equal("https://jithub-web-prod.azurewebsites.net/authorize", callback);
+    }
+
+    private static string FindRepositoryRoot()
+    {
+        DirectoryInfo? current = new(AppContext.BaseDirectory);
+        while (current is not null)
+        {
+            if (File.Exists(Path.Combine(current.FullName, "Directory.Build.props")))
+            {
+                return current.FullName;
+            }
+
+            current = current.Parent;
+        }
+
+        throw new DirectoryNotFoundException("Could not locate the repository root.");
+    }
+}

--- a/JitHub.Web/Program.cs
+++ b/JitHub.Web/Program.cs
@@ -4,7 +4,6 @@ using JitHub.Web.Services;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.HttpOverrides;
 using Microsoft.AspNetCore.RateLimiting;
-using StackExchange.Redis;
 
 WebApplicationBuilder builder = WebApplication.CreateBuilder(args);
 const string GithubAuthRateLimitPolicy = "github-auth";
@@ -12,11 +11,14 @@ bool isDevelopment = builder.Environment.IsDevelopment();
 int permitLimit = isDevelopment ? 1000 : 10;
 ForwardedHeaderTrustPolicy forwardedHeaderTrust = ForwardedHeaderTrustPolicy.Load(builder.Configuration);
 OAuthRedirectUriPolicy oauthRedirectPolicy = OAuthRedirectUriPolicy.Load(builder.Configuration, builder.Environment);
+OAuthHandoffBackendSelection oauthHandoffBackend = OAuthHandoffBackendRegistration.Configure(
+    builder.Services,
+    builder.Configuration,
+    isDevelopment);
 
 builder.Services.AddRazorComponents();
 builder.Services.AddSingleton(TimeProvider.System);
 builder.Services.AddSingleton(oauthRedirectPolicy);
-ConfigureOAuthHandoffBackend(builder, isDevelopment);
 builder.Services.AddSingleton<OAuthHandoffStore>();
 builder.Services.AddHttpClient<GithubAuthService>(client =>
 {
@@ -47,6 +49,20 @@ builder.Services.AddRateLimiter(options =>
 
 WebApplication app = builder.Build();
 
+if (oauthHandoffBackend.FallbackReason is { } fallbackReason)
+{
+    app.Logger.LogWarning(
+        "OAuth handoffs are using the bounded process-local backend. {FallbackReason}",
+        fallbackReason);
+}
+
+if (oauthRedirectPolicy.ConfigurationError is { } callbackConfigurationError)
+{
+    app.Logger.LogWarning(
+        "GitHub OAuth callbacks are disabled. {ConfigurationError}",
+        callbackConfigurationError);
+}
+
 if (!app.Environment.IsDevelopment())
 {
     app.UseHsts();
@@ -67,6 +83,7 @@ app.UseHttpsRedirection();
 app.UseAntiforgery();
 app.UseRateLimiter();
 app.MapStaticAssets();
+app.MapGet("/healthz", () => TypedResults.Text("ok", "text/plain"));
 
 RouteGroupBuilder api = app.MapGroup("/api")
     .RequireRateLimiting(GithubAuthRateLimitPolicy);
@@ -136,53 +153,6 @@ app.MapRazorComponents<App>()
     .WithStaticAssets();
 
 app.Run();
-
-static void ConfigureOAuthHandoffBackend(WebApplicationBuilder builder, bool isDevelopment)
-{
-    string? redisConnection = builder.Configuration.GetConnectionString("OAuthHandoffRedis");
-    string? encryptionKeyText = builder.Configuration["OAuthHandoff:EncryptionKey"];
-    bool hasRedis = !string.IsNullOrWhiteSpace(redisConnection);
-    bool hasEncryptionKey = !string.IsNullOrWhiteSpace(encryptionKeyText);
-
-    if (!hasRedis && !hasEncryptionKey && isDevelopment)
-    {
-        builder.Services.AddSingleton<IOAuthHandoffBackend, InMemoryOAuthHandoffBackend>();
-        return;
-    }
-
-    if (!hasRedis || !hasEncryptionKey)
-    {
-        throw new InvalidOperationException(
-            "Production OAuth handoffs require ConnectionStrings:OAuthHandoffRedis and " +
-            "OAuthHandoff:EncryptionKey (a Base64-encoded 32-byte key).");
-    }
-
-    byte[] encryptionKey;
-    try
-    {
-        encryptionKey = Convert.FromBase64String(encryptionKeyText!);
-    }
-    catch (FormatException ex)
-    {
-        throw new InvalidOperationException(
-            "OAuthHandoff:EncryptionKey must be a Base64-encoded 32-byte key.",
-            ex);
-    }
-
-    if (encryptionKey.Length != 32)
-    {
-        throw new InvalidOperationException(
-            "OAuthHandoff:EncryptionKey must decode to exactly 32 bytes.");
-    }
-
-    ConfigurationOptions redisOptions = ConfigurationOptions.Parse(redisConnection!);
-    redisOptions.AbortOnConnectFail = false;
-    builder.Services.AddSingleton<IConnectionMultiplexer>(_ => ConnectionMultiplexer.Connect(redisOptions));
-    builder.Services.AddSingleton<IOAuthHandoffBackend>(services =>
-        new RedisOAuthHandoffBackend(
-            services.GetRequiredService<IConnectionMultiplexer>(),
-            encryptionKey));
-}
 
 static void SetNoStore(HttpContext httpContext)
 {

--- a/JitHub.Web/Services/OAuthHandoffBackendRegistration.cs
+++ b/JitHub.Web/Services/OAuthHandoffBackendRegistration.cs
@@ -1,0 +1,82 @@
+using StackExchange.Redis;
+
+namespace JitHub.Web.Services;
+
+internal static class OAuthHandoffBackendRegistration
+{
+    internal const string RedisConnectionStringName = "OAuthHandoffRedis";
+    internal const string EncryptionKeySetting = "OAuthHandoff:EncryptionKey";
+
+    public static OAuthHandoffBackendSelection Configure(
+        IServiceCollection services,
+        IConfiguration configuration,
+        bool isDevelopment)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+        ArgumentNullException.ThrowIfNull(configuration);
+
+        string? redisConnection = configuration.GetConnectionString(RedisConnectionStringName);
+        string? encryptionKeyText = configuration[EncryptionKeySetting];
+        bool hasRedis = !string.IsNullOrWhiteSpace(redisConnection);
+        bool hasEncryptionKey = !string.IsNullOrWhiteSpace(encryptionKeyText);
+
+        if (!hasRedis || !hasEncryptionKey)
+        {
+            string? reason = isDevelopment && !hasRedis && !hasEncryptionKey
+                ? null
+                : "Redis configuration is absent or incomplete. Pending sign-ins expire after two minutes and may be lost during restart or scale-out.";
+            return UseInMemoryBackend(services, reason);
+        }
+
+        byte[] encryptionKey;
+        try
+        {
+            encryptionKey = Convert.FromBase64String(encryptionKeyText!);
+        }
+        catch (FormatException)
+        {
+            return UseInMemoryBackend(
+                services,
+                "The configured handoff encryption key is invalid. Pending sign-ins expire after two minutes and may be lost during restart or scale-out.");
+        }
+
+        if (encryptionKey.Length != 32)
+        {
+            return UseInMemoryBackend(
+                services,
+                "The configured handoff encryption key has an invalid length. Pending sign-ins expire after two minutes and may be lost during restart or scale-out.");
+        }
+
+        ConfigurationOptions redisOptions;
+        try
+        {
+            redisOptions = ConfigurationOptions.Parse(redisConnection!);
+        }
+        catch (ArgumentException)
+        {
+            return UseInMemoryBackend(
+                services,
+                "The configured Redis connection is invalid. Pending sign-ins expire after two minutes and may be lost during restart or scale-out.");
+        }
+
+        redisOptions.AbortOnConnectFail = false;
+        services.AddSingleton<IConnectionMultiplexer>(_ => ConnectionMultiplexer.Connect(redisOptions));
+        services.AddSingleton<IOAuthHandoffBackend>(serviceProvider =>
+            new RedisOAuthHandoffBackend(
+                serviceProvider.GetRequiredService<IConnectionMultiplexer>(),
+                encryptionKey));
+        return new OAuthHandoffBackendSelection(UsesRedis: true, FallbackReason: null);
+    }
+
+    private static OAuthHandoffBackendSelection UseInMemoryBackend(
+        IServiceCollection services,
+        string? reason)
+    {
+        services.AddSingleton<IOAuthHandoffBackend, InMemoryOAuthHandoffBackend>();
+        return new OAuthHandoffBackendSelection(UsesRedis: false, reason);
+    }
+}
+
+internal sealed record OAuthHandoffBackendSelection(
+    bool UsesRedis,
+    string? FallbackReason);

--- a/JitHub.Web/Services/OAuthRedirectUriPolicy.cs
+++ b/JitHub.Web/Services/OAuthRedirectUriPolicy.cs
@@ -5,6 +5,7 @@ internal sealed class OAuthRedirectUriPolicy
     internal const string CallbackUrlSetting = "GitHubOAuth:AuthorizationCallbackUrl";
     internal const string CallbackUrlEnvironmentSetting = "JITHUB_OAUTH_CALLBACK_URL";
     internal const string DevelopmentCallbackUrlsSection = "GitHubOAuth:DevelopmentCallbackUrls";
+    internal const string AzureWebsiteHostnameSetting = "WEBSITE_HOSTNAME";
 
     private static readonly string[] DefaultDevelopmentCallbacks =
     [
@@ -15,9 +16,12 @@ internal sealed class OAuthRedirectUriPolicy
 
     private readonly HashSet<string> _allowedRedirectUris;
 
-    private OAuthRedirectUriPolicy(HashSet<string> allowedRedirectUris)
+    private OAuthRedirectUriPolicy(
+        HashSet<string> allowedRedirectUris,
+        string? configurationError)
     {
         _allowedRedirectUris = allowedRedirectUris;
+        ConfigurationError = configurationError;
     }
 
     public static OAuthRedirectUriPolicy Load(
@@ -28,15 +32,30 @@ internal sealed class OAuthRedirectUriPolicy
         ArgumentNullException.ThrowIfNull(environment);
 
         HashSet<string> allowedRedirectUris = new(StringComparer.Ordinal);
+        string? configurationError = null;
         string? configuredCallback = GetConfiguredCallback(configuration);
         if (!string.IsNullOrWhiteSpace(configuredCallback))
         {
-            allowedRedirectUris.Add(NormalizeConfiguredCallback(configuredCallback, environment.IsDevelopment()));
+            try
+            {
+                allowedRedirectUris.Add(NormalizeConfiguredCallback(configuredCallback, environment.IsDevelopment()));
+            }
+            catch (InvalidOperationException ex) when (!environment.IsDevelopment())
+            {
+                configurationError = ex.Message;
+            }
+        }
+        else if (!environment.IsDevelopment() &&
+                 TryCreateAzureAppServiceCallback(
+                     configuration[AzureWebsiteHostnameSetting],
+                     out string azureCallback))
+        {
+            allowedRedirectUris.Add(azureCallback);
         }
         else if (!environment.IsDevelopment())
         {
-            throw new InvalidOperationException(
-                $"Production OAuth requires {CallbackUrlEnvironmentSetting} or {CallbackUrlSetting}.");
+            configurationError =
+                $"Production OAuth requires {CallbackUrlEnvironmentSetting}, {CallbackUrlSetting}, or a valid {AzureWebsiteHostnameSetting} value.";
         }
 
         if (environment.IsDevelopment())
@@ -55,7 +74,7 @@ internal sealed class OAuthRedirectUriPolicy
             }
         }
 
-        return new OAuthRedirectUriPolicy(allowedRedirectUris);
+        return new OAuthRedirectUriPolicy(allowedRedirectUris, configurationError);
     }
 
     public string RequireAllowed(string? redirectUri)
@@ -70,6 +89,8 @@ internal sealed class OAuthRedirectUriPolicy
     }
 
     internal IReadOnlyCollection<string> AllowedRedirectUris => _allowedRedirectUris;
+
+    internal string? ConfigurationError { get; }
 
     private static string? GetConfiguredCallback(IConfiguration configuration) =>
         configuration[CallbackUrlEnvironmentSetting] ??
@@ -107,6 +128,34 @@ internal sealed class OAuthRedirectUriPolicy
         }
 
         return normalizedCallback;
+    }
+
+    private static bool TryCreateAzureAppServiceCallback(
+        string? hostname,
+        out string callback)
+    {
+        callback = string.Empty;
+        string normalizedHostname = hostname?.Trim() ?? string.Empty;
+        if (normalizedHostname.Length == 0 ||
+            !Uri.TryCreate($"https://{normalizedHostname}/authorize", UriKind.Absolute, out Uri? uri) ||
+            !string.Equals(normalizedHostname, uri.Host, StringComparison.OrdinalIgnoreCase) ||
+            !uri.IsDefaultPort ||
+            !string.IsNullOrEmpty(uri.UserInfo) ||
+            !string.IsNullOrEmpty(uri.Query) ||
+            !string.IsNullOrEmpty(uri.Fragment))
+        {
+            return false;
+        }
+
+        const string AzureWebsitesSuffix = ".azurewebsites.net";
+        if (uri.Host.Length <= AzureWebsitesSuffix.Length ||
+            !uri.Host.EndsWith(AzureWebsitesSuffix, StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        callback = uri.GetLeftPart(UriPartial.Path);
+        return true;
     }
 
     private static bool TryNormalizeCallback(string? redirectUri, out string normalizedRedirectUri)

--- a/JitHub.WinUI.Tests/Services/OAuthHandoffDeploymentContractTests.cs
+++ b/JitHub.WinUI.Tests/Services/OAuthHandoffDeploymentContractTests.cs
@@ -7,10 +7,14 @@ public sealed class OAuthHandoffDeploymentContractTests
 {
     [Fact]
     [Trait("Category", "ReleaseSecurity")]
-    public void ProductionHandoffUsesEncryptedAtomicDistributedConsumption()
+    public void ProductionHandoffPrefersEncryptedAtomicDistributedConsumption()
     {
         string root = FindRepositoryRoot();
-        string program = File.ReadAllText(Path.Combine(root, "JitHub.Web", "Program.cs"));
+        string registration = File.ReadAllText(Path.Combine(
+            root,
+            "JitHub.Web",
+            "Services",
+            "OAuthHandoffBackendRegistration.cs"));
         string backend = File.ReadAllText(Path.Combine(
             root,
             "JitHub.Web",
@@ -18,10 +22,10 @@ public sealed class OAuthHandoffDeploymentContractTests
             "RedisOAuthHandoffBackend.cs"));
         XDocument project = XDocument.Load(Path.Combine(root, "JitHub.Web", "JitHub.Web.csproj"));
 
-        Assert.Contains("ConnectionStrings:OAuthHandoffRedis", program, StringComparison.Ordinal);
-        Assert.Contains("OAuthHandoff:EncryptionKey", program, StringComparison.Ordinal);
-        Assert.Contains("if (!hasRedis && !hasEncryptionKey && isDevelopment)", program, StringComparison.Ordinal);
-        Assert.Contains("throw new InvalidOperationException", program, StringComparison.Ordinal);
+        Assert.Contains("GetConnectionString(RedisConnectionStringName)", registration, StringComparison.Ordinal);
+        Assert.Contains("OAuthHandoff:EncryptionKey", registration, StringComparison.Ordinal);
+        Assert.Contains("ConfigurationOptions.Parse", registration, StringComparison.Ordinal);
+        Assert.Contains("RedisOAuthHandoffBackend", registration, StringComparison.Ordinal);
         Assert.Contains("StringGetDeleteAsync", backend, StringComparison.Ordinal);
         Assert.Contains("When.NotExists", backend, StringComparison.Ordinal);
         Assert.Contains("new AesGcm", backend, StringComparison.Ordinal);
@@ -32,6 +36,29 @@ public sealed class OAuthHandoffDeploymentContractTests
                 (string?)element.Attribute("Include"),
                 "Microsoft.Extensions.Caching.StackExchangeRedis",
                 StringComparison.Ordinal));
+    }
+
+    [Fact]
+    [Trait("Category", "ReleaseSecurity")]
+    public void UnconfiguredHandoffFallbackRemainsBoundedShortLivedAndAtomic()
+    {
+        string root = FindRepositoryRoot();
+        string registration = File.ReadAllText(Path.Combine(
+            root,
+            "JitHub.Web",
+            "Services",
+            "OAuthHandoffBackendRegistration.cs"));
+        string store = File.ReadAllText(Path.Combine(
+            root,
+            "JitHub.Web",
+            "Services",
+            "OAuthHandoffStore.cs"));
+
+        Assert.Contains("if (!hasRedis || !hasEncryptionKey)", registration, StringComparison.Ordinal);
+        Assert.Contains("UseInMemoryBackend", registration, StringComparison.Ordinal);
+        Assert.Contains("TimeSpan.FromMinutes(2)", store, StringComparison.Ordinal);
+        Assert.Contains("MaximumPendingHandoffs = 10_000", store, StringComparison.Ordinal);
+        Assert.Contains("_entries.TryRemove", store, StringComparison.Ordinal);
     }
 
     private static string FindRepositoryRoot()

--- a/JitHub.WinUI/appsettings.json
+++ b/JitHub.WinUI/appsettings.json
@@ -2,6 +2,7 @@
   "Credential": {
     "ClientId": "095ff0297fef36faef33",
     "DevelopmentClientId": "Ov23libqduSlPx5TcCne",
+    "AuthorizationCallbackUrl": "https://jithub-web-prod.azurewebsites.net/authorize",
     "DevelopmentAuthorizationCallbackUrl": "https://localhost:7284/authorize"
   }
 }

--- a/eng/Provision-JitHubWebApp.ps1
+++ b/eng/Provision-JitHubWebApp.ps1
@@ -176,11 +176,14 @@ Invoke-Az -Arguments @(
 Write-Host ''
 Write-Host 'Provisioning complete. Next steps:'
 Write-Host '1. Configure app settings for the GitHub OAuth app:'
-Write-Host "   az webapp config appsettings set -g $ResourceGroup -n $WebAppName --settings JitHubClientId=<client-id> JithubAppSecret=<client-secret> JITHUB_OAUTH_CALLBACK_URL=https://$WebAppName.azurewebsites.net/authorize"
-Write-Host '2. Download the publish profile:'
+Write-Host "   az webapp config appsettings set -g $ResourceGroup -n $WebAppName --settings JitHubClientId=<client-id> JithubAppSecret=<client-secret>"
+Write-Host "   The default callback is derived from App Service's read-only WEBSITE_HOSTNAME. Set JITHUB_OAUTH_CALLBACK_URL only when using a custom callback host."
+Write-Host '2. For multi-instance handoffs, configure ConnectionStrings__OAuthHandoffRedis and OAuthHandoff__EncryptionKey.'
+Write-Host '   Without Redis, the app uses a bounded two-minute process-local handoff store and remains available.'
+Write-Host '3. Download the publish profile:'
 Write-Host "   az webapp deployment list-publishing-profiles -g $ResourceGroup -n $WebAppName --xml > jithub-webapp.PublishSettings"
-Write-Host '3. Save it as the GitHub secret JITHUB_WEBAPP_PUBLISH_PROFILE:'
+Write-Host '4. Save it as the GitHub secret JITHUB_WEBAPP_PUBLISH_PROFILE:'
 Write-Host '   gh secret set JITHUB_WEBAPP_PUBLISH_PROFILE --repo JitHubApp/JitHubV2 < jithub-webapp.PublishSettings'
-Write-Host '4. Save the target app name as a GitHub Actions variable:'
+Write-Host '5. Save the target app name as a GitHub Actions variable:'
 Write-Host "   gh variable set JITHUB_WEBAPP_NAME --repo JitHubApp/JitHubV2 --body $WebAppName"
-Write-Host '5. Move custom domains/OAuth callback hosts after the new Web App passes a smoke test.'
+Write-Host '6. Move custom domains/OAuth callback hosts after the new Web App passes a smoke test.'


### PR DESCRIPTION
## Summary
- derive the exact production OAuth callback from App Service's read-only `WEBSITE_HOSTNAME` when no explicit callback is configured
- keep the public site available with the existing bounded, two-minute process-local handoff backend when Redis configuration is absent or invalid, while preferring encrypted atomic Redis handoffs when configured
- fail closed at the OAuth feature boundary instead of terminating ASP.NET startup for callback configuration errors
- add `/healthz`, an Ubuntu Production startup smoke test, and a post-deploy live health gate
- configure the packaged app with the public production callback and update provisioning guidance

## Root cause
The Aug 30 deployment artifact exits during startup because `JITHUB_OAUTH_CALLBACK_URL` was not provisioned. Supplying that setting exposes a second startup exception because `ConnectionStrings:OAuthHandoffRedis` and `OAuthHandoff:EncryptionKey` were also not provisioned. The deploy action reported success because it validated package upload, not application health.

## Verification
- `JitHub.Web.Tests`: 40/40 passed in Release with warnings as errors
- `JitHub.WinUI.Tests`: 2,839/2,839 passed
- warning-free Release website publish
- published app returns 200 for `/`, `/authorize`, and `/healthz` in Production with App Service hostname and no Redis
- published app returns 200 for `/` and `/healthz` in Production even with all OAuth settings absent; sign-in remains disabled and fail-closed