### PR TITLE
ci: pin Store CLI to v0.4.2 now that the upload timeout bug is fixed

### DIFF
--- a/.github/workflows/jithub-store-release.yml
+++ b/.github/workflows/jithub-store-release.yml
@@ -47,10 +47,13 @@ jobs:
       APP_DISPLAY_NAME: ${{ vars.STORE_APP_DISPLAY_NAME }}
       BUNDLE_PLATFORMS: ${{ vars.JITHUB_STORE_BUNDLE_PLATFORMS }}
       PUBLISHER_DISPLAY_NAME: ${{ vars.STORE_PUBLISHER_DISPLAY_NAME }}
-      STORE_CLI_VERSION: v0.4.1
+      STORE_CLI_VERSION: v0.4.2
       STORE_RELEASE_VERSION: ${{ inputs.release_version }}
-      # v0.4.1 resolves an omitted --uploadTimeout to zero (microsoft/msstore-cli#162).
-      # Keep an explicit value until a release containing the upstream fix is validated.
+      # Not a workaround any more: v0.4.0/v0.4.1 resolved an omitted
+      # --uploadTimeout to zero (microsoft/msstore-cli#162), fixed by #163 and
+      # released in v0.4.2 above. The value stays because the CLI sets no
+      # StorageTransferOptions, so an .appxupload under 256 MiB is sent as a
+      # single PUT and this timeout must cover the whole transfer, not a chunk.
       STORE_UPLOAD_TIMEOUT_SECONDS: 900
       TARGET_PLATFORM_VERSION: 10.0.26100.0
       STORE_CLIENT_ID: ${{ secrets.STORE_CLIENT_ID }}
@@ -81,8 +84,10 @@ jobs:
       - name: Set up Microsoft Store CLI
         uses: microsoft/microsoft-store-apppublisher@v1.4
         with:
-          # v0.4.1 is the first release with the Native AOT upload progress fix.
-          # Keep this pinned until a newer CLI release is validated here.
+          # v0.4.1 was the first release with the Native AOT upload progress
+          # fix; v0.4.2 adds the fix for the --uploadTimeout default
+          # (microsoft/msstore-cli#162). Keep this pinned until a newer CLI
+          # release is validated here.
           version: ${{ env.STORE_CLI_VERSION }}
 
       - name: Verify Microsoft Store CLI

--- a/JitHub.WinUI.Tests/Services/NativeAotSourceContractTests.cs
+++ b/JitHub.WinUI.Tests/Services/NativeAotSourceContractTests.cs
@@ -254,7 +254,7 @@ public sealed class NativeAotSourceContractTests
         Assert.DoesNotContain("actions: read", storeWorkflow, StringComparison.Ordinal);
         Assert.Contains("'x86|x64|ARM64'", storeWorkflow, StringComparison.Ordinal);
         Assert.Contains("microsoft/microsoft-store-apppublisher@v1.4", storeWorkflow, StringComparison.Ordinal);
-        Assert.Contains("STORE_CLI_VERSION: v0.4.1", storeWorkflow, StringComparison.Ordinal);
+        Assert.Contains("STORE_CLI_VERSION: v0.4.2", storeWorkflow, StringComparison.Ordinal);
         Assert.Contains("version: ${{ env.STORE_CLI_VERSION }}", storeWorkflow, StringComparison.Ordinal);
         Assert.Contains("STORE_UPLOAD_TIMEOUT_SECONDS: 900", storeWorkflow, StringComparison.Ordinal);
         Assert.Contains("'--uploadTimeout'", storeWorkflow, StringComparison.Ordinal);

--- a/docs/windows-cli-workflow.md
+++ b/docs/windows-cli-workflow.md
@@ -119,7 +119,7 @@ Store package versions use `Major.Minor.Build.0`. Microsoft reserves the fourth 
 
 It now uses the Microsoft Store Developer CLI as the release control plane:
 
-- `microsoft/microsoft-store-apppublisher@v1.4` installs the pinned `msstore` version on the runner. The workflow passes an explicit upload timeout because `msstore` v0.4.1 otherwise resolves the omitted option to zero; keep the version pin and timeout until a newer CLI release is deliberately validated.
+- `microsoft/microsoft-store-apppublisher@v1.4` installs the pinned `msstore` version on the runner. The workflow passes an explicit upload timeout because the `.appxupload` is sent to Azure blob storage as a single PUT, so the timeout has to cover the whole transfer rather than one chunk; keep the version pin and timeout until a newer CLI release is deliberately validated.
 - `msstore reconfigure` authenticates with the protected `microsoft-store` GitHub environment secrets.
 - `msstore publish` receives the exact `.appxupload` or `.msixupload` file produced by `eng/Build-JitHubWinUIStorePackage.ps1` as the publish command's positional input.
 - `use_signing_certificate` is optional. Leave it `false` to match the existing UWP Store-upload flow where Partner Center accepts and re-signs the submitted package; enable it only when `STORE_PACKAGE_CERTIFICATE_BASE64` and `STORE_PACKAGE_CERTIFICATE_PASSWORD` are configured.


### PR DESCRIPTION
`STORE_CLI_VERSION` sat on `v0.4.1`, the last release carrying [microsoft/msstore-cli#162](https://github.com/microsoft/msstore-cli/issues/162). That is fixed by [#163](https://github.com/microsoft/msstore-cli/pull/163) and released in **v0.4.2** on 2026-09-02, so the pin advances and the comments stop describing a live bug.

### This is deliberately not a revert of #92

#92 bundled three unrelated things: the timeout workaround, the `@v1.3` → `@v1.4` action upgrade, and error-handling improvements (the `msstore --version` gate, exit-code messages). Only the workaround framing and the pin change here — the action upgrade and the error handling are kept.

### `STORE_UPLOAD_TIMEOUT_SECONDS: 900` stays

It is no longer a workaround, but it is still worth setting. `AzureBlobManager` calls `blobClient.UploadAsync` **without setting `StorageTransferOptions`**, so the SDK's default 256 MiB `InitialTransferSize` applies and an `.appxupload` under that size is uploaded as a **single PUT**. `Retry.NetworkTimeout` therefore bounds the entire transfer rather than an individual chunk — so for a multi-arch `x86|x64|ARM64` bundle the restored 100 s default would be a real risk, and it would fail in the same silent `Uploading Bundle to Azure blob: 0%` shape that #162 produced.

The validation block and the `--uploadTimeout` argument are therefore untouched.

### Test contract

`NativeAotSourceContractTests.StoreRelease_UsesPrValidatedNativeAotWithoutHardwareDependency` asserts on the workflow's literal text, including `STORE_CLI_VERSION: v0.4.1`. That assertion is updated to `v0.4.2` in the same commit so the suite stays green. The `STORE_UPLOAD_TIMEOUT_SECONDS: 900` and `'--uploadTimeout'` assertions still hold unchanged.

### Net effect

Pin `v0.4.1` → `v0.4.2`, two comment rewrites, one test assertion, one docs sentence. No behaviour change beyond the version bump.

Sent as part of a sweep across the repos that referenced msstore-cli#162.
